### PR TITLE
Proposed API for AP enablement and initial configuration

### DIFF
--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -10,4 +10,6 @@ service NetRemote
 {
     rpc WifiConfigureAccessPoint (Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointRequest) returns (Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointResult);
     rpc WifiEnumerateAccessPoints (Microsoft.Net.Remote.Wifi.WifiEnumerateAccessPointsRequest) returns (Microsoft.Net.Remote.Wifi.WifiEnumerateAccessPointsResult);
+    rpc WifiAccessPointEnable (Microsoft.Net.Remote.Wifi.WifiAccessPointEnableRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointEnableResult);
+    rpc WifiAccessPointDisable (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableResult);
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -55,10 +55,12 @@ message WifiEnumerateAccessPointsResult
 
 enum WifiAccessPointOperationStatusCode
 {
-    WifiAccessPointOperationStatusCodeSucceeded = 0;
-    WifiAccessPointOperationStatusCodeAccessPointInvalid = 1;
-    WifiAccessPointOperationStatusCodeAccessPointNotEnabled = 2;
-    WifiAccessPointOperationStatusCodeOperationNotSupported = 3;
+    WifiAccessPointOperationStatusCodeUnknown = 0;
+    WifiAccessPointOperationStatusCodeSucceeded = 1;
+    WifiAccessPointOperationStatusCodeInvalidParameter = 2;
+    WifiAccessPointOperationStatusCodeAccessPointInvalid = 3;
+    WifiAccessPointOperationStatusCodeAccessPointNotEnabled = 4;
+    WifiAccessPointOperationStatusCodeOperationNotSupported = 5;
 }
 
 message WifiAccessPointOperationStatus
@@ -87,5 +89,6 @@ message WifiAccessPointDisableRequest
 
 message WifiAccessPointDisableResult
 {
+    string AccessPointId = 1;
     WifiAccessPointOperationStatus Status = 2;
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 
 package Microsoft.Net.Remote.Wifi;
 
+import "google/protobuf/any.proto";
 import "WifiCore.proto";
 
 message WifiConfigureAccessPointRequest
@@ -50,4 +51,41 @@ message WifiEnumerateAccessPointsRequest
 message WifiEnumerateAccessPointsResult
 {
     repeated Microsoft.Net.Remote.Wifi.WifiEnumerateAccessPointsResultItem AccessPoints = 1;
+}
+
+enum WifiAccessPointOperationStatusCode
+{
+    WifiAccessPointOperationStatusCodeSucceeded = 0;
+    WifiAccessPointOperationStatusCodeAccessPointInvalid = 1;
+    WifiAccessPointOperationStatusCodeAccessPointNotEnabled = 2;
+    WifiAccessPointOperationStatusCodeOperationNotSupported = 3;
+}
+
+message WifiAccessPointOperationStatus
+{
+    WifiAccessPointOperationStatusCode Code = 1;
+    string Message = 2;
+    google.protobuf.Any Details = 3;
+}
+
+message WifiAccessPointEnableRequest
+{
+    string AccessPointId = 1;
+    Microsoft.Net.Wifi.AccessPointConfiguration Configuration = 2;
+}
+
+message WifiAccessPointEnableResult
+{
+    string AccessPointId = 1;
+    WifiAccessPointOperationStatus Status = 2;
+}
+
+message WifiAccessPointDisableRequest
+{
+    string AccessPointId = 1;
+}
+
+message WifiAccessPointDisableResult
+{
+    WifiAccessPointOperationStatus Status = 2;
 }

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -124,7 +124,7 @@ message AccessPointCapabilities
     repeated Microsoft.Net.Wifi.RadioBand Bands = 1;
     repeated Microsoft.Net.Wifi.Dot11PhyType PhyTypes = 2;
     repeated Microsoft.Net.Wifi.Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 3;
-    repeated Microsoft.Net.Wifi.Dot11CipherAlgorithm CipherAlgorithms = 4;
+    repeated Microsoft.Net.Wifi.Dot11CipherAlgorithm EncryptionAlgorithms = 4;
 }
 
 enum AccessPointState

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -85,9 +85,38 @@ enum Dot11CipherAlgorithm
     Dot11CipherAlgorithmRsnUseGroup = 12;
 }
 
