### PR TITLE
Add 6GHz band to protobuf interface.

### DIFF
--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -5,6 +5,8 @@ package Microsoft.Net.Wifi;
 
 enum RadioBand
 {
+    option allow_alias = true;
+    
     RadioBandUnknown = 0;
     RadioBand2400MHz = 1;
     RadioBand2_4GHz = 1;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the 6GHz band can be used in the RPC-protobuf interface.

### Technical Details

* Add new enumeration value for 6GHz band.
* Add aliases for existing bands to improve clarity.

### Test Results

Compile-tested only.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
