### PR TITLE
Add workflow_call event to cicd workflow.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -8,6 +8,7 @@ name: CI/CD
 # coverage.
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build-validation:


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the CI/CD workflow can be used in branch settings.

### Technical Details

* Add `workflow_call` event to the workflow file allowing it to be called by Github actions.

### Test Results

* N/A

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
