### PR TITLE
Add github templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'Bug: '
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+A clear and concise description of what actually happened.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Version Information**
+- Framework version
+- Driver version
+- OS and version
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,52 @@
+
+### Type
+
+- [ ] Bug fix
+- [ ] Feature addition
+- [X] Feature update
+- [ ] Documentation
+- [ ] Build Infrastructure
+
+### Side Effects
+
+- [ ] Breaking change
+- [ ] Non-functional change
+
+### Goals
+
+Describe what the PR intends to achieve. If the change is a new feature, describe what it is. If the change is a bug fix, reference the issue being fixed. Provide any additional context and motivation for making the change. Eg.
+> Simplify maintenance of the event loop. A well-known open source library can be used in place of the custom written code, making it easier to use, understand, and debug.
+
+### Technical Details
+
+Describe how the goals of the PR were achieved. Eg.
+> Replace custom event loop code with libevent.
+
+### Test Results
+
+Describe which tests were carried out and a summary of their results. Eg.
+> Verified Near Object session completed successfully with the following configurations:
+>
+> - [X] host as controlee
+> - [X] host as controller
+
+### Reviewer Focus
+
+Describe what reviewers should focus on. Eg.
+
+> The event loop could cause the service to exit early if it does not manage object lifetime correctly. Please pay careful attention to how this is achieved in the new event loop.
+
+### Future Work
+
+Describe any future work that is required as a result of this change. Eg.
+
+>
+> - Long-running stress testing needs to be completed.
+> - The old event loop code needs to be removed once stress-testing with libevent has been completed.
+>
+
+### Checklist
+
+- [ ] Build target `all` compiles cleanly.
+- [ ] clang-format and clang-tidy deltas produced no new output.
+- [ ] Newly added functions include doxygen-style comment block.


### PR DESCRIPTION
This pull request includes changes to the GitHub repository's templates for pull requests and issue creation. The most important changes include adding a new section to the pull request template for specifying the type of change, adding a new issue template for feature requests, and adding a new issue template for bug reports.

Template improvements:

* <a href="diffhunk://#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6bR1-R52">`.github/pull_request_template.md`</a>: Added a new section to the pull request template for specifying the type of change.
* <a href="diffhunk://#diff-148870715557a13127284f8aeaa28002ed6b034268af13c5d030ab59fd078220R1-R20">`.github/ISSUE_TEMPLATE/feature_request.md`</a>: Added a new issue template for feature requests.
* <a href="diffhunk://#diff-185833cb26d7ac66a4d39042fd576a820c2c2c6d05ad18973bb9c7dce77267c5R1-R35">`.github/ISSUE_TEMPLATE/bug_report.md`</a>: Added a new issue template for bug reports.