### PR TITLE
Hardcode the list of generated protobuf headers to workaround a potential cmake bug

### DIFF
--- a/protocol/CMakeLists.txt
+++ b/protocol/CMakeLists.txt
@@ -9,10 +9,29 @@ set(PROTO_FILES
     ${PROTO_DIR}/WifiCore.proto
 )
 
-# Create a list of the generated headers.
-file(GLOB PROTO_FILES_GENERATED "${PROTO_DIR_BINARY}/*.pb.h")
-string(REGEX REPLACE "[.]proto$" ".pb.h" PROTO_HEADERS_GENERATED "${PROTO_FILES_GENERATED}")
-string(REGEX REPLACE "[.]proto$" ".pb.grpc.h" PROTO_HEADERS_GENERATED_GRPC "${PROTO_FILES_GENERATED}")
+# Create a list of the generated headers. The below code isn't used because
+# we've encountered intermittent errors when building with external vcpkg (eg.
+# via port) which results in empty file lists and thus, the generated headers
+# are not installed. It appears to be some sort of race condition in CMake
+# itself
+#
+# file(GLOB PROTO_FILES_GENERATED "${PROTO_DIR_BINARY}/*.pb.h")
+# string(REGEX REPLACE "[.]proto$" ".pb.h" PROTO_HEADERS_GENERATED "${PROTO_FILES_GENERATED}")
+# string(REGEX REPLACE "[.]proto$" ".pb.grpc.h" PROTO_HEADERS_GENERATED_GRPC "${PROTO_FILES_GENERATED}")
+#
+set(PROTO_HEADERS_GENERATED
+    ${PROTO_DIR_BINARY}/NetRemote.pb.h
+    ${PROTO_DIR_BINARY}/NetRemoteService.pb.h
+    ${PROTO_DIR_BINARY}/NetRemoteWifi.pb.h
+    ${PROTO_DIR_BINARY}/WifiCore.pb.h
+)
+
+set(PROTO_HEADERS_GENERATED_GRPC
+    ${PROTO_DIR_BINARY}/NetRemote.grpc.pb.h
+    ${PROTO_DIR_BINARY}/NetRemoteService.grpc.pb.h
+    ${PROTO_DIR_BINARY}/NetRemoteWifi.grpc.pb.h
+    ${PROTO_DIR_BINARY}/WifiCore.grpc.pb.h
+)
 
 add_library(${PROJECT_NAME}-protocol STATIC "")
 


### PR DESCRIPTION
…cmake bug.


### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the generated protobuf headers are always installed.

### Technical Details

* Replace dynamic generation of the protobuf header file names with a hardcoded list. There appears to be some sort of race condition in the CMake code where the file lists are sometimes (frequently) empty, which prevents them from being installed.

### Test Results

* Ran `cmake --install` from a fresh configure and validated the generated protobuf headers were present in the install tree.
* Did the same with a checked out netremote source from an external vcpkg source tree for netremote and validated the same.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
