### PR TITLE
Fix host ssh key import on retremote-dev-hostapd Docker compose service.

### DIFF
--- a/development/docker/compose.yaml
+++ b/development/docker/compose.yaml
@@ -45,6 +45,23 @@ services:
     tty: true
     stdin_open: true
     privileged: true
+    volumes:
+      # netremote sources
+      - type: volume
+        source: build-data
+        target: /netremote
+        consistency: delegated
+      # user ssh keys
+      - type: bind
+        source: ${USERPROFILE}/.ssh
+        target: /tmp/.ssh
+        read_only: true
+      # user git config
+      - type: bind
+        source: ${USERPROFILE}/.gitconfig
+        target: /tmp/.gitconfig
+        read_only: true
+    working_dir: /netremote
 
 volumes:
   build-data:


### PR DESCRIPTION
This pull request adds volumes to the `development/docker/compose.yaml` file to allow the `netremote-dev-hostapd` container service to access ssh keys from the host machine.

Main change:

* <a href="diffhunk://#diff-05586f3e263528f1639f1b0e842e8d9086a637e0c1fb96c5993fc038d49bbfcfR48-R64">`development/docker/compose.yaml`</a>: Added volumes for netremote sources, user ssh keys, and user git config to allow the container to access these files and directories from the host machine.