### PR TITLE
Add server API to enumerate Wi-Fi Access Points

### DIFF
--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -9,4 +9,5 @@ import "NetRemoteWifi.proto";
 service NetRemote
 {
     rpc WifiConfigureAccessPoint (Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointRequest) returns (Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointResult);
+    rpc WifiEnumerateAccessPoints (Microsoft.Net.Remote.Wifi.WifiEnumerateAccessPointsRequest) returns (Microsoft.Net.Remote.Wifi.WifiEnumerateAccessPointsResult);
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -36,11 +36,11 @@ message WifiConfigureAccessPointResult
     bool Succeeded = 2;
 }
 
-message AccessPointDescriptor
+message WifiEnumerateAccessPointsResultItem
 {
     string AccessPointId = 1;
-    bool IsEnabled = 2;
-    Microsoft.Net.Wifi.AccessPointCapabilities Capabilities = 3;
+    Microsoft.Net.Wifi.AccessPointCapabilities Capabilities = 2;
+    bool IsEnabled = 3;
 }
 
 message WifiEnumerateAccessPointsRequest
@@ -49,5 +49,5 @@ message WifiEnumerateAccessPointsRequest
 
 message WifiEnumerateAccessPointsResult
 {
-    repeated Microsoft.Net.Remote.Wifi.AccessPointDescriptor AccessPoints = 1;
+    repeated Microsoft.Net.Remote.Wifi.WifiEnumerateAccessPointsResultItem AccessPoints = 1;
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -35,3 +35,12 @@ message WifiConfigureAccessPointResult
     //
     bool Succeeded = 2;
 }
+
+message WifiEnumerateAccessPointsRequest
+{
+}
+
+message WifiEnumerateAccessPointsResult
+{
+
+}

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -36,11 +36,18 @@ message WifiConfigureAccessPointResult
     bool Succeeded = 2;
 }
 
+message AccessPointDescriptor
+{
+    string AccessPointId = 1;
+    bool IsEnabled = 2;
+    Microsoft.Net.Wifi.AccessPointCapabilities Capabilities = 3;
+}
+
 message WifiEnumerateAccessPointsRequest
 {
 }
 
 message WifiEnumerateAccessPointsResult
 {
-
+    repeated Microsoft.Net.Remote.Wifi.AccessPointDescriptor AccessPoints = 1;
 }

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -92,7 +92,8 @@ message AccessPointConfiguration
 
 message AccessPointCapabilities
 {
-    repeated Microsoft.Net.Wifi.RadioBand SupportedBands = 1;
+    repeated Microsoft.Net.Wifi.RadioBand Bands = 1;
+    repeated Microsoft.Net.Wifi.Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 2;
 }
 
 enum AccessPointState

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -89,3 +89,13 @@ message AccessPointConfiguration
 {
     Dot11PhyType PhyType = 1;
 }
+
+message AccessPointCapabilities
+{
+    repeated Microsoft.Net.Wifi.RadioBand SupportedBands = 1;
+}
+
+enum AccessPointState
+{
+    AccessPointStateUnknown = 0;
+}

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -93,7 +93,8 @@ message AccessPointConfiguration
 message AccessPointCapabilities
 {
     repeated Microsoft.Net.Wifi.RadioBand Bands = 1;
-    repeated Microsoft.Net.Wifi.Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 2;
+    repeated Microsoft.Net.Wifi.Dot11PhyType PhyTypes = 2;
+    repeated Microsoft.Net.Wifi.Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 3;
 }
 
 enum AccessPointState

--- a/src/common/server/CMakeLists.txt
+++ b/src/common/server/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(${PROJECT_NAME}-server
         ${PROJECT_NAME}-service
     PRIVATE
         CLI11::CLI11
+        plog::plog
 )
 
 install(

--- a/src/common/server/NetRemoteServer.cxx
+++ b/src/common/server/NetRemoteServer.cxx
@@ -35,7 +35,7 @@ void NetRemoteServer::Run()
     builder.RegisterService(&m_service);
 
     m_server = builder.BuildAndStart();
-    LOG_INFO << std::format("netremote server started listening on {}", m_serverAddress) << std::endl;
+    LOG_INFO << std::format("netremote server started listening on {}", m_serverAddress);
 }
 
 void NetRemoteServer::Stop()

--- a/src/common/server/NetRemoteServer.cxx
+++ b/src/common/server/NetRemoteServer.cxx
@@ -5,6 +5,7 @@
 
 #include <grpcpp/server_builder.h>
 #include <microsoft/net/remote/NetRemoteServer.hxx>
