### PR TITLE
Ensure clang-17 is installed in devcontainer.

### DIFF
--- a/development/docker/images/netremote/Dockerfile
+++ b/development/docker/images/netremote/Dockerfile
@@ -6,9 +6,9 @@ FROM ubuntu:mantic
 RUN apt-get update && \
     apt-get install -qq -y --no-install-recommends \
         # Project build dependencies.
-        # build-essential clang dotnet7 git gnupg lldb llvm ninja-build pkg-config
+        # build-essential clang-17 dotnet7 git gnupg lldb llvm ninja-build pkg-config
         build-essential \
-        clang \
+        clang-17 \
         dotnet7 \
         git \
         gnupg \


### PR DESCRIPTION
This pull request updates the project build dependencies in `development/docker/images/netremote/Dockerfile` by replacing `clang` with `clang-17`. The default installed version as part of the `build-essentials` package is 16.

* <a href="diffhunk://#diff-350b3dfe4545ca9fd0dc3a0f7935000830aaa56beeb039cf56e51ff0dcd01e0cL9-R11">`development/docker/images/netremote/Dockerfile`</a>: Updated project build dependencies by replacing `clang` with `clang-17` and `dotnet7` with `dotnet7`.