### PR TITLE
Add extensions to install in container.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
-	"workspaceFolder": "/netremote"
+	"workspaceFolder": "/netremote",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -34,7 +34,20 @@
 	// "postCreateCommand": "cat /etc/os-release",
 
 	// Configure tool-specific properties.
-	// "customizations": {},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"cschlosser.doxdocgen",
+				"eamodio.gitlens",
+				"EditorConfig.EditorConfig",
+				"GitHub.copilot-chat",
+				"GitHub.copilot",
+				"ms-vscode.cmake-tools",
+				"ms-vscode.cpptools",
+				"ms-vscode.makefile-tools"
+			]
+		}
+	}
 
 	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "devcontainer"


### PR DESCRIPTION
This pull request adds new properties to the `.devcontainer/devcontainer.json` file to improve the functionality of the development container. The most important changes include adding a new property to specify the default path that VS Code should open when connected, and adding a `customizations` object to specify a list of extensions to install in the dev container.

* <a href="diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L19-R19">`.devcontainer/devcontainer.json`</a>: Added a new property to specify the default path that VS Code should open when connected, and added a `customizations` object to specify a list of extensions to install in the dev container. <a href="diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L19-R19">[1]</a> <a href="diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L37-R50">[2]</a>