+#include <plog/Log.h>
 
 using namespace Microsoft::Net::Remote;
 
@@ -34,7 +35,7 @@ void NetRemoteServer::Run()
     builder.RegisterService(&m_service);
 
     m_server = builder.BuildAndStart();
-    std::cout << std::format("Started listening on {}", m_serverAddress) << std::endl;
+    LOG_INFO << std::format("netremote server started listening on {}", m_serverAddress) << std::endl;
 }
 
 void NetRemoteServer::Stop()

--- a/src/common/service/CMakeLists.txt
+++ b/src/common/service/CMakeLists.txt
@@ -18,6 +18,8 @@ target_sources(${PROJECT_NAME}-service
 target_link_libraries(${PROJECT_NAME}-service
     PUBLIC
         ${PROJECT_NAME}-protocol
+    PRIVATE
+        plog::plog
 )
 
 install(

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -15,3 +15,9 @@ using namespace Microsoft::Net::Remote::Service;
 
     return grpc::Status::OK;
 }
+
+
+::grpc::Status NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerContext* context, [[maybe_unused]] const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, [[maybe_unused]] ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response)
+{
+    return grpc::Status::OK;
+}

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -3,12 +3,13 @@
 #include <iostream>
 
 #include <microsoft/net/remote/NetRemoteService.hxx>
+#include <plog/Log.h>
 
 using namespace Microsoft::Net::Remote::Service;
 
 ::grpc::Status NetRemoteService::WifiConfigureAccessPoint([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response)
 {
-    std::cout << std::format("Received WifiConfigureAccessPoint request for access point id {} with {} configurations\n", request->accesspointid(), request->configurations_size());
+    LOG_VERBOSE << std::format("Received WifiConfigureAccessPoint request for access point id {} with {} configurations\n", request->accesspointid(), request->configurations_size());
 
     response->set_accesspointid(request->accesspointid());
     response->set_succeeded(true);

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -20,5 +20,7 @@ using namespace Microsoft::Net::Remote::Service;
 
 ::grpc::Status NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerContext* context, [[maybe_unused]] const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, [[maybe_unused]] ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response)
 {
+    LOG_VERBOSE << std::format("Received WifiEnumerateAccessPoints request\n");
+
     return grpc::Status::OK;
 }

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -9,6 +9,8 @@ namespace Microsoft::Net::Remote::Service
 class NetRemoteService : public NetRemote::Service
 {
     virtual ::grpc::Status WifiConfigureAccessPoint(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response) override;
+    virtual ::grpc::Status WifiEnumerateAccessPoints(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response) override;
+
 };
 } // namespace Microsoft::Net::Remote::Service
 

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -10,7 +10,6 @@ class NetRemoteService : public NetRemote::Service
 {
     virtual ::grpc::Status WifiConfigureAccessPoint(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response) override;
     virtual ::grpc::Status WifiEnumerateAccessPoints(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response) override;
-
 };
 } // namespace Microsoft::Net::Remote::Service
 

--- a/src/linux/wpa-controller/WpaController.cxx
+++ b/src/linux/wpa-controller/WpaController.cxx
@@ -70,7 +70,7 @@ WpaController::GetCommandControlSocket()
     // Update the member and return it.
     m_controlSocketCommand = controlSocket;
     return controlSocket;
- }
+}
 
 std::shared_ptr<WpaResponse>
 WpaController::SendCommand(const WpaCommand& command)

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -48,3 +48,27 @@ TEST_CASE("WifiConfigureAccessPoint API can be called", "[basic][rpc][client][re
         }
     }
 }
+
+TEST_CASE("WifiEnumerateAccessPoints API can be called", "[basic][rpc][client][remote]")
+{
+    using namespace Microsoft::Net::Remote;
+    using namespace Microsoft::Net::Remote::Service;
+    using namespace Microsoft::Net::Remote::Wifi;
+
+    NetRemoteServer server{ Test::RemoteServiceAddressHttp };
+    server.Run();
+
+    auto channel = grpc::CreateChannel(Test::RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());
+    auto client = NetRemote::NewStub(channel);
+
+    SECTION("Can be called")
+    {
+        WifiEnumerateAccessPointsRequest request{};
+
+        WifiEnumerateAccessPointsResult result{};
+        grpc::ClientContext clientContext{};
+
+        auto status = client->WifiEnumerateAccessPoints(&clientContext, request, &result);
+        REQUIRE(status.ok());
+    }
+}

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -10,7 +10,7 @@
 
 #include "TestNetRemoteCommon.hxx"
 
