### PR TITLE
Add CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -59,7 +59,7 @@
         },
         {
             "name": "dev-linux",
-            "displayName": "Development (Linux)",
+            "displayName": "Development",
             "description": "Development build for inner-loop on Linux",
             "inherits": [
                 "os-linux",
@@ -72,12 +72,15 @@
         },
         {
             "name": "dev-windows",
-            "displayName": "Development (Windows)",
+            "displayName": "Development",
             "description": "Development build for inner-loop on Windows",
             "inherits": [
                 "os-windows",
                 "dev"
-            ]
+            ],
+            "cacheVariables": {
+                "CMAKE_GENERATOR": "Visual Studio 17 2022"
+            }
         }
     ],
     "buildPresets": [


### PR DESCRIPTION
This pull request includes a single change to the `CMakePresets.json` file, adding new presets for development builds on Linux and Windows platforms. The new presets inherit from existing presets and set specific build options.

* <a href="diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5R1-R109">`CMakePresets.json`</a>: Added new presets for development builds on Linux and Windows platforms, inheriting from existing presets and setting specific build options.