### PR TITLE
Add build badges to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Network Remote Control
 
+[![CI/CD](https://github.com/microsoft/netremote/actions/workflows/cicd.yml/badge.svg)](https://github.com/microsoft/netremote/actions/workflows/cicd.yml)
+[![Build Linux](https://github.com/microsoft/netremote/actions/workflows/build-linux.yml/badge.svg)](https://github.com/microsoft/netremote/actions/workflows/build-linux.yml)
+[![Build Windows](https://github.com/microsoft/netremote/actions/workflows/build-windows.yml/badge.svg)](https://github.com/microsoft/netremote/actions/workflows/build-windows.yml)
+
 This project provides the ability to remotely control network components such as Wi-Fi access points typically used to test network functionality on Windows.
 
 ## Project Structure


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [X] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow checking status of important builds from the `README`.

### Technical Details

* Add badges for the CI/CD, Build Windows, and Build Linux workflows to the primary `README`.

### Test Results

* N/A

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