+message Dot11Ssid
+{
+    oneof Value
+    {
+        string Name = 1;
+        string Hex = 2;
+        bytes Data = 3;
+    }
+}
+
+message Dot11MacAddress
+{
+    bytes Value = 1;
+}
+
+message SharedKey
+{
+    oneof Value
+    {
+        string Passphrase = 1;
+        bytes Data = 2;
+    }
+}
+
 message AccessPointConfiguration
 {
-    Dot11PhyType PhyType = 1;
+    Dot11Ssid Ssid = 1;
+    Dot11MacAddress Bssid = 2;
+    Dot11PhyType PhyType = 3;
+    Dot11AuthenticationAlgorithm AuthenticationAlgorithm = 4;
+    Dot11CipherAlgorithm EncryptionAlgorithm = 5;
+    repeated RadioBand Bands = 6;
 }
 
 message AccessPointCapabilities
@@ -95,6 +124,7 @@ message AccessPointCapabilities
     repeated Microsoft.Net.Wifi.RadioBand Bands = 1;
     repeated Microsoft.Net.Wifi.Dot11PhyType PhyTypes = 2;
     repeated Microsoft.Net.Wifi.Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 3;
+    repeated Microsoft.Net.Wifi.Dot11CipherAlgorithm CipherAlgorithms = 4;
 }
 
 enum AccessPointState

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -33,15 +33,15 @@ using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
 using Microsoft::Net::Wifi::Dot11CipherAlgorithm;
 using Microsoft::Net::Wifi::Dot11PhyType;
 
