### PR TITLE
Configure vcpkg only if not already done.

### DIFF
--- a/cmake/vcpkg.cmake
+++ b/cmake/vcpkg.cmake
@@ -17,30 +17,34 @@ function(vcpkg_configure)
     ${ARGN}
   )
 
-  # If the vcpkg root has been specified externally, use it.
-  if (DEFINED ENV{VCPKG_ROOT})
-    set(VCPKG_ROOT "$ENV{VCPKG_ROOT}")
-  # Otherwise, use the specified submodule root.
-  else()
-    set(VCPKG_ROOT ${VCPKG_SUBMODULE_ROOT})
+  # Only configure vcpkg if not already done externally.
+  if ("${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}" STREQUAL "")
+    # If the vcpkg root has been specified externally, use it.
+    if (DEFINED ENV{VCPKG_ROOT})
+      set(VCPKG_ROOT "$ENV{VCPKG_ROOT}")
+    # Otherwise, use the specified submodule root.
+    else()
+      set(VCPKG_ROOT ${VCPKG_SUBMODULE_ROOT})
 
-    find_package(Git REQUIRED)
+      find_package(Git REQUIRED)
 
-    # Initialize vcpkg sub-module if not already done.
-    if (NOT EXISTS ${VCPKG_SUBMODULE_ROOT}/.git)
-      execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${VCPKG_SUBMODULE_ROOT}
-        WORKING_DIRECTORY ${VCPKG_SUBMODULE_ROOT}/../
-        COMMAND_ERROR_IS_FATAL ANY)
+      # Initialize vcpkg sub-module if not already done.
+      if (NOT EXISTS ${VCPKG_SUBMODULE_ROOT}/.git)
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${VCPKG_SUBMODULE_ROOT}
+          WORKING_DIRECTORY ${VCPKG_SUBMODULE_ROOT}/../
+          COMMAND_ERROR_IS_FATAL ANY)
+      endif()
+
+      # Ignore all changes to the submodule tree.
+      get_filename_component(VCPKG_SUBMODULE_NAME ${VCPKG_SUBMODULE_ROOT} NAME)
+      execute_process(COMMAND ${GIT_EXECUTABLE} "config submodule.${VCPKG_SUBMODULE_NAME}.ignore all"
+        WORKING_DIRECTORY ${VCPKG_SUBMODULE_ROOT}../
+      )
     endif()
 
-    # Ignore all changes to the submodule tree.
-    get_filename_component(VCPKG_SUBMODULE_NAME ${VCPKG_SUBMODULE_ROOT} NAME)
-    execute_process(COMMAND ${GIT_EXECUTABLE} "config submodule.${VCPKG_SUBMODULE_NAME}.ignore all"
-      WORKING_DIRECTORY ${VCPKG_SUBMODULE_ROOT}../
-    )
-  endif()
+    # Set the CMake toolchain file to use vcpkg.
+    set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE FILEPATH "CMake toolchain file")
 
-  # Set the CMake toolchain file to use vcpkg.
-  set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE FILEPATH "CMake toolchain file")
+  endif()
 
 endfunction()


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the project can be built by vcpkg externally.

### Technical Details

* Conditionally configure vcpkg if the chainload toolchain isn't already set.

### Test Results

* Did a clean CMake configure and ensured it still worked. Note: this does not test the external case and will have to be verified.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
