### PR TITLE
Clean vcpkg downloads and buildtrees after building each package for Windows build

### DIFF
--- a/.github/actions/build-with-host/action.yml
+++ b/.github/actions/build-with-host/action.yml
@@ -48,7 +48,7 @@ runs:
     run: |
       echo "VCPKG_DEFAULT_BINARY_CACHE=${VCPKG_DEFAULT_BINARY_CACHE}" >> "${GITHUB_ENV}"
       New-Item -Path ${env:VCPKG_DEFAULT_BINARY_CACHE} -ItemType Directory -Force
-      vcpkg install --binarysource="clear;files,${VCPKG_DEFAULT_BINARY_CACHE},x-gha,readwrite"
+      vcpkg install --binarysource="clear;default,x-gha,readwrite"
     shell: pwsh
 
   - name: CMake Configure

--- a/.github/actions/build-with-host/action.yml
+++ b/.github/actions/build-with-host/action.yml
@@ -40,10 +40,13 @@ runs:
       script: |
         core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
         core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+        core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE ', 'C:/vcpkg/archives');
 
   - name: Install vcpkg dependencies with Github Actions Cache
     if: ${{ inputs.vcpkg-binarycache == 'true' }}
-    run: vcpkg install --binarysource="clear;x-gha,readwrite" --clean-after-build
+    run: |
+      New-Item -Path ${env:VCPKG_DEFAULT_BINARY_CACHE} -ItemType Directory -Force
+      vcpkg install --binarysource="clear;files,x-gha,readwrite"
     shell: pwsh
 
   - name: CMake Configure

--- a/.github/actions/build-with-host/action.yml
+++ b/.github/actions/build-with-host/action.yml
@@ -43,7 +43,7 @@ runs:
 
   - name: Install vcpkg dependencies with Github Actions Cache
     if: ${{ inputs.vcpkg-binarycache == 'true' }}
-    run: vcpkg install --binarysource="clear;x-gha,readwrite"
+    run: vcpkg install --binarysource="clear;x-gha,readwrite" --clean-buildtrees-after-build --clean-downloads-after-build
     shell: pwsh
 
   - name: CMake Configure

--- a/.github/actions/build-with-host/action.yml
+++ b/.github/actions/build-with-host/action.yml
@@ -42,14 +42,14 @@ runs:
         core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
         core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
         core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', 'C:/vcpkg/archive');
+        core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite');
 
   - name: Install vcpkg dependencies with Github Actions Cache
     if: ${{ inputs.vcpkg-binarycache == 'true' }}
     run: |
       echo "VCPKG_DEFAULT_BINARY_CACHE=${VCPKG_DEFAULT_BINARY_CACHE}" >> "${GITHUB_ENV}"
+      echo "VCPKG_BINARY_SOURCES=${VCPKG_BINARY_SOURCES}" >> "${GITHUB_ENV}"
       New-Item -Path ${env:VCPKG_DEFAULT_BINARY_CACHE} -ItemType Directory -Force
-      vcpkg install --binarysource="clear;default;x-gha,readwrite"
-      echo "VCPKG_BINARY_SOURCES=clear;x-gha" >> "${GITHUB_ENV}"
     shell: pwsh
 
   - name: CMake Configure

--- a/.github/actions/build-with-host/action.yml
+++ b/.github/actions/build-with-host/action.yml
@@ -48,7 +48,7 @@ runs:
     run: |
       echo "VCPKG_DEFAULT_BINARY_CACHE=${VCPKG_DEFAULT_BINARY_CACHE}" >> "${GITHUB_ENV}"
       New-Item -Path ${env:VCPKG_DEFAULT_BINARY_CACHE} -ItemType Directory -Force
-      vcpkg install --binarysource="clear;files,x-gha,readwrite"
+      vcpkg install --binarysource="clear;files,${VCPKG_DEFAULT_BINARY_CACHE},x-gha,readwrite"
     shell: pwsh
 
   - name: CMake Configure

--- a/.github/actions/build-with-host/action.yml
+++ b/.github/actions/build-with-host/action.yml
@@ -49,6 +49,7 @@ runs:
       echo "VCPKG_DEFAULT_BINARY_CACHE=${VCPKG_DEFAULT_BINARY_CACHE}" >> "${GITHUB_ENV}"
       New-Item -Path ${env:VCPKG_DEFAULT_BINARY_CACHE} -ItemType Directory -Force
       vcpkg install --binarysource="clear;default;x-gha,readwrite"
