### PR TITLE
Add Windows server implementation

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_subdirectory(server)

--- a/windows/server/CMakeLists.txt
+++ b/windows/server/CMakeLists.txt
@@ -1,0 +1,18 @@
+
+add_executable(netremote-server-windows "")
+
+target_sources(netremote-server-windows
+    PRIVATE
+        Main.cxx
+)
+
+target_link_libraries(netremote-server-windows
+    PRIVATE
+        netremote-server
+)
+
+install(
+    TARGETS netremote-server-windows
+    EXPORT netremote
+)
+

--- a/windows/server/Main.cxx
+++ b/windows/server/Main.cxx
@@ -1,0 +1,19 @@
+
+#include <format>
+#include <iostream>
+
+#include <microsoft/net/remote/NetRemoteServerConfiguration.hxx>
+#include <microsoft/net/remote/NetRemoteServer.hxx>
+
+using namespace Microsoft::Net::Remote;
+
+int main(int argc, char* argv[])
+{
+    const auto configuration = NetRemoteServerConfiguration::FromCommandLineArguments(argc, argv);
+
+    NetRemoteServer server{ configuration.ServerAddress };
+    server.Run();
+    server.GetGrpcServer()->Wait();
+
+    return 0;
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow the gPRC server to run on Windows.

### Technical Details

* Add `netremote-server-windows` executable hosting the server library.

### Test Results

* Ran the server executable manually and validated the `netremote-test-unit` tests all passed.

### Reviewer Focus

None

### Future Work

* The Windows server executable needs to support daemonization through the `-d` CLI flag.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
