### PR TITLE
Remove git config from Dockerfile.

### DIFF
--- a/.docker/netremote-dev/Dockerfile
+++ b/.docker/netremote-dev/Dockerfile
@@ -89,10 +89,6 @@ RUN chmod 0755 /etc/update-motd.d/50-sysinfo && \
     # Permission for entrypoint script
     chmod +x /bin/entrypoint.sh
 
-# Ensure Linux-style line endings are used
-RUN git config --global core.autocrlf input && \
-    git config --global credential.helper 'cache --timeout=36000'
-
 # Set entrypoint and start interactive shell (bash).
 ENTRYPOINT [ "/bin/entrypoint.sh" ]
 CMD /bin/bash -i


### PR DESCRIPTION
This pull request removes unnecessary lines configuring git from the `.docker/netremote-dev/Dockerfile`. This interferes with devcontainer's support for forwarding built-in user git settings to the container.

Main change:

* <a href="diffhunk://#diff-c7eb2bd22ebe69afa5c72c57aea2c86c8d682d139c759ba0d89c7cccd11fd00aL92-L95">`.docker/netremote-dev/Dockerfile`</a>: Removed unnecessary lines configuring git.