### PR TITLE
Fix a few cosmetic issues in the primary README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Use of dev containers in VSCode is the recommended and officially supported deve
 
     Select **NetRemoteDev-Stateless**, which is configured to mount the workspace directory in a bind mount instead of a volume. The **NetRemoteDev** configuration will not work.
 
-    > [!WARNING]
-    > A major drawback of this method is that the source tree is mounted in the container using a bind mount, which has extremely poor performance to the point where git operations are essentially unusable. Hence, this method typically requires two (2) VSCode windows: one for the repository on the host where git operations are carried out, and one for the container where the source is modified and built. Therefore, this method is strongly discouraged.
+> [!WARNING]
+> A major drawback of this method is that the source tree is mounted in the container using a bind mount, which has extremely poor performance to the point where git operations are essentially unusable. Hence, this method typically requires two (2) VSCode windows: one for the repository on the host where git operations are carried out, and one for the container where the source is modified and built. Therefore, this method is strongly discouraged.
 
 ## Contributing
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [X] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Ensure the `README` doesn't have formatting errors.

### Technical Details

* Remove an extraneous backtick.
* Move a `[!WARNING]` block to be un-indented due to a recent change described [here](https://github.com/orgs/community/discussions/16925) that introduced a regression for tabbed support.

### Test Results

* Visually inspected new rendered `README` and confirmed no formatting issues are present.

### Reviewer Focus

* Consider whether there are any formatting, spelling, or grammar errors that need fixing.

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