-::grpc::Status NetRemoteService::WifiAccessPointEnable([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableResult* response)
+::grpc::Status
+NetRemoteService::WifiAccessPointEnable([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableResult* response)
 {
     LOG_VERBOSE << std::format("Received WifiAccessPointEnable request for access point id {}\n", request->accesspointid());
 
     WifiAccessPointOperationStatus status{};
 
     // Validate request is well-formed and has all required parameters.
-    if (ValidateWifiAccessPointEnableRequest(request, status))
-    {
+    if (ValidateWifiAccessPointEnableRequest(request, status)) {
         // TODO: Enable the access point.
         status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
     }
@@ -52,7 +52,8 @@ using Microsoft::Net::Wifi::Dot11PhyType;
     return grpc::Status::OK;
 }
 
-::grpc::Status NetRemoteService::WifiAccessPointDisable([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableResult* response)
+::grpc::Status
+NetRemoteService::WifiAccessPointDisable([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableResult* response)
 {
     LOG_VERBOSE << std::format("Received WifiAccessPointDisable request for access point id {}\n", request->accesspointid());
 
@@ -66,44 +67,39 @@ using Microsoft::Net::Wifi::Dot11PhyType;
     return grpc::Status::OK;
 }
 
-bool NetRemoteService::ValidateWifiAccessPointEnableRequest(const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus& status)
+bool
+NetRemoteService::ValidateWifiAccessPointEnableRequest(const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus& status)
 {
     // Validate required arguments are present. Detailed argument validation is left to the implementation.
 
-    if (!request->has_configuration())
-    {
+    if (!request->has_configuration()) {
         // Configuration isn't required, so exit early.
         return true;
     }
 
     // Configuration isn't required, but if it's present, it must be valid.
     const auto& configuration = request->configuration();
-    if (!configuration.has_ssid())
-    {
+    if (!configuration.has_ssid()) {
         status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
         status.set_message("No SSID provided");
         return false;
     }
-    if (configuration.phytype() == Dot11PhyType::Dot11PhyTypeUnknown)
-    {
+    if (configuration.phytype() == Dot11PhyType::Dot11PhyTypeUnknown) {
         status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
         status.set_message("No PHY type provided");
         return false;
     }
-    if (configuration.authenticationalgorithm() == Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmUnknown)
-    {
+    if (configuration.authenticationalgorithm() == Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmUnknown) {
         status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
         status.set_message("No authentication algorithm provided");
         return false;
     }
-    if (configuration.encryptionalgorithm() == Dot11CipherAlgorithm::Dot11CipherAlgorithmUnknown)
-    {
+    if (configuration.encryptionalgorithm() == Dot11CipherAlgorithm::Dot11CipherAlgorithmUnknown) {
         status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
         status.set_message("No encryption algorithm provided");
         return false;
     }
-    if (std::empty(configuration.bands()))
-    {
+    if (std::empty(configuration.bands())) {
         status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
         status.set_message("No radio bands provided");
         return false;

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -57,6 +57,7 @@ using Microsoft::Net::Wifi::Dot11PhyType;
     LOG_VERBOSE << std::format("Received WifiAccessPointDisable request for access point id {}\n", request->accesspointid());
 
     WifiAccessPointOperationStatus status{};
+    // TODO: Disable the access point.
     status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
 
     response->set_accesspointid(request->accesspointid());

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -72,11 +72,11 @@ bool NetRemoteService::ValidateWifiAccessPointEnableRequest(const ::Microsoft::N
 
     if (!request->has_configuration())
     {
-        status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
-        status.set_message("No configuration provided");
-        return false;
+        // Configuration isn't required, so exit early.
+        return true;
     }
 
+    // Configuration isn't required, but if it's present, it must be valid.
     const auto& configuration = request->configuration();
     if (!configuration.has_ssid())
     {

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -1,6 +1,7 @@
 
 #include <format>
 #include <iostream>
+#include <iterator>
 
 #include <microsoft/net/remote/NetRemoteService.hxx>
 #include <plog/Log.h>
@@ -24,4 +25,88 @@ NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerConte
     LOG_VERBOSE << std::format("Received WifiEnumerateAccessPoints request\n");
 
     return grpc::Status::OK;
+}
+
+using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus;
+using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode;
+using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
+using Microsoft::Net::Wifi::Dot11CipherAlgorithm;
+using Microsoft::Net::Wifi::Dot11PhyType;
+
+::grpc::Status NetRemoteService::WifiAccessPointEnable([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableResult* response)
+{
+    LOG_VERBOSE << std::format("Received WifiAccessPointEnable request for access point id {}\n", request->accesspointid());
+
+    WifiAccessPointOperationStatus status{};
+
+    // Validate request is well-formed and has all required parameters.
+    if (ValidateWifiAccessPointEnableRequest(request, status))
+    {
+        // TODO: Enable the access point.
+        status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
+    }
+
+    response->set_accesspointid(request->accesspointid());
+    *response->mutable_status() = std::move(status);
+
+    return grpc::Status::OK;
+}
+
+::grpc::Status NetRemoteService::WifiAccessPointDisable([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableResult* response)
+{
+    LOG_VERBOSE << std::format("Received WifiAccessPointDisable request for access point id {}\n", request->accesspointid());
+
+    WifiAccessPointOperationStatus status{};
+    status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
+
+    response->set_accesspointid(request->accesspointid());
+    *response->mutable_status() = std::move(status);
+
+    return grpc::Status::OK;
+}
+
+bool NetRemoteService::ValidateWifiAccessPointEnableRequest(const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus& status)
+{
+    // Validate required arguments are present. Detailed argument validation is left to the implementation.
+
+    if (!request->has_configuration())
+    {
+        status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+        status.set_message("No configuration provided");
+        return false;
+    }
+
+    const auto& configuration = request->configuration();
+    if (!configuration.has_ssid())
+    {
+        status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+        status.set_message("No SSID provided");
+        return false;
+    }
+    if (configuration.phytype() == Dot11PhyType::Dot11PhyTypeUnknown)
+    {
+        status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+        status.set_message("No PHY type provided");
+        return false;
+    }
+    if (configuration.authenticationalgorithm() == Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmUnknown)
+    {
+        status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+        status.set_message("No authentication algorithm provided");
+        return false;
+    }
+    if (configuration.encryptionalgorithm() == Dot11CipherAlgorithm::Dot11CipherAlgorithmUnknown)
+    {
+        status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+        status.set_message("No encryption algorithm provided");
+        return false;
+    }
+    if (std::empty(configuration.bands()))
+    {
+        status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+        status.set_message("No radio bands provided");
+        return false;
+    }
+
+    return true;
 }

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -9,11 +9,13 @@ namespace Microsoft::Net::Remote::Service
 class NetRemoteService :
     public NetRemote::Service
 {
-    virtual ::grpc::Status
-    WifiConfigureAccessPoint(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response) override;
+    virtual ::grpc::Status WifiConfigureAccessPoint(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response) override;
+    virtual ::grpc::Status WifiEnumerateAccessPoints(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response) override;
+    virtual ::grpc::Status WifiAccessPointEnable(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableResult* response) override;
+    virtual ::grpc::Status WifiAccessPointDisable(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableResult* response) override;
 
-    virtual ::grpc::Status
-    WifiEnumerateAccessPoints(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response) override;
+protected:
+    bool ValidateWifiAccessPointEnableRequest(const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus& status);
 };
 } // namespace Microsoft::Net::Remote::Service
 

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -9,13 +9,21 @@ namespace Microsoft::Net::Remote::Service
 class NetRemoteService :
     public NetRemote::Service
 {
-    virtual ::grpc::Status WifiConfigureAccessPoint(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response) override;
-    virtual ::grpc::Status WifiEnumerateAccessPoints(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response) override;
-    virtual ::grpc::Status WifiAccessPointEnable(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableResult* response) override;
-    virtual ::grpc::Status WifiAccessPointDisable(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableResult* response) override;
+    virtual ::grpc::Status
+    WifiConfigureAccessPoint(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response) override;
+
+    virtual ::grpc::Status
+    WifiEnumerateAccessPoints(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response) override;
+
+    virtual ::grpc::Status
+    WifiAccessPointEnable(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableResult* response) override;
+
+    virtual ::grpc::Status
+    WifiAccessPointDisable(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableResult* response) override;
 
 protected:
-    bool ValidateWifiAccessPointEnableRequest(const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus& status);
+    bool
+    ValidateWifiAccessPointEnableRequest(const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus& status);
 };
 } // namespace Microsoft::Net::Remote::Service
 

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -1,8 +1,8 @@
 
 #include <format>
 #include <iostream>
-#include <string_view>
 #include <string>
+#include <string_view>
 
 #include <catch2/catch_test_macros.hpp>
 #include <grpcpp/create_channel.h>

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -1,6 +1,8 @@
 
 #include <format>
 #include <iostream>
+#include <string_view>
+#include <string>
 
 #include <catch2/catch_test_macros.hpp>
 #include <grpcpp/create_channel.h>
@@ -86,5 +88,47 @@ TEST_CASE("WifiEnumerateAccessPoints API", "[basic][rpc][client][remote]")
         for (const auto& accessPoint : result.accesspoints()) {
             REQUIRE(!accessPoint.isenabled());
         }
+    }
+}
+
+TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
+{
+    using namespace Microsoft::Net::Remote;
+    using namespace Microsoft::Net::Remote::Service;
+    using namespace Microsoft::Net::Remote::Wifi;
+    using namespace Microsoft::Net::Wifi;
+
+    constexpr auto SsidName{ "TestWifiAccessPointEnable" };
+
+    NetRemoteServer server{ Test::RemoteServiceAddressHttp };
+    server.Run();
+
+    auto channel = grpc::CreateChannel(Test::RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());
+    auto client = NetRemote::NewStub(channel);
+
+    SECTION("Can be called")
+    {
+        AccessPointConfiguration apConfiguration{};
+        apConfiguration.mutable_ssid()->set_name(SsidName);
+        apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
+        apConfiguration.set_authenticationalgorithm(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);
+        apConfiguration.set_encryptionalgorithm(Dot11CipherAlgorithm::Dot11CipherAlgorithmCcmp256);
+        apConfiguration.mutable_bands()->Add(RadioBand::RadioBand2_4GHz);
+        apConfiguration.mutable_bands()->Add(RadioBand::RadioBand5_0GHz);
+
+        WifiAccessPointEnableRequest request{};
+        request.set_accesspointid("TestWifiAccessPointEnable");
+        *request.mutable_configuration() = std::move(apConfiguration);
+
+        WifiAccessPointEnableResult result{};
+        grpc::ClientContext clientContext{};
+
+        auto status = client->WifiAccessPointEnable(&clientContext, request, &result);
+        REQUIRE(status.ok());
+        REQUIRE(result.accesspointid() == request.accesspointid());
+        REQUIRE(result.has_status());
+        REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
+        REQUIRE(result.status().message().empty());
+        REQUIRE(result.status().has_details() == false);
     }
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Provide APIs for enabling and disabling access points.
* For AP enablement, also allow specifying configuration for first-time enablement.

### Technical Details

* Add protobuf rpcs `WifiAccessPointEnable` and `WifiAccessPointDisable`.
* Add some additional core Wi-Fi protobuf data structures (ssid, mac address, shared key).
* Add encryption algorithms to `AccessPointCapabilities`.
* Extend `AccessPointConfiguration` with minimal configuration expected to be set prior to first enablement.
* `WifiAccessPointEnable` API takes an `AccessPointConfiguration` to allow initial configuration is performed.

### Test Results

* Added unit tests pass.

### Reviewer Focus

* The authentication details, such as the PSK, are not yet encoded in this API. These should be trivial to add.

### Future Work

* Resolve issues mentioned in the `Reviewer Focus` section above.

### Checklist

- [X] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
