### PR TITLE
Fix first-time build on Linux when Ninja generator is used 

### DIFF
--- a/external/hostap/CMakeLists.txt
+++ b/external/hostap/CMakeLists.txt
@@ -43,14 +43,6 @@ ExternalProject_Add(hostap
     GIT_REPOSITORY "http://w1.fi/hostap.git"
     GIT_TAG "hostap_2_10"
     GIT_SHALLOW TRUE
-    BUILD_BYPRODUCTS
-        ${HOSTAP_INSTALL_BIN_DIR}/hostapd
-        ${HOSTAP_INSTALL_BIN_DIR}/hostapd_cli
-        ${HOSTAP_INSTALL_INCLUDE_DIR}/wpa_ctrl.h
-        ${HOSTAP_INSTALL_LIB_DIR}/libwpa_client.so
-        ${HOSTAP_INSTALL_SBIN_DIR}/wpa_cli
-        ${HOSTAP_INSTALL_SBIN_DIR}/wpa_passphrase
-        ${HOSTAP_INSTALL_SBIN_DIR}/wpa_supplicant
     CONFIGURE_COMMAND
         # Copy local build configuration files for libwpa_client.so and hostapd builds.
         COMMAND cp -n ${CMAKE_CURRENT_SOURCE_DIR}/libwpa_client/.config ${WPA_SUPPLICANT_PREFIX}/.config
@@ -62,6 +54,14 @@ ExternalProject_Add(hostap
     INSTALL_COMMAND 
         COMMAND Q=1 DESTDIR=${HOSTAP_INSTALL_DIR} ${MAKE} -C ${WPA_SUPPLICANT_DIR_NAME} install
         COMMAND Q=1 DESTDIR=${HOSTAP_INSTALL_DIR} ${MAKE} -C ${HOSTAPD_DIR_NAME} install
+    INSTALL_BYPRODUCTS
+        ${HOSTAP_INSTALL_BIN_DIR}/hostapd
+        ${HOSTAP_INSTALL_BIN_DIR}/hostapd_cli
+        ${HOSTAP_INSTALL_INCLUDE_DIR}/wpa_ctrl.h
+        ${HOSTAP_INSTALL_LIB_DIR}/libwpa_client.so
+        ${HOSTAP_INSTALL_SBIN_DIR}/wpa_cli
+        ${HOSTAP_INSTALL_SBIN_DIR}/wpa_passphrase
+        ${HOSTAP_INSTALL_SBIN_DIR}/wpa_supplicant
 )
 
 # Define an interface library for libwpa_client.so that other cmake targets can use in target_link_libraries to pull it in as a dependency.


### PR DESCRIPTION
This pull request includes a change to the `CMakeLists.txt` file in the `external/hostap` directory. The change adds several files to the `INSTALL_BYPRODUCTS` list, ensuring that they are included as byproducts of the installation process. This creates the correct nodes in the dependency graph, allowing the first-ever build to be initiated.

Main change:

* <a href="diffhunk://#diff-ba17d71b3fc2feaf7a8d35b5d015e4c73684981ebf948f495ee844cdced9392eR57-R64">`external/hostap/CMakeLists.txt`</a>: Added several files to the `INSTALL_BYPRODUCTS` list to include them as byproducts of the installation process.