### PR TITLE
Add github codeowners file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @microsoft/net-remote-collaborators


### PR DESCRIPTION
This pull request adds the `net-remote-collaborators` team at Microsoft as code owners for all files in the repository.

Main change:

* <a href="diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1">`.github/CODEOWNERS`</a>: Added `net-remote-collaborators` team at Microsoft as code owners for all files in the repository.