+      echo "VCPKG_BINARY_SOURCES=clear;x-gha" >> "${GITHUB_ENV}"
     shell: pwsh
 
   - name: CMake Configure

--- a/.github/actions/build-with-host/action.yml
+++ b/.github/actions/build-with-host/action.yml
@@ -43,7 +43,7 @@ runs:
 
   - name: Install vcpkg dependencies with Github Actions Cache
     if: ${{ inputs.vcpkg-binarycache == 'true' }}
-    run: vcpkg install --binarysource="clear;x-gha,readwrite" --clean-buildtrees-after-build --clean-downloads-after-build
+    run: vcpkg install --binarysource="clear;x-gha,readwrite" --clean-after-build
     shell: pwsh
 
   - name: CMake Configure

--- a/.github/actions/build-with-host/action.yml
+++ b/.github/actions/build-with-host/action.yml
@@ -48,7 +48,7 @@ runs:
     run: |
       echo "VCPKG_DEFAULT_BINARY_CACHE=${VCPKG_DEFAULT_BINARY_CACHE}" >> "${GITHUB_ENV}"
       New-Item -Path ${env:VCPKG_DEFAULT_BINARY_CACHE} -ItemType Directory -Force
-      vcpkg install --binarysource="clear;default,x-gha,readwrite"
+      vcpkg install --binarysource="clear;default;x-gha,readwrite"
     shell: pwsh
 
   - name: CMake Configure

--- a/.github/actions/build-with-host/action.yml
+++ b/.github/actions/build-with-host/action.yml
@@ -30,6 +30,7 @@ inputs:
     required: false
     default: 'true'
     description: 'Use the vcpkg binary cache'
+
 runs:
   using: 'composite'
   steps:
@@ -40,11 +41,12 @@ runs:
       script: |
         core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
         core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-        core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE ', 'C:/vcpkg/archives');
+        core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', 'VCPKG_DEFAULT_BINARY_CACHE');
 
   - name: Install vcpkg dependencies with Github Actions Cache
     if: ${{ inputs.vcpkg-binarycache == 'true' }}
     run: |
+      echo "VCPKG_DEFAULT_BINARY_CACHE=${VCPKG_DEFAULT_BINARY_CACHE}" >> "${GITHUB_ENV}"
       New-Item -Path ${env:VCPKG_DEFAULT_BINARY_CACHE} -ItemType Directory -Force
       vcpkg install --binarysource="clear;files,x-gha,readwrite"
     shell: pwsh

--- a/.github/actions/build-with-host/action.yml
+++ b/.github/actions/build-with-host/action.yml
@@ -41,7 +41,7 @@ runs:
       script: |
         core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
         core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-        core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', 'VCPKG_DEFAULT_BINARY_CACHE');
+        core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', 'C:/vcpkg/archive');
 
   - name: Install vcpkg dependencies with Github Actions Cache
     if: ${{ inputs.vcpkg-binarycache == 'true' }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -94,14 +94,6 @@
             ]
         },
         {
-            "name": "dev-windows-arm64",
-            "displayName": "Development (ARM64)",
-            "inherits": [
-                "dev-windows"
-            ],
-            "architecture": "arm64"
-        },
-        {
             "name": "release-base",
             "hidden": true,
             "inherits": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -94,6 +94,14 @@
             ]
         },
         {
+            "name": "dev-windows-arm64",
+            "displayName": "Development (ARM64)",
+            "inherits": [
+                "dev-windows"
+            ],
+            "architecture": "arm64"
+        },
+        {
             "name": "release-base",
             "hidden": true,
             "inherits": [


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the Windows build can complete successfully on a Github hosted runner.

### Technical Details

* The Github hosted runners have main drives with ~14GB free space for building a repository. Our project, specifically the gPRC dependency, generates massive buildtrees due to PDB size on Windows. As such, the vcpkg dependency build cannot complete because the runner exhausts it free disk space.
* Enable use of the Github Action Cache for vcpkg binary caching.
* Re-direct default vcpkg file cache to the C drive on the runner since it typically has much more space.

### Test Results

* Automated Windows build workflow now completes successfully instead of running out of space.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
