### PR TITLE
Proposed API for field-updatable ap configuration.

### DIFF
--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -8,6 +8,6 @@ import "NetRemoteWifi.proto";
 
 service NetRemote
 {
-    rpc WifiConfigureAccessPoint (Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointRequest) returns (Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointResult);
+    rpc WifiConfigureAccessPoint (Microsoft.Net.Remote.Wifi.WifiAccessPointApplyConfigurationRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointApplyConfigurationResult);
     rpc WifiEnumerateAccessPoints (Microsoft.Net.Remote.Wifi.WifiEnumerateAccessPointsRequest) returns (Microsoft.Net.Remote.Wifi.WifiEnumerateAccessPointsResult);
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -51,7 +51,7 @@ message WifiAccessPointApplyConfigurationResultConfigurationItem
     // The status of applying the configuration.
     WifiAccessPointApplyConfigurationStatus Status = 3;
 
-    // Indicates the parts of the corresponging 'WifiAccessPointApplyConfigurationRequestConfigurationItem.Configuration'
+    // Indicates the parts of the corresponding 'WifiAccessPointApplyConfigurationRequestConfigurationItem.Configuration'
     // field that were successfully applied. Set only when Status != WifiAccessPointApplyConfigurationStatusSucceeded.
     google.protobuf.FieldMask ConfigurationFailuresMask = 4;
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -3,37 +3,79 @@ syntax = "proto3";
 
 package Microsoft.Net.Remote.Wifi;
 
+import "google/protobuf/field_mask.proto";
 import "WifiCore.proto";
 
-message WifiConfigureAccessPointRequest
+//
+// General notes:
+//
+// Despite all fields being implicitly optional in proto3, all fields are
+// required to be specified unless their definition is explicitly marked with
+// the 'optional' proto keyword.
+//
+
+enum WifiAccessPointApplyConfigurationStatus
+{
+    WifiAccessPointApplyConfigurationStatusUnknown = 0;
+    WifiAccessPointApplyConfigurationStatusSucceeded = 1;
+    WifiAccessPointApplyConfigurationStatusAccessPointInvalid = 2;
+    WifiAccessPointApplyConfigurationStatusAccessPointNotEnabled = 3;
+    WifiAccessPointApplyConfigurationStatusBandInactive = 4;
+    WifiAccessPointApplyConfigurationStatusOperationNotSupported = 5;
+}
+
+message WifiAccessPointApplyConfigurationRequestConfigurationItem
+{
+    // An optional unique identifier for this configuration request.
+    optional string Id = 1;
+
+    // The band the AP should be configured for.
+    Microsoft.Net.Wifi.RadioBand Band = 2;
+
+    // Specifies the parts of the 'Configuration' field to be applied.
+    google.protobuf.FieldMask ConfigurationMask = 3;
+
+    // The configuration for the AP.
+    Microsoft.Net.Wifi.AccessPointConfiguration Configuration = 4;
+}
+
+message WifiAccessPointApplyConfigurationResultConfigurationItem
+{
+    // The unique identifier of the configuration that was requested to be
+    // applied. Not populated if not specified in the corresponding request.
+    optional string Id = 1;
+
+    // The band the AP was requested to be configured for.
+    Microsoft.Net.Wifi.RadioBand Band = 2;
+
+    // The status of applying the configuration.
+    WifiAccessPointApplyConfigurationStatus Status = 3;
+
+    // Indicates the parts of the corresponging 'WifiAccessPointApplyConfigurationRequestConfigurationItem.Configuration'
+    // field that were successfully applied.
+    google.protobuf.FieldMask ConfigurationMask = 4;
+}
+
+message WifiAccessPointApplyConfigurationRequest
 {
     // The unique identifier of the access point to configure.
     string AccessPointId = 1;
 
-    // The default band the AP should be configured for.
-    Microsoft.Net.Wifi.RadioBand DefaultBand = 2;
-
-    // All the possible configurations for the AP. The key field *must* be a
-    // Microsoft.Net.Wifi.RadioBand enumeration value. This is to workaround the
-    // inability to use enums as map keys in proto3. So it must be used as if
-    // the 'Configurations' field was defined with type:
-    //      map<Microsoft.Net.Wifi.RadioBand, Microsoft.Net.Wifi.AccessPointConfiguration>
-    //
-    map<int32, Microsoft.Net.Wifi.AccessPointConfiguration> Configurations = 3;
+    // All desired configurations for the AP. One configuration item per active
+    // band is permitted. The server will neither apply nor persist any
+    // configurations for inactive bands.
+    repeated WifiAccessPointApplyConfigurationRequestConfigurationItem Configurations = 2;
 }
 
-message WifiConfigureAccessPointResult
+message WifiAccessPointApplyConfigurationResult
 {
     // The unique identifier of the access point that was requested to be configured.
     string AccessPointId = 1;
 
-    // Whether the configuration succeeded or not.
-    // TODO: 
-    //  - this seems too coarse. Should we return a map<int32, bool> instead?
-    //      - Would that information be actionable?
-    //  - is an error code better?
-    //
-    bool Succeeded = 2;
+    // The result of each configuration that was requested to be applied.
+    // Clients must not assume the order of items will match the order of those
+    // in the corresponding request.
+    repeated WifiAccessPointApplyConfigurationResultConfigurationItem ConfigurationResults = 2;
 }
 
 message WifiEnumerateAccessPointsResultItem

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -52,8 +52,8 @@ message WifiAccessPointApplyConfigurationResultConfigurationItem
     WifiAccessPointApplyConfigurationStatus Status = 3;
 
     // Indicates the parts of the corresponging 'WifiAccessPointApplyConfigurationRequestConfigurationItem.Configuration'
-    // field that were successfully applied.
-    google.protobuf.FieldMask ConfigurationMask = 4;
+    // field that were successfully applied. Set only when Status != WifiAccessPointApplyConfigurationStatusSucceeded.
+    google.protobuf.FieldMask ConfigurationFailuresMask = 4;
 }
 
 message WifiAccessPointApplyConfigurationRequest

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -32,11 +32,8 @@ message WifiAccessPointApplyConfigurationRequestConfigurationItem
     // The band the AP should be configured for.
     Microsoft.Net.Wifi.RadioBand Band = 2;
 
