### PR TITLE
Remove windows-specific header from Linux server

### DIFF
--- a/src/linux/server/Main.cxx
+++ b/src/linux/server/Main.cxx
@@ -7,7 +7,6 @@
 #include <microsoft/net/remote/NetRemoteServer.hxx>
 #include <notstd/Utility.hxx>
 #include <plog/Appenders/ColorConsoleAppender.h>
-#include <plog/Appenders/DebugOutputAppender.h>
 #include <plog/Appenders/RollingFileAppender.h>
 #include <plog/Formatters/MessageOnlyFormatter.h>
 #include <plog/Formatters/TxtFormatter.h>


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Ensure Linux code isn't using any Windows-specific headers.

### Technical Details

* Remove Windows-specific `#include`.

### Test Results

* Built on Linux and validated it succeeds.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
