### PR TITLE
Fix link to Dockerfile in Linux README

### DIFF
--- a/src/linux/README.md
+++ b/src/linux/README.md
@@ -79,7 +79,7 @@ sudo apt-get install -y libnl-3-dev libssl-dev libnl-genl-3-dev libnl-3-dev libd
 ```
 
 > [!NOTE]
-> The source of truth for installing development dependencies is found in the development environment [Dockerfile](../.docker/netremote-dev/Dockerfile). The instructions there always trump the instructions here as the contianer described by the `Dockerfile` is used to build the official package.
+> The source of truth for installing development dependencies is found in the development environment [Dockerfile](/.docker/netremote-dev/Dockerfile). The instructions there always trump the instructions here as the contianer described by the `Dockerfile` is used to build the official package.
 
 ### 3. Install Docker on Windows
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [X] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Ensure link to `Dockerfile` in Linux documentation is valid and working.

### Technical Details

* Fix the link to point to the correct file.

### Test Results

* Ctrl-clicked the link in markdown preview in VSCode and verified it navigated to the `Dockerfile`.

### Reviewer Focus

None

### Future Work

None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