-TEST_CASE("WifiConfigureAccessPoint API can be called", "[basic][rpc][client][remote]")
+TEST_CASE("WifiConfigureAccessPoint API", "[basic][rpc][client][remote]")
 {
     using namespace Microsoft::Net::Remote;
     using namespace Microsoft::Net::Remote::Service;
@@ -49,7 +49,7 @@ TEST_CASE("WifiConfigureAccessPoint API can be called", "[basic][rpc][client][re
     }
 }
 
-TEST_CASE("WifiEnumerateAccessPoints API can be called", "[basic][rpc][client][remote]")
+TEST_CASE("WifiEnumerateAccessPoints API", "[basic][rpc][client][remote]")
 {
     using namespace Microsoft::Net::Remote;
     using namespace Microsoft::Net::Remote::Service;

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -14,6 +14,7 @@ TEST_CASE("WifiConfigureAccessPoint API can be called", "[basic][rpc][client][re
 {
     using namespace Microsoft::Net::Remote;
     using namespace Microsoft::Net::Remote::Service;
+    using namespace Microsoft::Net::Remote::Wifi;
 
     NetRemoteServer server{ Test::RemoteServiceAddressHttp };
     server.Run();
@@ -30,12 +31,12 @@ TEST_CASE("WifiConfigureAccessPoint API can be called", "[basic][rpc][client][re
                 Microsoft::Net::Wifi::AccessPointConfiguration apConfiguration{};
                 apConfiguration.set_phytype(phyType);
 
-                Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest request{};
+                WifiConfigureAccessPointRequest request{};
                 request.set_accesspointid(std::format("TestWifiConfigureAccessPoint{}", magic_enum::enum_name(band)));
                 request.set_defaultband(band);
                 request.mutable_configurations()->emplace(band, apConfiguration);
 
-                Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult result{};
+                WifiConfigureAccessPointResult result{};
                 grpc::ClientContext clientContext{};
 
                 auto status = client->WifiConfigureAccessPoint(&clientContext, request, &result);

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -70,5 +70,21 @@ TEST_CASE("WifiEnumerateAccessPoints API", "[basic][rpc][client][remote]")
 
         auto status = client->WifiEnumerateAccessPoints(&clientContext, request, &result);
         REQUIRE(status.ok());
+        REQUIRE_NOTHROW([&]{ [[maybe_unused]] const auto& accessPoints = result.accesspoints(); });
+    }
+
+    SECTION("Initial enablement status is disabled")
+    {
+        WifiEnumerateAccessPointsRequest request{};
+
+        WifiEnumerateAccessPointsResult result{};
+        grpc::ClientContext clientContext{};
+
+        auto status = client->WifiEnumerateAccessPoints(&clientContext, request, &result);
+        REQUIRE(status.ok());
+        // for (const auto& accessPoint : result.accesspoints())
+        // {
+        //     REQUIRE(accessPoint.enabled() == false);
+        // }
     }
 }

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -82,9 +82,10 @@ TEST_CASE("WifiEnumerateAccessPoints API", "[basic][rpc][client][remote]")
 
         auto status = client->WifiEnumerateAccessPoints(&clientContext, request, &result);
         REQUIRE(status.ok());
-        // for (const auto& accessPoint : result.accesspoints())
-        // {
-        //     REQUIRE(accessPoint.enabled() == false);
-        // }
+
+        for (const auto& accessPoint : result.accesspoints())
+        {
+            REQUIRE(!accessPoint.isenabled());
+        }
     }
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow clients to discover the access points that are available on the server, including their current status (enabled or not) and capabilities.

### Technical Details

* Add new API `WifiEnumerateAccessPoints` to `NetRemote` protobuf gprc structure which enumerates the access points available on the server, including their enablement status and capabilities.
* Implement `WifiEnumerateAccessPoints` with a stub.
* Add basic unit test for `WifiEnumerateAccessPoints` API.
* Use plog verbose for logging API invocations instead of `std::cout`.

### Test Results

* New unit tests pass.

### Reviewer Focus

* Consider whether this API provides enough actionable information for tests to use.
* Consider whether this API will be extensible for future uses.

### Future Work

* Implement `WifiEnumerateAccessPoints` properly.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