-    // Specifies the parts of the 'Configuration' field to be applied.
-    google.protobuf.FieldMask ConfigurationMask = 3;
-
     // The configuration for the AP.
-    Microsoft.Net.Wifi.AccessPointConfiguration Configuration = 4;
+    Microsoft.Net.Wifi.AccessPointConfiguration Configuration = 3;
 }
 
 message WifiAccessPointApplyConfigurationResultConfigurationItem

--- a/src/common/dotnet/NetRemoteClientUnitTest/UnitTestNetRemoteClient.cs
+++ b/src/common/dotnet/NetRemoteClientUnitTest/UnitTestNetRemoteClient.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Net.Remote.Client.Test
             {
                 foreach (var phyType in Enum.GetValues(typeof(Net.Wifi.Dot11PhyType)).Cast<Net.Wifi.Dot11PhyType>())
                 {
-                    var request = new WifiConfigureAccessPointRequest
+                    var request = new WifiAccessPointApplyConfigurationRequest
                     {
                         AccessPointId = string.Format("TestWifiConfigureAccessPoint{0}", band),
                         DefaultBand = band,

--- a/src/common/dotnet/NetRemoteService/Services/NetRemoteService.cs
+++ b/src/common/dotnet/NetRemoteService/Services/NetRemoteService.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Net.Remote.Service
             _logger = logger;
         }
 
-        public override Task<Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointResult> WifiConfigureAccessPoint(Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointRequest request, Grpc::ServerCallContext context)
+        public override Task<Microsoft.Net.Remote.Wifi.WifiAccessPointApplyConfigurationResult> WifiConfigureAccessPoint(Microsoft.Net.Remote.Wifi.WifiAccessPointApplyConfigurationRequest request, Grpc::ServerCallContext context)
         {
-            return Task.FromResult(new Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointResult
+            return Task.FromResult(new Microsoft.Net.Remote.Wifi.WifiAccessPointApplyConfigurationResult
             {
                 AccessPointId = request.AccessPointId,
                 Succeeded = true,

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -1,6 +1,8 @@
 
+#include <algorithm>
 #include <format>
 #include <iostream>
+#include <vector>
 
 #include <microsoft/net/remote/NetRemoteService.hxx>
 #include <plog/Log.h>
@@ -10,10 +12,21 @@ using namespace Microsoft::Net::Remote::Service;
 ::grpc::Status
 NetRemoteService::WifiConfigureAccessPoint([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response)
 {
+    using Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationResultConfigurationItem;
+
     LOG_VERBOSE << std::format("Received WifiConfigureAccessPoint request for access point id {} with {} configurations\n", request->accesspointid(), request->configurations_size());
 
     response->set_accesspointid(request->accesspointid());
-    response->set_succeeded(true);
+
+    std::vector<WifiAccessPointApplyConfigurationResultConfigurationItem> results(static_cast<std::size_t>(std::size(request->configurations())));
+    std::ranges::transform(request->configurations(), std::begin(results), [&](const auto& configuration) {
+        return WifiAccessPointApplyConfiguration(request->accesspointid(), configuration);
+    });
+
+    *response->mutable_configurationresults() = {
+        std::make_move_iterator(std::begin(results)),
+        std::make_move_iterator(std::end(results))
+    };
 
     return grpc::Status::OK;
 }
@@ -24,4 +37,13 @@ NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerConte
     LOG_VERBOSE << std::format("Received WifiEnumerateAccessPoints request\n");
 
     return grpc::Status::OK;
+}
+
+::Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationResultConfigurationItem 
+NetRemoteService::WifiAccessPointApplyConfiguration([[maybe_unused]] std::string_view accessPointId, [[maybe_unused]] const ::Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationRequestConfigurationItem& configuredDesired)
+{
+    ::Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationResultConfigurationItem result{};
+    result.set_status(Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationStatus::WifiAccessPointApplyConfigurationStatusSucceeded);
+    // TODO: implement if design accepted
+    return result;
 }

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -18,6 +18,7 @@ NetRemoteService::WifiConfigureAccessPoint([[maybe_unused]] ::grpc::ServerContex
 
     response->set_accesspointid(request->accesspointid());
 
+    // Apply configuration for requested band on the access point.
     std::vector<WifiAccessPointApplyConfigurationResultConfigurationItem> results(static_cast<std::size_t>(std::size(request->configurations())));
     std::ranges::transform(request->configurations(), std::begin(results), [&](const auto& configuration) {
         return WifiAccessPointApplyConfiguration(request->accesspointid(), configuration);
@@ -40,10 +41,19 @@ NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerConte
 }
 
 ::Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationResultConfigurationItem 
-NetRemoteService::WifiAccessPointApplyConfiguration([[maybe_unused]] std::string_view accessPointId, [[maybe_unused]] const ::Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationRequestConfigurationItem& configuredDesired)
+NetRemoteService::WifiAccessPointApplyConfiguration([[maybe_unused]] std::string_view accessPointId, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationRequestConfigurationItem& configurationDesired)
 {
     ::Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationResultConfigurationItem result{};
-    result.set_status(Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationStatus::WifiAccessPointApplyConfigurationStatusSucceeded);
+
+    result.set_band(configurationDesired.band());
+    if (configurationDesired.has_id())
+    {
+        result.set_id(configurationDesired.id());
+    }
+
     // TODO: implement if design accepted
+
+    result.set_status(Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationStatus::WifiAccessPointApplyConfigurationStatusSucceeded);
+
     return result;
 }

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -2,18 +2,25 @@
 #ifndef NET_REMOTE_SERVICE_HXX
 #define NET_REMOTE_SERVICE_HXX
 
+#include <string_view>
+
 #include <microsoft/net/remote/protocol/NetRemoteService.grpc.pb.h>
 
 namespace Microsoft::Net::Remote::Service
 {
-class NetRemoteService : 
+class NetRemoteService :
     public NetRemote::Service
 {
+public:
     virtual ::grpc::Status
-    WifiConfigureAccessPoint(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response) override;
+    WifiConfigureAccessPoint(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationResult* response) override;
 
     virtual ::grpc::Status
     WifiEnumerateAccessPoints(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response) override;
+
+protected:
+    ::Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationResultConfigurationItem
+    WifiAccessPointApplyConfiguration(std::string_view accessPointId, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationRequestConfigurationItem& configuredDesired);
 };
 } // namespace Microsoft::Net::Remote::Service
 

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -1,8 +1,12 @@
 
+#include <algorithm>
 #include <format>
 #include <iostream>
+#include <iterator>
+#include <vector>
 
 #include <catch2/catch_test_macros.hpp>
+#include <google/protobuf/util/field_mask_util.h>
 #include <grpcpp/create_channel.h>
 #include <magic_enum.hpp>
 #include <microsoft/net/remote/NetRemoteServer.hxx>
@@ -12,9 +16,15 @@
 
 TEST_CASE("WifiConfigureAccessPoint API", "[basic][rpc][client][remote]")
 {
+    using namespace google::protobuf::util;
     using namespace Microsoft::Net::Remote;
     using namespace Microsoft::Net::Remote::Service;
     using namespace Microsoft::Net::Remote::Wifi;
+
+    using Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationRequest;
+    using Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationRequestConfigurationItem;
+    using Microsoft::Net::Remote::Wifi::WifiAccessPointApplyConfigurationResult;
+    using Microsoft::Net::Wifi::AccessPointConfiguration;
 
     NetRemoteServer server{ Test::RemoteServiceAddressHttp };
     server.Run();
@@ -24,24 +34,41 @@ TEST_CASE("WifiConfigureAccessPoint API", "[basic][rpc][client][remote]")
 
     SECTION("Can be called")
     {
-        for (const auto& band : magic_enum::enum_values<Microsoft::Net::Wifi::RadioBand>()) {
-            for (const auto& phyType : magic_enum::enum_values<Microsoft::Net::Wifi::Dot11PhyType>()) {
-                Microsoft::Net::Wifi::AccessPointConfiguration apConfiguration{};
-                apConfiguration.set_phytype(phyType);
+        for (const auto& phyType : magic_enum::enum_values<Microsoft::Net::Wifi::Dot11PhyType>()) {
+            AccessPointConfiguration apConfiguration{};
+            apConfiguration.set_phytype(phyType);
 
-                WifiConfigureAccessPointRequest request{};
-                request.set_accesspointid(std::format("TestWifiConfigureAccessPoint{}", magic_enum::enum_name(band)));
-                request.set_defaultband(band);
-                request.mutable_configurations()->emplace(band, apConfiguration);
+            WifiAccessPointApplyConfigurationRequest request{};
+            request.set_accesspointid(std::format("TestWifiConfigureAccessPoint{}", magic_enum::enum_name(phyType)));
 
-                WifiConfigureAccessPointResult result{};
-                grpc::ClientContext clientContext{};
+            // Build a list of configurations to apply, one for each radio band.
+            std::vector<WifiAccessPointApplyConfigurationRequestConfigurationItem> configurationsToApply{ magic_enum::enum_count<Microsoft::Net::Wifi::RadioBand>() };
+            std::ranges::transform(magic_enum::enum_values<Microsoft::Net::Wifi::RadioBand>(), std::begin(configurationsToApply), [&](const auto& band) {
+                WifiAccessPointApplyConfigurationRequestConfigurationItem item{};
+                item.set_band(band);
+                item.mutable_configuration()->set_phytype(phyType);
+                *item.mutable_configurationmask() = google::protobuf::util::FieldMaskUtil::GetFieldMaskForAllFields<AccessPointConfiguration>();
 
-                auto status = client->WifiConfigureAccessPoint(&clientContext, request, &result);
+                return item;
+            });
 
-                REQUIRE(status.ok());
-                REQUIRE(result.succeeded() == true);
-                REQUIRE(result.accesspointid() == request.accesspointid());
+            // Assign the configurations to the request.
+            *request.mutable_configurations() = {
+                std::make_move_iterator(std::begin(configurationsToApply)),
+                std::make_move_iterator(std::end(configurationsToApply))
+            };
+
+            WifiAccessPointApplyConfigurationResult result{};
+            grpc::ClientContext clientContext{};
+
+            auto status = client->WifiConfigureAccessPoint(&clientContext, request, &result);
+
+            REQUIRE(status.ok());
+            REQUIRE(result.accesspointid() == request.accesspointid());
+            REQUIRE(std::size(result.configurationresults()) == std::size(request.configurations()));
+
+            for (const auto& configurationResult : result.configurationresults()) {
+                REQUIRE(configurationResult.status() == WifiAccessPointApplyConfigurationStatus::WifiAccessPointApplyConfigurationStatusSucceeded);
             }
         }
     }

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -47,7 +47,6 @@ TEST_CASE("WifiConfigureAccessPoint API", "[basic][rpc][client][remote]")
                 WifiAccessPointApplyConfigurationRequestConfigurationItem item{};
                 item.set_band(band);
                 item.mutable_configuration()->set_phytype(phyType);
-                *item.mutable_configurationmask() = google::protobuf::util::FieldMaskUtil::GetFieldMaskForAllFields<AccessPointConfiguration>();
 
                 return item;
             });

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -68,6 +68,7 @@ TEST_CASE("WifiConfigureAccessPoint API", "[basic][rpc][client][remote]")
             REQUIRE(std::size(result.configurationresults()) == std::size(request.configurations()));
 
             for (const auto& configurationResult : result.configurationresults()) {
+                REQUIRE(configurationResult.band() == configurationResult.band());
                 REQUIRE(configurationResult.status() == WifiAccessPointApplyConfigurationStatus::WifiAccessPointApplyConfigurationStatusSucceeded);
             }
         }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [X] Breaking change
- [ ] Non-functional change

### Goals

* Provide an API for updating many configuration settings of an access point at once. 
    - The driving scenario is to allow an initial, base/core set of configurations to be applied to an access point when initially enabled.

### Technical Details

*  This proposes an API which enables partial access point configuration updates in a single call. The request structure `WifiAccessPointApplyConfigurationRequest` takes in series of configurations, one for each active radio band, and attempts to apply these configurations. 

### Test Results

* All added unit tests pass.

### Reviewer Focus

* Consider whether partial configuration in a single API is needed at all, compared to the alternative of providing distinct APIs to change configuration options instead, of which some will be required anyway (eg. changing authentication mechanism and the active band are just a few).
* Consider whether this functionality could be achieved differently by requiring a core set of configuration when enabling an access point, something like (roughly):

```proto

rpc WifiAccessPointEnable (WifiAccessPointEnableRequest, WifiAccessPointEnableResult);
message WifiAccessPointEnableRequest
{
    string AccessPointId;
    WifiAccessPointConfigurationCore CoreConfiguration;
}

message Ssid {/* ... */};
message WifiAccessPointConfigurationCore
{
    RadioBand Band;
    Ssid Ssid;
    Dot11PhyType PhyType;
    Dot11AuthenticationAlgorithm AuthenticationAlgorithm;
    // Other core configuration required for basic operation here.
}
```

### Future Work

* Propose alternative API for achieving same effect.

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
