### PR TITLE
Enable building with external vcpkg instance.

### DIFF
--- a/cmake/vcpkg.cmake
+++ b/cmake/vcpkg.cmake
@@ -17,23 +17,30 @@ function(vcpkg_configure)
     ${ARGN}
   )
 
-  get_filename_component(VCPKG_SUBMODULE_NAME ${VCPKG_SUBMODULE_ROOT} NAME)
+# If the vcpkg root has been specified externally, use it.
+if (DEFINED ENV{VCPKG_ROOT})
+  set(VCPKG_ROOT "$ENV{VCPKG_ROOT}")
+# Otherwise, use the specified submodule root.
+else()
+  set(VCPKG_ROOT ${VCPKG_SUBMODULE_ROOT})
 
-  if ("${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}" STREQUAL "")
-    find_package(Git REQUIRED)
+  find_package(Git REQUIRED)
 
-    # Initialize vcpkg sub-module if not already done.
-    if (NOT EXISTS ${VCPKG_SUBMODULE_ROOT}/.git)
-      execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${VCPKG_SUBMODULE_ROOT}
-        WORKING_DIRECTORY ${VCPKG_SUBMODULE_ROOT}/../
-        COMMAND_ERROR_IS_FATAL ANY)
-    endif()
-    set(CMAKE_TOOLCHAIN_FILE "${VCPKG_SUBMODULE_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "vcpkg toolchain file")
+  # Initialize vcpkg sub-module if not already done.
+  if (NOT EXISTS ${VCPKG_SUBMODULE_ROOT}/.git)
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${VCPKG_SUBMODULE_ROOT}
+      WORKING_DIRECTORY ${VCPKG_SUBMODULE_ROOT}/../
+      COMMAND_ERROR_IS_FATAL ANY)
   endif()
 
   # Ignore all changes to the submodule tree.
+  get_filename_component(VCPKG_SUBMODULE_NAME ${VCPKG_SUBMODULE_ROOT} NAME)
   execute_process(COMMAND ${GIT_EXECUTABLE} "config submodule.${VCPKG_SUBMODULE_NAME}.ignore all"
     WORKING_DIRECTORY ${VCPKG_SUBMODULE_ROOT}../
   )
+endif()
+
+# Set the CMake toolchain file to use vcpkg.
+set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE FILEPATH "CMake toolchain file")
 
 endfunction()


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Allow the build to use an external vcpkg instance to support binary caching in container-based builds (ie. on GitHub).

### Technical Details

* Enable use of external vcpkg instance by using the `VCPKG_ROOT` environment variable. If set, the instance rooted at this path will be used, otherwise, the build will fall back to its usual method which is to use a cloned sub-module.
* Hide the `local-base` CMake test preset as it seems to have a problem that CMake is rejecting (though it's unclear what this might be).

### Test Results

* Configured the build in an environment where `VCPKG_ROOT` is defined and pre-staged to contain the installed dependencies. Verified that configuration step succeeded and the build step used its cached binaries.
* Configured the build in an environment where `VCPKG_ROOT` was not defined. Verified that the configuration step succeeded, cloned the sub-module, and built the dependencies from scratch.

### Reviewer Focus

None

### Future Work

* Update the `README`. Normally this should go along with this change, however, there have been significant changes and the update will be involved enough to warrant its own PR.
* Incorporate this into the CI/CD build.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.

