### PR TITLE
Fix proto/grpc protocol includes.

### DIFF
--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -2,7 +2,7 @@
 #ifndef NET_REMOTE_SERVICE_HXX
 #define NET_REMOTE_SERVICE_HXX
 
-#include <NetRemoteService.grpc.pb.h>
+#include <microsoft/net/remote/protocol/NetRemoteService.grpc.pb.h>
 
 namespace Microsoft::Net::Remote::Service
 {

--- a/tests/unit/TestNetRemoteCommon.hxx
+++ b/tests/unit/TestNetRemoteCommon.hxx
@@ -10,7 +10,7 @@
 #include <tuple>
 #include <vector>
 
-#include <NetRemoteService.grpc.pb.h>
+#include <microsoft/net/remote/protocol/NetRemoteService.grpc.pb.h>
 
 namespace Microsoft::Net::Remote::Test
 {

--- a/tests/unit/TestNetRemoteServer.cxx
+++ b/tests/unit/TestNetRemoteServer.cxx
@@ -5,7 +5,7 @@
 #include <catch2/generators/catch_generators_range.hpp>
 #include <grpcpp/create_channel.h>
 #include <microsoft/net/remote/NetRemoteServer.hxx>
-#include <NetRemoteService.grpc.pb.h>
+#include <microsoft/net/remote/protocol/NetRemoteService.grpc.pb.h>
 
 #include "TestNetRemoteCommon.hxx"
 

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -5,9 +5,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <grpcpp/create_channel.h>
 #include <magic_enum.hpp>
-#include <NetRemoteService.grpc.pb.h>
-
 #include <microsoft/net/remote/NetRemoteServer.hxx>
+#include <microsoft/net/remote/protocol/NetRemoteService.grpc.pb.h>
 
 #include "TestNetRemoteCommon.hxx"
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure code including the proto/gprc headers uses the correct filesystem prefix, per the update in #51.

### Technical Details

* Add `microsoft/net/remote/protocol` prefix for all included, generated protobuf+grpc headers.

### Test Results

* Built on both Windows and Linux and ensured the build succeeded.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
