### PR TITLE
Clean up the Windows build workflow

### DIFF
--- a/.github/actions/build-with-host/action.yml
+++ b/.github/actions/build-with-host/action.yml
@@ -26,16 +26,11 @@ inputs:
     required: false
     default: 'dev-windows'
     description: 'The name of the preset to use for all CMake operations (configure, build, test, install, package)'
-  vcpkg-binarycache:
-    required: false
-    default: 'true'
-    description: 'Use the vcpkg binary cache'
 
 runs:
   using: 'composite'
   steps:
   - name: Configure vcpkg to use Github Actions Cache 
-    if: ${{ inputs.vcpkg-binarycache == 'true' }}
     uses: actions/github-script@v6
     with:
       script: |
@@ -45,7 +40,6 @@ runs:
         core.exportVariable('VCPKG_BINARY_SOURCES', 'clear;x-gha,readwrite');
 
   - name: Install vcpkg dependencies with Github Actions Cache
-    if: ${{ inputs.vcpkg-binarycache == 'true' }}
     run: |
       echo "VCPKG_DEFAULT_BINARY_CACHE=${VCPKG_DEFAULT_BINARY_CACHE}" >> "${GITHUB_ENV}"
       echo "VCPKG_BINARY_SOURCES=${VCPKG_BINARY_SOURCES}" >> "${GITHUB_ENV}"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -26,10 +26,8 @@ jobs:
         with:
           build-type: ${{ inputs.build-type }}
           preset-name: 'dev-windows'
-          analyze-codeql: false
-          build-arm64: false
           install: false
           test: false 
           package: false 
-          publish-artifacts: false 
+          publish-artifacts: false
  


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the Windows build workflow does not have unused variables or steps.

### Technical Details

* Remove specification of `analyze-codeql` and `build-arm64` inputs when calling the `build-with-host` action, which are no longer valid inputs.
* Remove 'vcpkg-binarycache` input argument from `build-with-host` action since caching should always be used.

### Test Results

* None

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.