### PR TITLE
Apply clang-format to the codebase

### DIFF
--- a/src/common/server/NetRemoteServer.cxx
+++ b/src/common/server/NetRemoteServer.cxx
@@ -18,15 +18,16 @@ NetRemoteServer::~NetRemoteServer()
     Stop();
 }
 
-std::unique_ptr<grpc::Server>& NetRemoteServer::GetGrpcServer() noexcept
+std::unique_ptr<grpc::Server>&
+NetRemoteServer::GetGrpcServer() noexcept
 {
     return m_server;
 }
 
-void NetRemoteServer::Run()
+void
+NetRemoteServer::Run()
 {
-    if (m_server != nullptr)
-    {
+    if (m_server != nullptr) {
         return;
     }
 
@@ -38,10 +39,10 @@ void NetRemoteServer::Run()
     LOG_INFO << std::format("netremote server started listening on {}", m_serverAddress);
 }
 
-void NetRemoteServer::Stop()
+void
+NetRemoteServer::Stop()
 {
-    if (m_server == nullptr)
-    {
+    if (m_server == nullptr) {
         return;
     }
 

--- a/src/common/server/NetRemoteServerConfiguration.cxx
+++ b/src/common/server/NetRemoteServerConfiguration.cxx
@@ -37,14 +37,10 @@ ParseCliAppOptions(bool throwOnParseError, Args&&... args)
     NetRemoteServerConfiguration configuration{};
     ConfigureCliAppOptions(app, configuration);
 
-    try
-    {
+    try {
         app.parse(std::forward<Args>(args)...);
-    }
-    catch (const CLI::ParseError& parseError)
-    {
-        if (throwOnParseError)
-        {
+    } catch (const CLI::ParseError& parseError) {
+        if (throwOnParseError) {
             throw parseError;
         }
     }

--- a/src/common/server/include/microsoft/net/remote/NetRemoteServer.hxx
+++ b/src/common/server/include/microsoft/net/remote/NetRemoteServer.hxx
@@ -3,8 +3,8 @@
 #define NET_REMOTE_SERVER_HXX
 
 #include <memory>
-#include <string_view>
 #include <string>
+#include <string_view>
 
 #include <grpcpp/server.h>
 #include <microsoft/net/remote/NetRemoteService.hxx>
@@ -20,27 +20,30 @@ struct NetRemoteServer
 
     /**
      * @brief Construct a new NetRemoteServer object.
-     * 
-     * @param serverAddress 
+     *
+     * @param serverAddress
      */
     NetRemoteServer(std::string_view serverAddress);
 
     /**
      * @brief Get the GrpcServer object.
-     * 
-     * @return std::unique_ptr<grpc::Server>& 
+     *
+     * @return std::unique_ptr<grpc::Server>&
      */
-    std::unique_ptr<grpc::Server>& GetGrpcServer() noexcept;
+    std::unique_ptr<grpc::Server>&
+    GetGrpcServer() noexcept;
 
     /**
      * @brief Start the server if not already started.
      */
-    void Run();
+    void
+    Run();
 
     /**
      * @brief Stop the server if started.
      */
-    void Stop();
+    void
+    Stop();
 
 private:
     std::string m_serverAddress;

--- a/src/common/server/include/microsoft/net/remote/NetRemoteServerConfiguration.hxx
+++ b/src/common/server/include/microsoft/net/remote/NetRemoteServerConfiguration.hxx
@@ -18,11 +18,11 @@ struct NetRemoteServerConfiguration
     /**
      * @brief Create a NetRemoteServerConfiguration object from command-line
      * arguments.
-     * 
-     * @param argc 
-     * @param argv 
+     *
+     * @param argc
+     * @param argv
      * @param throwOnParseError
-     * @return NetRemoteServerConfiguration 
+     * @return NetRemoteServerConfiguration
      */
     static NetRemoteServerConfiguration
     FromCommandLineArguments(int argc, char* argv[], bool throwOnParseError = false);
@@ -30,10 +30,10 @@ struct NetRemoteServerConfiguration
     /**
      * @brief Create a NetRemoteServerConfiguration object from command-line
      * arguments.
-     * 
-     * @param args 
+     *
+     * @param args
      * @param throwOnParseError
-     * @return NetRemoteServerConfiguration 
+     * @return NetRemoteServerConfiguration
      */
     static NetRemoteServerConfiguration
     FromCommandLineArguments(std::vector<std::string>& args, bool throwOnParseError = false);

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -7,7 +7,8 @@
 
 using namespace Microsoft::Net::Remote::Service;
 
-::grpc::Status NetRemoteService::WifiConfigureAccessPoint([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response)
+::grpc::Status
+NetRemoteService::WifiConfigureAccessPoint([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response)
 {
     LOG_VERBOSE << std::format("Received WifiConfigureAccessPoint request for access point id {} with {} configurations\n", request->accesspointid(), request->configurations_size());
 
@@ -17,8 +18,8 @@ using namespace Microsoft::Net::Remote::Service;
     return grpc::Status::OK;
 }
 
-
-::grpc::Status NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerContext* context, [[maybe_unused]] const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, [[maybe_unused]] ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response)
+::grpc::Status
+NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerContext* context, [[maybe_unused]] const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, [[maybe_unused]] ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response)
 {
     LOG_VERBOSE << std::format("Received WifiEnumerateAccessPoints request\n");
 

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -6,7 +6,8 @@
 
 namespace Microsoft::Net::Remote::Service
 {
-class NetRemoteService : public NetRemote::Service
+class NetRemoteService : 
+    public NetRemote::Service
 {
     virtual ::grpc::Status
     WifiConfigureAccessPoint(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response) override;

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -8,9 +8,12 @@ namespace Microsoft::Net::Remote::Service
 {
 class NetRemoteService : public NetRemote::Service
 {
-    virtual ::grpc::Status WifiConfigureAccessPoint(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response) override;
-    virtual ::grpc::Status WifiEnumerateAccessPoints(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response) override;
+    virtual ::grpc::Status
+    WifiConfigureAccessPoint(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response) override;
+
+    virtual ::grpc::Status
+    WifiEnumerateAccessPoints(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response) override;
 };
 } // namespace Microsoft::Net::Remote::Service
 
-#endif // NET_REMOTE_SERVICE_HXX 
+#endif // NET_REMOTE_SERVICE_HXX

--- a/src/common/shared/logging/LogUtils.cxx
+++ b/src/common/shared/logging/LogUtils.cxx
@@ -5,7 +5,8 @@
 
 #include <logging/LogUtils.hxx>
 
-std::string logging::GetLogName(std::string_view componentName)
+std::string
+logging::GetLogName(std::string_view componentName)
 {
     const auto now = std::chrono::system_clock::now();
     const std::time_t t_c = std::chrono::system_clock::to_time_t(now);
@@ -20,10 +21,10 @@ std::string logging::GetLogName(std::string_view componentName)
     return ss.str();
 }
 
-plog::Severity logging::LogVerbosityToPlogSeverity(uint8_t verbosity) noexcept
+plog::Severity
+logging::LogVerbosityToPlogSeverity(uint8_t verbosity) noexcept
 {
-    switch (verbosity)
-    {
+    switch (verbosity) {
     case 0:
         return plog::warning;
     case 1:

--- a/src/common/shared/logging/include/logging/LogUtils.hxx
+++ b/src/common/shared/logging/include/logging/LogUtils.hxx
@@ -3,8 +3,8 @@
 #define LOG_UTILS_HXX
 
 #include <cstdint>
-#include <string_view>
 #include <string>
+#include <string_view>
 
 #include <plog/Severity.h>
 
@@ -19,15 +19,17 @@ namespace logging
  * @param componentName The name of the component the log is for. Eg. 'server', 'client', etc.
  * @return std::string
  */
-std::string GetLogName(std::string_view componentName);
+std::string
+GetLogName(std::string_view componentName);
 
 /**
  * @brief Converts a log verbosity level to a plog severity level.
- * 
+ *
  * @param verbosity The log verbosity level.
  * @return plog::Severity
  */
-plog::Severity LogVerbosityToPlogSeverity(uint8_t verbosity) noexcept;
+plog::Severity
+LogVerbosityToPlogSeverity(uint8_t verbosity) noexcept;
 
 } // namespace logging
 

--- a/src/common/shared/notstd/include/notstd/Utility.hxx
+++ b/src/common/shared/notstd/include/notstd/Utility.hxx
@@ -9,17 +9,19 @@ namespace notstd
 {
 /**
  * @brief Converts a enumeration value to its underlying type.
- * 
+ *
  * The function prototype matches the C++23 function so can be used in its
  * place.
- * 
+ *
  * @tparam Enum The enumeration class type to convert.
  * @param e The enumeration class value.
- * @return constexpr std::underlying_type_t<Enum> 
+ * @return constexpr std::underlying_type_t<Enum>
  */
+// clang-format off
 template <typename EnumT>
 requires std::is_enum_v<EnumT>
 constexpr std::underlying_type_t<EnumT>
+// clang-format on
 to_underlying(EnumT e) noexcept
 {
     return static_cast<std::underlying_type_t<EnumT>>(e);

--- a/src/common/shared/strings/include/strings/StringHelpers.hxx
+++ b/src/common/shared/strings/include/strings/StringHelpers.hxx
@@ -5,21 +5,24 @@
 #include <algorithm>
 #include <cctype>
 #include <concepts>
-#include <string_view>
 #include <string>
+#include <string_view>
 
 namespace Strings
 {
 /**
  * @brief Cast a character for use in lowercase conversions.
- * 
+ *
  * @tparam CharT The type to be cast from.
  * @param c The character value to cast.
  * @return
  */
+// clang-format off
 template <typename CharT>
 requires std::integral<CharT>
-unsigned char LowerCast(CharT c)
+// clang-format on
+unsigned char
+LowerCast(CharT c)
 {
     return static_cast<unsigned char>(c);
 }
@@ -27,25 +30,27 @@ unsigned char LowerCast(CharT c)
 /**
  * @brief std::tolower() analog which properly casts the input character to an
  * appropriate type.
- * 
- * @param c 
- * @return int 
+ *
+ * @param c
+ * @return int
  */
 template <typename CharT>
-int ToLower(CharT c)
+int
+ToLower(CharT c)
 {
     return std::tolower(LowerCast(c));
 }
 
 /**
  * @brief Converts the specified string to lowercase.
- * 
+ *
  * @param s
- * @return std::string 
+ * @return std::string
  */
-std::string ToLower(std::string s)
+std::string
+ToLower(std::string s)
 {
-    std::ranges::transform(s, std::begin(s), [](auto c) { 
+    std::ranges::transform(s, std::begin(s), [](auto c) {
         return ToLower(c);
     });
 
@@ -54,26 +59,28 @@ std::string ToLower(std::string s)
 
 /**
  * @brief Determines if the specified characters are equal, ignoring case.
- * 
+ *
  * @param lhs
  * @param rhs
  * @return true
  * @return false
  */
-bool CaseInsensitiveCharEquals(char lhs, char rhs)
+bool
+CaseInsensitiveCharEquals(char lhs, char rhs)
 {
     return ToLower(lhs) == ToLower(rhs);
 }
 
 /**
  * @brief Determines if the specified strings are equal, ignoring case.
- * 
+ *
  * @param lhs
  * @param rhs
  * @return true
  * @return false
  */
-bool CaseInsensitiveStringEquals(std::string_view lhs, std::string_view rhs)
+bool
+CaseInsensitiveStringEquals(std::string_view lhs, std::string_view rhs)
 {
     return std::ranges::equal(lhs, rhs, CaseInsensitiveCharEquals);
 }

--- a/src/common/wifi/apmanager/AccessPointManager.cxx
+++ b/src/common/wifi/apmanager/AccessPointManager.cxx
@@ -8,7 +8,8 @@ AccessPointManager::AccessPointManager(std::unique_ptr<IAccessPointFactory> acce
 {
 }
 
-std::unordered_map<std::string, std::weak_ptr<AccessPoint>> AccessPointManager::EnumerateAccessPoints() const noexcept
+std::unordered_map<std::string, std::weak_ptr<AccessPoint>>
+AccessPointManager::EnumerateAccessPoints() const noexcept
 {
     std::shared_lock sharedAccessPointsLock{ m_accessPointsGate };
     return { std::cbegin(m_accessPoints), std::cend(m_accessPoints) };

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
@@ -20,17 +20,18 @@ struct AccessPointManager
 {
     /**
      * @brief Construct a new AccessPointManager with the given access point factory.
-     * 
-     * @param accessPointFactory 
+     *
+     * @param accessPointFactory
      */
     AccessPointManager(std::unique_ptr<IAccessPointFactory> accessPointFactory);
 
     /**
      * @brief Return a list of the currently available access points.
-     * 
-     * @return std::unordered_map<std::string, std::weak_ptr<AccessPoint>> 
+     *
+     * @return std::unordered_map<std::string, std::weak_ptr<AccessPoint>>
      */
-    std::unordered_map<std::string, std::weak_ptr<AccessPoint>> EnumerateAccessPoints() const noexcept;
+    std::unordered_map<std::string, std::weak_ptr<AccessPoint>>
+    EnumerateAccessPoints() const noexcept;
 
 private:
     std::unique_ptr<IAccessPointFactory> m_accessPointFactory;

--- a/src/common/wifi/core/AccessPoint.cxx
+++ b/src/common/wifi/core/AccessPoint.cxx
@@ -7,7 +7,8 @@ AccessPoint::AccessPoint(std::string_view id) :
     m_interface(id)
 {}
 
-std::string_view AccessPoint::GetInterface() const noexcept
+std::string_view
+AccessPoint::GetInterface() const noexcept
 {
     return m_interface;
 }

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
@@ -4,14 +4,14 @@
 
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 
-#include <string_view>
 #include <string>
+#include <string_view>
 
 namespace Microsoft::Net::Wifi
 {
 /**
  * @brief Base IAccessPoint implementation providing functionality common to all
- * implementations. 
+ * implementations.
  */
 struct AccessPoint :
     public IAccessPoint
@@ -19,17 +19,18 @@ struct AccessPoint :
     /**
      * @brief Construct a new AccessPoint object with the given network
      * interface name.
-     * 
+     *
      * @param interface The network interface name representing the access point.
      */
     AccessPoint(std::string_view interface);
 
     /**
      * @brief Get the network interface name representing the access point.
-     * 
-     * @return std::string_view 
+     *
+     * @return std::string_view
      */
-    std::string_view GetInterface() const noexcept override;
+    std::string_view
+    GetInterface() const noexcept override;
 
 private:
     const std::string m_interface;

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
@@ -18,10 +18,11 @@ struct IAccessPoint
 
     /**
      * @brief Get the network interface name representing the access point.
-     * 
-     * @return std::string_view 
+     *
+     * @return std::string_view
      */
-    virtual std::string_view GetInterface() const noexcept = 0;
+    virtual std::string_view
+    GetInterface() const noexcept = 0;
 };
 } // namespace Microsoft::Net::Wifi
 

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointFactory.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointFactory.hxx
@@ -21,11 +21,12 @@ struct IAccessPointFactory
 
     /**
      * @brief Create a new access point object for the given network interface.
-     * 
-     * @param interface 
-     * @return std::shared_ptr<AccessPoint> 
+     *
+     * @param interface
+     * @return std::shared_ptr<AccessPoint>
      */
-    virtual std::shared_ptr<IAccessPoint> Create(std::string_view interface) = 0;
+    virtual std::shared_ptr<IAccessPoint>
+    Create(std::string_view interface) = 0;
 };
 } // namespace Microsoft::Net::Wifi
 

--- a/src/linux/server/Main.cxx
+++ b/src/linux/server/Main.cxx
@@ -3,8 +3,8 @@
 
 #include <errno.h>
 #include <logging/LogUtils.hxx>
-#include <microsoft/net/remote/NetRemoteServerConfiguration.hxx>
 #include <microsoft/net/remote/NetRemoteServer.hxx>
+#include <microsoft/net/remote/NetRemoteServerConfiguration.hxx>
 #include <notstd/Utility.hxx>
 #include <plog/Appenders/ColorConsoleAppender.h>
 #include <plog/Appenders/RollingFileAppender.h>
@@ -16,14 +16,14 @@
 
 using namespace Microsoft::Net::Remote;
 
-enum class LogInstanceId : int
-{
+enum class LogInstanceId : int {
     // Default logger is 0 and is omitted from this enumeration.
     Console = 1,
-    File = 2,    
+    File = 2,
 };
 
-int main(int argc, char* argv[])
+int
+main(int argc, char* argv[])
 {
     // Create file and console log appenders.
     static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
@@ -45,13 +45,11 @@ int main(int argc, char* argv[])
     server.Run();
 
     // If running in the background, daemonize the process.
-    if (configuration.RunInBackground)
-    {
+    if (configuration.RunInBackground) {
         constexpr int nochdir = 0; // Change current working directory to /
         constexpr int noclose = 0; // Don't redirect stdin, stdout to /dev/null
 
-        if (daemon(nochdir, noclose) != 0) 
-        {
+        if (daemon(nochdir, noclose) != 0) {
             const int error = errno;
             const auto what = std::format("failed to daemonize (error={})", error);
             LOG_ERROR << what;
@@ -59,8 +57,7 @@ int main(int argc, char* argv[])
         }
     }
     // Otherwise wait for the server to exit.
-    else
-    {
+    else {
         server.GetGrpcServer()->Wait();
     }
 

--- a/src/linux/wifi/core/AccessPointFactoryLinux.cxx
+++ b/src/linux/wifi/core/AccessPointFactoryLinux.cxx
@@ -1,10 +1,11 @@
 
-#include <microsoft/net/wifi/AccessPointLinux.hxx>
 #include <microsoft/net/wifi/AccessPointFactoryLinux.hxx>
+#include <microsoft/net/wifi/AccessPointLinux.hxx>
 
 using namespace Microsoft::Net::Wifi;
 
-std::shared_ptr<IAccessPoint> AccessPointFactoryLinux::Create(std::string_view interface)
+std::shared_ptr<IAccessPoint>
+AccessPointFactoryLinux::Create(std::string_view interface)
 {
     return std::make_shared<AccessPointLinux>(interface);
 }

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointFactoryLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointFactoryLinux.hxx
@@ -17,11 +17,12 @@ struct AccessPointFactoryLinux :
 {
     /**
      * @brief Create an access point object for the given network interface.
-     * 
-     * @param interface 
-     * @return std::shared_ptr<IAccessPoint> 
+     *
+     * @param interface
+     * @return std::shared_ptr<IAccessPoint>
      */
-    std::shared_ptr<IAccessPoint> Create(std::string_view interface) override;
+    std::shared_ptr<IAccessPoint>
+    Create(std::string_view interface) override;
 };
 } // namespace Microsoft::Net::Wifi
 

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointLinux.hxx
@@ -5,7 +5,7 @@
 #include <microsoft/net/wifi/AccessPoint.hxx>
 
 namespace Microsoft::Net::Wifi
-{  
+{
 /**
  * @brief Access point implementation for Linux.
  */

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -19,49 +19,49 @@ Hostapd::Hostapd(std::string_view interfaceName) :
 {
 }
 
-std::string_view Hostapd::GetInterface()
+std::string_view
+Hostapd::GetInterface()
 {
     return m_interface;
 }
 
-bool Hostapd::Ping()
+bool
+Hostapd::Ping()
 {
     static constexpr WpaCommand PingCommand(ProtocolHostapd::CommandPayloadPing);
 
     const auto response = m_controller.SendCommand(PingCommand);
-    if (!response)
-    {
+    if (!response) {
         throw HostapdException("Failed to ping hostapd");
     }
 
     return response->Payload.starts_with(ProtocolHostapd::ResponsePayloadPing);
 }
 
-HostapdStatus Hostapd::GetStatus()
+HostapdStatus
+Hostapd::GetStatus()
 {
     static constexpr WpaCommandStatus StatusCommand;
 
     auto response = m_controller.SendCommand<WpaResponseStatus>(StatusCommand);
-    if (!response)
-    {
+    if (!response) {
         throw HostapdException("Failed to send hostapd 'status' command");
     }
 
     return response->Status;
 }
 
-bool Hostapd::GetProperty(std::string_view propertyName, std::string& propertyValue)
+bool
+Hostapd::GetProperty(std::string_view propertyName, std::string& propertyValue)
 {
     const WpaCommandGet getCommand(propertyName);
     const auto response = m_controller.SendCommand(getCommand);
-    if (!response)
-    {
+    if (!response) {
         throw HostapdException("Failed to send hostapd 'get' command");
     }
     // Check Failed() and not IsOk() since the response will indicate failure
     // with "FAIL", otherwise, the payload is the property value (not "OK").
-    else if (response->Failed())
-    {
+    else if (response->Failed()) {
         return false;
     }
 
@@ -69,29 +69,27 @@ bool Hostapd::GetProperty(std::string_view propertyName, std::string& propertyVa
     return true;
 }
 
-bool Hostapd::SetProperty(std::string_view propertyName, std::string_view propertyValue)
+bool
+Hostapd::SetProperty(std::string_view propertyName, std::string_view propertyValue)
 {
     const WpaCommandSet setCommand(propertyName, propertyValue);
     const auto response = m_controller.SendCommand(setCommand);
-    if (!response)
-    {
+    if (!response) {
         throw HostapdException("Failed to send hostapd 'set' command");
     }
 
     return response->IsOk();
 }
 
-bool Hostapd::Enable()
+bool
+Hostapd::Enable()
 {
     static constexpr WpaCommand EnableCommand(ProtocolHostapd::CommandPayloadEnable);
 
     const auto response = m_controller.SendCommand(EnableCommand);
-    if (!response)
-    {
+    if (!response) {
         throw HostapdException("Failed to send hostapd 'enable' command");
-    }
-    else if (response->IsOk())
-    {
+    } else if (response->IsOk()) {
         return true;
     }
 
@@ -103,17 +101,15 @@ bool Hostapd::Enable()
     return IsHostapdStateOperational(status.State);
 }
 
-bool Hostapd::Disable() 
+bool
+Hostapd::Disable()
 {
     static constexpr WpaCommand DisableCommand(ProtocolHostapd::CommandPayloadDisable);
 
     const auto response = m_controller.SendCommand(DisableCommand);
-    if (!response)
-    {
+    if (!response) {
         throw HostapdException("Failed to send hostapd 'disable' command");
-    }
-    else if (response->IsOk())
-    {
+    } else if (response->IsOk()) {
         return true;
     }
 
@@ -125,13 +121,13 @@ bool Hostapd::Disable()
     return !IsHostapdStateOperational(status.State);
 }
 
-bool Hostapd::Terminate()
+bool
+Hostapd::Terminate()
 {
     static constexpr WpaCommand TerminateCommand(ProtocolHostapd::CommandPayloadTerminate);
 
     const auto response = m_controller.SendCommand(TerminateCommand);
-    if (!response)
-    {
+    if (!response) {
         throw HostapdException("Failed to send hostapd 'terminate' command");
     }
 

--- a/src/linux/wpa-controller/ProtocolHostapd.cxx
+++ b/src/linux/wpa-controller/ProtocolHostapd.cxx
@@ -3,50 +3,36 @@
 
 using namespace Wpa;
 
-HostapdInterfaceState Wpa::HostapdInterfaceStateFromString(std::string_view state) noexcept
+HostapdInterfaceState
+Wpa::HostapdInterfaceStateFromString(std::string_view state) noexcept
 {
     // Implementation uses starts_with() instead of equals() to accommodate
     // unparsed payloads from command responses.
-    if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusUninitialized))
-    {
+    if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusUninitialized)) {
         return HostapdInterfaceState::Uninitialized;
-    }
-    else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusDisabled))
-    {
+    } else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusDisabled)) {
         return HostapdInterfaceState::Disabled;
-    }
-    else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusEnabled))
-    {
+    } else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusEnabled)) {
         return HostapdInterfaceState::Enabled;
-    }
-    else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusCountryUpdate))
-    {
+    } else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusCountryUpdate)) {
         return HostapdInterfaceState::CountryUpdate;
-    }
-    else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusAcs))
-    {
+    } else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusAcs)) {
         return HostapdInterfaceState::Acs;
-    }
-    else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusHtScan))
-    {
+    } else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusHtScan)) {
         return HostapdInterfaceState::HtScan;
-    }
-    else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusDfs))
-    {
+    } else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusDfs)) {
         return HostapdInterfaceState::Dfs;
-    }
-    else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusNoIr))
-    {
+    } else if (state.starts_with(ProtocolHostapd::ResponsePayloadStatusNoIr)) {
         return HostapdInterfaceState::NoIr;
     }
 
     return HostapdInterfaceState::Unknown;
 }
 
-bool Wpa::IsHostapdStateOperational(HostapdInterfaceState state) noexcept
+bool
+Wpa::IsHostapdStateOperational(HostapdInterfaceState state) noexcept
 {
-    switch (state)
-    {
+    switch (state) {
     case HostapdInterfaceState::Enabled:
     case HostapdInterfaceState::CountryUpdate:
     case HostapdInterfaceState::Acs:

--- a/src/linux/wpa-controller/ProtocolWpa.cxx
+++ b/src/linux/wpa-controller/ProtocolWpa.cxx
@@ -4,13 +4,15 @@
 using namespace Wpa;
 
 /* static */
-bool ProtocolWpa::IsResponseOk(std::string_view response)
+bool
+ProtocolWpa::IsResponseOk(std::string_view response)
 {
     return (response.starts_with(ResponsePayloadOk));
 }
 
 /* static */
-bool ProtocolWpa::IsResponseFail(std::string_view response)
+bool
+ProtocolWpa::IsResponseFail(std::string_view response)
 {
     return (response.starts_with(ResponsePayloadFail));
 }

--- a/src/linux/wpa-controller/WpaCommand.cxx
+++ b/src/linux/wpa-controller/WpaCommand.cxx
@@ -3,7 +3,8 @@
 
 using namespace Wpa;
 
-void WpaCommand::SetPayload(std::string_view payload)
+void
+WpaCommand::SetPayload(std::string_view payload)
 {
     Payload = payload;
 }
@@ -14,19 +15,17 @@ WpaCommand::ParseResponse(std::string_view responsePayload) const
     std::shared_ptr<WpaResponse> response;
 
     auto parser = CreateResponseParser(this, responsePayload);
-    if (parser != nullptr)
-    {
+    if (parser != nullptr) {
         response = parser->Parse();
-    }
-    else
-    {
+    } else {
         response = std::make_shared<WpaResponse>(responsePayload);
     }
 
     return response;
 }
 
-std::unique_ptr<WpaResponseParser> WpaCommand::CreateResponseParser([[maybe_unused]] const WpaCommand* command, [[maybe_unused]] std::string_view responsePayload) const
+std::unique_ptr<WpaResponseParser>
+WpaCommand::CreateResponseParser([[maybe_unused]] const WpaCommand* command, [[maybe_unused]] std::string_view responsePayload) const
 {
     // Basic commands don't need a response parser since they only provide OK/FAIL results.
     return nullptr;

--- a/src/linux/wpa-controller/WpaCommandStatus.cxx
+++ b/src/linux/wpa-controller/WpaCommandStatus.cxx
@@ -6,27 +6,29 @@
 
 using namespace Wpa;
 
-std::unique_ptr<WpaResponseParser> WpaCommandStatus::CreateResponseParser(const WpaCommand* command, std::string_view responsePayload) const
+std::unique_ptr<WpaResponseParser>
+WpaCommandStatus::CreateResponseParser(const WpaCommand* command, std::string_view responsePayload) const
 {
     return std::make_unique<WpaStatusResponseParser>(command, responsePayload);
 }
 
+// clang-format off
 WpaStatusResponseParser::WpaStatusResponseParser(const WpaCommand* command, std::string_view responsePayload) :
     WpaResponseParser(command, responsePayload, {
         { ProtocolHostapd::ResponseStatusPropertyKeyState, WpaValuePresence::Required },
     })
+// clang-format on
 {
 }
 
-std::shared_ptr<WpaResponse> WpaStatusResponseParser::ParsePayload()
+std::shared_ptr<WpaResponse>
+WpaStatusResponseParser::ParsePayload()
 {
     const auto properties = GetProperties();
     const auto response = std::make_shared<WpaResponseStatus>();
 
-    for (const auto& [key, value] : properties)
-    {
-        if (key == ProtocolHostapd::ResponseStatusPropertyKeyState)
-        {
+    for (const auto& [key, value] : properties) {
+        if (key == ProtocolHostapd::ResponseStatusPropertyKeyState) {
             response->Status.State = HostapdInterfaceStateFromString(value);
         }
     }

--- a/src/linux/wpa-controller/WpaController.cxx
+++ b/src/linux/wpa-controller/WpaController.cxx
@@ -5,9 +5,10 @@
 #include <iostream>
 #include <mutex>
 
-#include <Wpa/WpaController.hxx>
 #include <magic_enum.hpp>
 #include <wpa_ctrl.h>
+
+#include <Wpa/WpaController.hxx>
 
 using namespace Wpa;
 

--- a/src/linux/wpa-controller/WpaController.cxx
+++ b/src/linux/wpa-controller/WpaController.cxx
@@ -5,9 +5,9 @@
 #include <iostream>
 #include <mutex>
 
+#include <Wpa/WpaController.hxx>
 #include <magic_enum.hpp>
 #include <wpa_ctrl.h>
-#include <Wpa/WpaController.hxx>
 
 using namespace Wpa;
 
@@ -28,12 +28,14 @@ WpaController::WpaController(std::string_view interfaceName, WpaType type, std::
 {
 }
 
-WpaType WpaController::Type() const noexcept
+WpaType
+WpaController::Type() const noexcept
 {
     return m_type;
 }
 
-std::filesystem::path WpaController::ControlSocketPath() const noexcept
+std::filesystem::path
+WpaController::ControlSocketPath() const noexcept
 {
     return m_controlSocketPath;
 }
@@ -43,17 +45,15 @@ WpaController::GetCommandControlSocket()
 {
     // Check if a socket connection is already established.
     {
-        std::shared_lock lockShared{m_controlSocketCommandGate};
-        if (m_controlSocketCommand != nullptr)
-        {
+        std::shared_lock lockShared{ m_controlSocketCommandGate };
+        if (m_controlSocketCommand != nullptr) {
             return m_controlSocketCommand;
         }
     }
 
     // Check if socket was updated between releasing the shared lock and acquiring the exclusive lock.
     std::scoped_lock lockExclusive{ m_controlSocketCommandGate };
-    if (m_controlSocketCommand != nullptr)
-    {
+    if (m_controlSocketCommand != nullptr) {
         return m_controlSocketCommand;
     }
 
@@ -61,8 +61,7 @@ WpaController::GetCommandControlSocket()
     // until the connection is established to prevent multiple connections.
     const auto controlSocketPath = m_controlSocketPath / m_interfaceName;
     struct wpa_ctrl* controlSocket = wpa_ctrl_open(controlSocketPath.c_str());
-    if (controlSocket == nullptr)
-    {
+    if (controlSocket == nullptr) {
         std::cerr << std::format("Failed to open control socket for {} interface at {}.", m_interfaceName, controlSocketPath.c_str()) << std::endl;
         return nullptr;
     }
@@ -77,8 +76,7 @@ WpaController::SendCommand(const WpaCommand& command)
 {
     // Obtain a control socket connection to send the command over.
     struct wpa_ctrl* controlSocket = GetCommandControlSocket();
-    if (controlSocket == nullptr)
-    {
+    if (controlSocket == nullptr) {
         std::cerr << std::format("Failed to get control socket for {}.", m_interfaceName) << std::endl;
         return nullptr;
     }
@@ -88,11 +86,9 @@ WpaController::SendCommand(const WpaCommand& command)
     std::size_t responseSize = std::size(responseBuffer);
 
     int ret = wpa_ctrl_request(controlSocket, std::data(command.Payload), std::size(command.Payload), std::data(responseBuffer), &responseSize, nullptr);
-    switch (ret)
-    {
-    case 0:
-    {
-        std::string_view responsePayload{std::data(responseBuffer), responseSize};
+    switch (ret) {
+    case 0: {
+        std::string_view responsePayload{ std::data(responseBuffer), responseSize };
         return command.ParseResponse(responsePayload);
     }
     case -1:

--- a/src/linux/wpa-controller/WpaCore.cxx
+++ b/src/linux/wpa-controller/WpaCore.cxx
@@ -1,10 +1,10 @@
 
 #include <Wpa/WpaCore.hxx>
 
-std::string_view Wpa::GetWpaTypeDaemonBinaryName(WpaType type) noexcept
+std::string_view
+Wpa::GetWpaTypeDaemonBinaryName(WpaType type) noexcept
 {
-    switch (type)
-    {
+    switch (type) {
     case WpaType::Hostapd:
         return "hostapd";
     case WpaType::WpaSupplicant:

--- a/src/linux/wpa-controller/WpaKeyValuePair.cxx
+++ b/src/linux/wpa-controller/WpaKeyValuePair.cxx
@@ -6,15 +6,14 @@
 
 using namespace Wpa;
 
-std::optional<std::string_view> WpaKeyValuePair::TryParseValue(std::string_view input)
+std::optional<std::string_view>
+WpaKeyValuePair::TryParseValue(std::string_view input)
 {
     // If not already parsed...
-    if (!Value.has_value())
-    {
+    if (!Value.has_value()) {
         // Find the starting position of the key.
         const auto keyPosition = input.find(Key);
-        if (keyPosition != input.npos)
-        {
+        if (keyPosition != input.npos) {
             // Assign the starting position of the value, advancing past the key.
             Value = std::data(input) + keyPosition + std::size(Key);
         }

--- a/src/linux/wpa-controller/WpaResponse.cxx
+++ b/src/linux/wpa-controller/WpaResponse.cxx
@@ -1,6 +1,6 @@
 
-#include <Wpa/WpaResponse.hxx>
 #include <Wpa/ProtocolWpa.hxx>
+#include <Wpa/WpaResponse.hxx>
 
 using namespace Wpa;
 
@@ -15,12 +15,14 @@ WpaResponse::operator bool() const
     return IsOk();
 }
 
-bool WpaResponse::IsOk() const
+bool
+WpaResponse::IsOk() const
 {
     return (ProtocolWpa::IsResponseOk(Payload));
 }
 
-bool WpaResponse::Failed() const
+bool
+WpaResponse::Failed() const
 {
     return (ProtocolWpa::IsResponseFail(Payload));
 }

--- a/src/linux/wpa-controller/WpaResponseParser.cxx
+++ b/src/linux/wpa-controller/WpaResponseParser.cxx
@@ -13,17 +13,18 @@ WpaResponseParser::WpaResponseParser(const WpaCommand* command, std::string_view
 {
 }
 
-const std::unordered_map<std::string_view, std::string_view>& WpaResponseParser::GetProperties() const noexcept
+const std::unordered_map<std::string_view, std::string_view>&
+WpaResponseParser::GetProperties() const noexcept
 {
     return m_properties;
 }
 
-std::shared_ptr<WpaResponse> WpaResponseParser::Parse()
+std::shared_ptr<WpaResponse>
+WpaResponseParser::Parse()
 {
     // Attempt to parse the properties, bailing on an error.
     auto propertiesParsed = TryParseProperties();
-    if (!propertiesParsed)
-    {
+    if (!propertiesParsed) {
         return nullptr;
     }
 
@@ -31,30 +32,24 @@ std::shared_ptr<WpaResponse> WpaResponseParser::Parse()
     return ParsePayload();
 }
 
-bool WpaResponseParser::TryParseProperties()
+bool
+WpaResponseParser::TryParseProperties()
 {
-    if (std::empty(m_propertiesToParse))
-    {
+    if (std::empty(m_propertiesToParse)) {
         return true;
     }
 
-    for (auto propertyToParseIterator = std::begin(m_propertiesToParse); propertyToParseIterator != std::end(m_propertiesToParse); )
-    {
+    for (auto propertyToParseIterator = std::begin(m_propertiesToParse); propertyToParseIterator != std::end(m_propertiesToParse);) {
         auto& propertyToParse = *propertyToParseIterator;
         auto propertyValue = propertyToParse.TryParseValue(ResponsePayload);
-        if (propertyValue.has_value())
-        {
+        if (propertyValue.has_value()) {
             m_properties[propertyToParse.Key] = *propertyValue;
             propertyToParseIterator = m_propertiesToParse.erase(propertyToParseIterator);
             continue;
-        }
-        else if (propertyToParse.IsRequired)
-        {
+        } else if (propertyToParse.IsRequired) {
             std::cerr << std::format("Failed to parse required property: {}", propertyToParse.Key) << std::endl;
             return false;
-        }
-        else
-        {
+        } else {
             ++propertyToParseIterator;
         }
     }

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -2,8 +2,8 @@
 #ifndef HOSTAPD_HXX
 #define HOSTAPD_HXX
 
-#include <string_view>
 #include <string>
+#include <string_view>
 
 #include <Wpa/IHostapd.hxx>
 #include <Wpa/WpaController.hxx>
@@ -18,73 +18,81 @@ struct Hostapd :
 {
     /**
      * @brief Construct a new Hostapd object.
-     * 
+     *
      * @param interfaceName The name of the intrerface to control. Eg. wlan1.
      */
     Hostapd(std::string_view interfaceName);
 
     /**
      * @brief Enables the interface for use.
-     * 
-     * @return true 
-     * @return false 
+     *
+     * @return true
+     * @return false
      */
-    bool Enable() override;
+    bool
+    Enable() override;
 
     /**
      * @brief Disables the interface for use.
-     * 
-     * @return true 
-     * @return false 
+     *
+     * @return true
+     * @return false
      */
-    bool Disable() override;
+    bool
+    Disable() override;
 
     /**
      * @brief Terminates the process hosting the daemon.
-     * 
-     * @return true 
-     * @return false 
+     *
+     * @return true
+     * @return false
      */
-    bool Terminate() override;
+    bool
+    Terminate() override;
 
     /**
      * @brief Checks connectivity to the hostapd daemon.
      */
-    bool Ping() override;
+    bool
+    Ping() override;
 
     /**
      * @brief Get the name of the interface hostapd is managing.
-     * 
-     * @return std::string_view 
+     *
+     * @return std::string_view
      */
-    std::string_view GetInterface() override;
+    std::string_view
+    GetInterface() override;
 
     /**
      * @brief Get the status for the interface.
-     * 
-     * @return HostapdStatus 
+     *
+     * @return HostapdStatus
      */
-    HostapdStatus GetStatus() override;
+    HostapdStatus
+    GetStatus() override;
 
     /**
      * @brief Get a property value for the interface.
-     * 
+     *
      * @param propertyName The name of the property to retrieve.
      * @param propertyValue The string to store the property value in.
      * @return true If the property value was obtained and its value is in 'propertyValue'.
      * @return false If t he property value could not be obtained due to an error.
      */
-    bool GetProperty(std::string_view propertyName, std::string& propertyValue) override; 
+    bool
+    GetProperty(std::string_view propertyName, std::string& propertyValue) override;
 
     /**
      * @brief Set a property on the interface.
-     * 
+     *
      * @param propertyName The name of the property to set.
      * @param propertyValue The value of the property to set.
      * @return true The property was set successfully.
      * @return false The property was not set successfully.
      */
-    bool SetProperty(std::string_view propertyName, std::string_view propertyValue) override;
+    bool
+    SetProperty(std::string_view propertyName, std::string_view propertyValue) override;
 
 private:
     const std::string m_interface;

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -11,7 +11,7 @@ namespace Wpa
 {
 /**
  * @brief Interface for interacting with the hostapd daemon.
- * 
+ *
  * The documentation for the control interface is sparse, so the source code
  * hostapd_ctrl_iface_receive_process() was used as a reference:
  * https://w1.fi/cgit/hostap/tree/hostapd/ctrl_iface.c?h=hostap_2_10#n3503.
@@ -25,66 +25,74 @@ struct IHostapd
 
     /**
      * @brief Enables the interface for use.
-     * 
-     * @return true 
-     * @return false 
+     *
+     * @return true
+     * @return false
      */
-    virtual bool Enable() = 0;
+    virtual bool
+    Enable() = 0;
 
     /**
      * @brief Disables the interface for use.
-     * 
-     * @return true 
-     * @return false 
+     *
+     * @return true
+     * @return false
      */
-    virtual bool Disable() = 0;
+    virtual bool
+    Disable() = 0;
 
     /**
      * @brief Terminates the process hosting the daemon.
-     * 
-     * @return true 
-     * @return false 
+     *
+     * @return true
+     * @return false
      */
-    virtual bool Terminate() = 0;
+    virtual bool
+    Terminate() = 0;
 
     /**
      * @brief Checks connectivity to the hostapd daemon.
      */
-    virtual bool Ping() = 0;
+    virtual bool
+    Ping() = 0;
 
     /**
      * @brief Get the name of the interface hostapd is managing.
-     * 
-     * @return std::string_view 
+     *
+     * @return std::string_view
      */
-    virtual std::string_view GetInterface() = 0;
+    virtual std::string_view
+    GetInterface() = 0;
 
     /**
      * @brief Get the status for the interface.
-     * 
-     * @return HostapdStatus 
+     *
+     * @return HostapdStatus
      */
-    virtual HostapdStatus GetStatus() = 0;
+    virtual HostapdStatus
+    GetStatus() = 0;
 
     /**
      * @brief Get a property value for the interface.
-     * 
+     *
      * @param propertyName The name of the property to retrieve.
      * @param propertyValue The string to store the property value in.
      * @return true If the property value was obtained and its value is in 'propertyValue'.
      * @return false If t he property value could not be obtained due to an error.
      */
-    virtual bool GetProperty(std::string_view propertyName, std::string& propertyValue) = 0;
+    virtual bool
+    GetProperty(std::string_view propertyName, std::string& propertyValue) = 0;
 
     /**
      * @brief Set a property on the interface.
-     * 
+     *
      * @param propertyName The name of the property to set.
      * @param propertyValue The value of the property to set.
      * @return true The property was set successfully.
      * @return false The property was not set successfully.
      */
-    virtual bool SetProperty(std::string_view propertyName, std::string_view propertyValue) = 0;
+    virtual bool
+    SetProperty(std::string_view propertyName, std::string_view propertyValue) = 0;
 };
 
 /**
@@ -98,7 +106,8 @@ struct HostapdException : std::exception
     {
     }
 
-    const char* what() const noexcept override
+    const char*
+    what() const noexcept override
     {
         return m_message.c_str();
     }

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -15,8 +15,7 @@ namespace Wpa
 /**
  * @brief Describes the state of the interface.
  */
-enum class HostapdInterfaceState
-{
+enum class HostapdInterfaceState {
     Uninitialized,
     Disabled,
     Enabled,
@@ -28,8 +27,7 @@ enum class HostapdInterfaceState
     Unknown
 };
 
-enum class HostapdHwMode
-{
+enum class HostapdHwMode {
     Unknown,
     Ieee80211b,
     Ieee80211g, // 2.4 GHz
@@ -71,7 +69,7 @@ struct HostapdStatus
     // commented out for the time being. Many of them may not be kept if they
     // have no use in the implementation, but for now, this is a complete list
     // of all fields that are returned from the 'STATUS' message.
-    
+
     // std::string PhyRadio;   // eg. phy=34
     // int Frequency{ 0 };     // eg. 2412
     // int NumberOfStationsNonErp{ 0 };
@@ -92,7 +90,7 @@ struct HostapdStatus
 
     // int CacTimeSeconds{ 0 };
     // // Present only if CAC is in progress.
-    // std::optional<long> CacTimeRemainingSeconds; 
+    // std::optional<long> CacTimeRemainingSeconds;
 
     // uint8_t Channel{ 0 };
     // int EdmgEnable{ 0 };
@@ -153,7 +151,6 @@ struct HostapdStatus
     // //  - At least one rate is supported with current configuration.
     // std::optional<std::string> SupportedRates; // Space separated hex string, eg. '%02x %02x ....'.
 
-
     // // Present with:
     // //  - The current operational mode supports the currently active frequency.
     // std::optional<unsigned> MaxTxPower;
@@ -200,22 +197,24 @@ struct ProtocolHostapd :
 
 /**
  * @brief Converts a string to a HostapdInterfaceState.
- * 
+ *
  * @param state The state string to convert.
  * @return HostapdInterfaceState The corresponding HostapdInterfaceState
  * enumeration value, or HostapdInterfaceState::Unknown if an invalid state was
  * provided.
  */
-HostapdInterfaceState HostapdInterfaceStateFromString(std::string_view state) noexcept;
+HostapdInterfaceState
+HostapdInterfaceStateFromString(std::string_view state) noexcept;
 
 /**
  * @brief Indicates if the given state describes an operational interface.
- * 
+ *
  * @param state The state to check.
  * @return true If the interface is operational.
  * @return false If the interface is not operational.
  */
-bool IsHostapdStateOperational(HostapdInterfaceState state) noexcept;
+bool
+IsHostapdStateOperational(HostapdInterfaceState state) noexcept;
 } // namespace Wpa
 
 #endif // HOSTAPD_PROTOCOL_HXX

--- a/src/linux/wpa-controller/include/Wpa/ProtocolWpa.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolWpa.hxx
@@ -53,21 +53,23 @@ struct ProtocolWpa
 
     /**
      * @brief Determines if a response payload indicates success.
-     * 
+     *
      * @param response The response payload to check.
-     * @return true 
-     * @return false 
+     * @return true
+     * @return false
      */
-    static bool IsResponseOk(std::string_view response);
+    static bool
+    IsResponseOk(std::string_view response);
 
     /**
      * @brief Determines if a response payload indicates failure.
-     * 
+     *
      * @param response The response payload to check.
-     * @return true 
-     * @return false 
+     * @return true
+     * @return false
      */
-    static bool IsResponseFail(std::string_view response);
+    static bool
+    IsResponseFail(std::string_view response);
 };
 } // namespace Wpa
 

--- a/src/linux/wpa-controller/include/Wpa/WpaCommand.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaCommand.hxx
@@ -3,8 +3,8 @@
 #define WPA_COMMAND_HXX
 
 #include <memory>
-#include <string_view>
 #include <string>
+#include <string_view>
 
 #include <Wpa/WpaResponseParser.hxx>
 
@@ -27,16 +27,17 @@ struct WpaCommand :
 
     /**
      * @brief Set the payload of the command.
-     * 
+     *
      * @param payload The payload to assign.
      */
-    void SetPayload(std::string_view payload);
+    void
+    SetPayload(std::string_view payload);
 
     /**
      * @brief Parse the response payload into a WpaResponse object.
-     * 
+     *
      * @param responsePayload The response payload to parse.
-     * @return std::shared_ptr<WpaResponse> 
+     * @return std::shared_ptr<WpaResponse>
      */
     std::shared_ptr<WpaResponse>
     ParseResponse(std::string_view responsePayload) const;
@@ -46,12 +47,13 @@ struct WpaCommand :
 private:
     /**
      * @brief Create a response parser object for the given command.
-     * 
+     *
      * @param command The command to create a response parser for.
      * @param responsePayload The response payload to parse.
-     * @return std::unique_ptr<WpaResponseParser> 
+     * @return std::unique_ptr<WpaResponseParser>
      */
-    std::unique_ptr<WpaResponseParser> CreateResponseParser(const WpaCommand* command, std::string_view responsePayload) const override;
+    std::unique_ptr<WpaResponseParser>
+    CreateResponseParser(const WpaCommand* command, std::string_view responsePayload) const override;
 };
 } // namespace Wpa
 

--- a/src/linux/wpa-controller/include/Wpa/WpaCommandGet.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaCommandGet.hxx
@@ -2,8 +2,8 @@
 #ifndef WPA_COMMAND_GET_HXX
 #define WPA_COMMAND_GET_HXX
 
-#include <string_view>
 #include <string>
+#include <string_view>
 
 #include <Wpa/WpaCommand.hxx>
 
@@ -17,7 +17,7 @@ struct WpaCommandGet :
 {
     /**
      * @brief Construct a new WpaCommandGet object for the specified property.
-     * 
+     *
      * @param propertyName The name of the property to retrieve.
      */
     WpaCommandGet(std::string_view propertyName);

--- a/src/linux/wpa-controller/include/Wpa/WpaCommandSet.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaCommandSet.hxx
@@ -2,8 +2,8 @@
 #ifndef WPA_COMMAND_SET_HXX
 #define WPA_COMMAND_SET_HXX
 
-#include <string_view>
 #include <string>
+#include <string_view>
 
 #include <Wpa/WpaCommand.hxx>
 
@@ -17,7 +17,7 @@ struct WpaCommandSet :
 {
     /**
      * @brief Construct a new WpaCommandSet object for the specified property.
-     * 
+     *
      * @param propertyName The name of the property to set.
      * @param propertyValue The value to set the property to.
      */

--- a/src/linux/wpa-controller/include/Wpa/WpaCommandStatus.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaCommandStatus.hxx
@@ -32,7 +32,8 @@ private:
 /**
  * @brief Parser for the "STATUS" command response.
  */
-struct WpaStatusResponseParser : public WpaResponseParser
+struct WpaStatusResponseParser : 
+    public WpaResponseParser
 {
     /**
      * @brief Construct a new WpaStatusResponseParser object.

--- a/src/linux/wpa-controller/include/Wpa/WpaCommandStatus.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaCommandStatus.hxx
@@ -21,11 +21,12 @@ struct WpaCommandStatus :
      */
     constexpr WpaCommandStatus() :
         WpaCommand(ProtocolWpa::CommandPayloadStatus)
-        {
-        }
+    {
+    }
 
 private:
-    std::unique_ptr<WpaResponseParser> CreateResponseParser(const WpaCommand* command, std::string_view responsePayload) const override;
+    std::unique_ptr<WpaResponseParser>
+    CreateResponseParser(const WpaCommand* command, std::string_view responsePayload) const override;
 };
 
 /**
@@ -35,7 +36,7 @@ struct WpaStatusResponseParser : public WpaResponseParser
 {
     /**
      * @brief Construct a new WpaStatusResponseParser object.
-     * 
+     *
      * @param command The command associated with the response.
      * @param responsePayload The response payload to parse.
      */
@@ -44,10 +45,11 @@ struct WpaStatusResponseParser : public WpaResponseParser
     /**
      * @brief Parses the response payload, returning a WpaResponseStatus object
      * if successful.
-     * 
-     * @return std::shared_ptr<WpaResponse> 
+     *
+     * @return std::shared_ptr<WpaResponse>
      */
-    std::shared_ptr<WpaResponse> ParsePayload() override;
+    std::shared_ptr<WpaResponse>
+    ParsePayload() override;
 };
 
 } // namespace Wpa

--- a/src/linux/wpa-controller/include/Wpa/WpaController.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaController.hxx
@@ -10,8 +10,8 @@
 #include <string>
 #include <string_view>
 
-#include <Wpa/WpaCore.hxx>
 #include <Wpa/WpaCommand.hxx>
+#include <Wpa/WpaCore.hxx>
 #include <Wpa/WpaResponse.hxx>
 
 namespace Wpa
@@ -25,7 +25,7 @@ struct WpaController
     /**
      * @brief Construct a new WpaController object for the specified interface
      * with a default control socket path.
-     * 
+     *
      * @param interfaceName The name of the interface to control. Eg. wlan1.
      * @param type The type of daemon controlling the interface.
      */
@@ -34,7 +34,7 @@ struct WpaController
     /**
      * @brief Construct a new WpaController object for the specified interface
      * using the specified control socket.
-     * 
+     *
      * @param interfaceName The name of the interface to control. Eg. wlan1.
      * @param type The type of daemon controlling the interface.
      * @param controlSocketPath The full path to the daemon control socket.
@@ -44,7 +44,7 @@ struct WpaController
     /**
      * @brief Construct a new WpaController object for the specified interface
      * using the specified control socket.
-     * 
+     *
      * @param interfaceName The name of the interface to control. Eg. wlan1.
      * @param type The type of daemon controlling the interface.
      * @param controlSocketPath The full path to the daemon control socket.
@@ -53,39 +53,43 @@ struct WpaController
 
     /**
      * @brief The type of daemon this object is controlling.
-     * 
-     * @return WpaType 
+     *
+     * @return WpaType
      */
-    WpaType Type() const noexcept;
+    WpaType
+    Type() const noexcept;
 
     /**
      * @brief The path of the control socket this object is using.
-     * 
-     * @return std::filesystem::path 
+     *
+     * @return std::filesystem::path
      */
-    std::filesystem::path ControlSocketPath() const noexcept;
+    std::filesystem::path
+    ControlSocketPath() const noexcept;
 
     /**
      * @brief Send a command over the control socket and return the response
      * synchronously.
-     * 
+     *
      * This will not receive any unsolicited event messages.
-     * 
+     *
      * @param command The command to send.
-     * @return std::shared_ptr<WpaResponse> 
+     * @return std::shared_ptr<WpaResponse>
      */
     std::shared_ptr<WpaResponse>
     SendCommand(const WpaCommand& command);
 
     /**
      * @brief Syntactic sugar for returning a specific derived response type.
-     * 
+     *
      * @tparam ResponseT The type of response to return.
      * @param command The command to send.
-     * @return std::shared_ptr<ResponseT> 
+     * @return std::shared_ptr<ResponseT>
      */
+    // clang-format off
     template <typename ResponseT>
     requires std::derived_from<ResponseT, WpaResponse>
+    // clang-format on
     std::shared_ptr<ResponseT>
     SendCommand(const WpaCommand& command)
     {
@@ -111,14 +115,14 @@ struct WpaController
 
         /**
          * @brief Get the default path for the control socket of the specified daemon.
-         * 
+         *
          * @param wpaType The wpa daemon type to get the default control socket for.
          * @return constexpr auto A string containing the default control socket path.
          */
-        static constexpr auto DefaultPath(WpaType wpaType)
+        static constexpr auto
+        DefaultPath(WpaType wpaType)
         {
-            switch (wpaType)
-            {
+            switch (wpaType) {
             case WpaType::Hostapd:
                 return DefaultPathHostapd;
             case WpaType::WpaSupplicant:
@@ -133,7 +137,7 @@ private:
     /**
      * @brief Get the control socket object. If a socket connection does not
      * exist, one will be established.
-     * 
+     *
      * @return struct wpa_ctrl*
      */
     struct wpa_ctrl*

--- a/src/linux/wpa-controller/include/Wpa/WpaCore.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaCore.hxx
@@ -9,19 +9,19 @@ namespace Wpa
 /**
  * @brief The type of WPA daemon/service.
  */
-enum class WpaType
-{
+enum class WpaType {
     Hostapd,
     WpaSupplicant
 };
 
 /**
  * @brief Get the WpaType associated daemon binary name.
- * 
+ *
  * @param type The WpaType to obtain the daemon binary name for.
- * @return std::string_view 
+ * @return std::string_view
  */
-std::string_view GetWpaTypeDaemonBinaryName(WpaType type) noexcept;
+std::string_view
+GetWpaTypeDaemonBinaryName(WpaType type) noexcept;
 
 } // namespace Wpa
 

--- a/src/linux/wpa-controller/include/Wpa/WpaKeyValuePair.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaKeyValuePair.hxx
@@ -6,8 +6,8 @@
 #include <optional>
 #include <string_view>
 
-#include <notstd/Utility.hxx>
 #include <Wpa/ProtocolWpa.hxx>
+#include <notstd/Utility.hxx>
 
 namespace Wpa
 {
@@ -15,8 +15,7 @@ namespace Wpa
  * @brief Describes the presence of a property in a WPA control protocol
  * response.
  */
-enum class WpaValuePresence : bool
-{
+enum class WpaValuePresence : bool {
     Required = true,
     Optional = false,
 };
@@ -24,7 +23,7 @@ enum class WpaValuePresence : bool
 /**
  * @brief Represents a key-value pair in the WPA control protocol. Most commands
  * output lists of data as key-value pairs with a '=' delimiter.
- * 
+ *
  * This class helps parse and collect such pairs.
  */
 struct WpaKeyValuePair
@@ -36,8 +35,8 @@ struct WpaKeyValuePair
 
     /**
      * @brief Construct a new WpaKeyValue Pair object.
-     * 
-     * @param key The key of the property. 
+     *
+     * @param key The key of the property.
      * @param presence Whether the property is required or optional.
      */
     constexpr WpaKeyValuePair(std::string_view key, WpaValuePresence presence) :
@@ -46,8 +45,7 @@ struct WpaKeyValuePair
     {
         // Ensure the specified key ends with the delimiter. If not, this is a
         // programming error so throw a runtime exception.
-        if (!Key.ends_with(KeyDelimiter))
-        {
+        if (!Key.ends_with(KeyDelimiter)) {
             throw std::runtime_error(std::format("Key must end with {} delimiter.", KeyDelimiter));
         }
     }
@@ -58,14 +56,15 @@ struct WpaKeyValuePair
      * not parse the value itself, it only resolves the value location in the
      * input string, making it available for later parsing by derived classes
      * that know its type/structure.
-     * 
+     *
      * The input string is expected to contain a property of the form:
-     * key=value, as is encoded by the WPA control protocol.    * @brief 
-     * 
-     * @param input 
-     * @return std::optional<std::string_view> 
+     * key=value, as is encoded by the WPA control protocol.    * @brief
+     *
+     * @param input
+     * @return std::optional<std::string_view>
      */
-    std::optional<std::string_view> TryParseValue(std::string_view input);
+    std::optional<std::string_view>
+    TryParseValue(std::string_view input);
 
     std::string_view Key;
     std::optional<std::string_view> Value;

--- a/src/linux/wpa-controller/include/Wpa/WpaResponse.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaResponse.hxx
@@ -2,8 +2,8 @@
 #ifndef WPA_RESPONSE_HXX
 #define WPA_RESPONSE_HXX
 
-#include <string_view>
 #include <string>
+#include <string_view>
 
 namespace Wpa
 {
@@ -20,13 +20,13 @@ struct WpaResponse
 
     /**
      * @brief Construct an empty WpaResponse object.
-     * 
+     *
      */
     WpaResponse() = default;
 
     /**
      * @brief Construct a WpaResponse object with the specified payload.
-     * 
+     *
      * @param payload The payload of a WPA control command response.
      */
     WpaResponse(std::string_view payload);
@@ -34,27 +34,29 @@ struct WpaResponse
     /**
      * @brief Implicit bool operator allowing WpaResponse to be used directly in
      * condition statements (eg. if (response) // ...).
-     * 
-     * @return true 
-     * @return false 
+     *
+     * @return true
+     * @return false
      */
     operator bool() const;
 
     /**
      * @brief Indicates whether the response describes a successful result.
-     * 
-     * @return true 
-     * @return false 
+     *
+     * @return true
+     * @return false
      */
-    bool IsOk() const;
+    bool
+    IsOk() const;
 
     /**
      * @brief Indicates whether the response describes a failed result.
-     * 
-     * @return true 
-     * @return false 
+     *
+     * @return true
+     * @return false
      */
-    bool Failed() const;
+    bool
+    Failed() const;
 
 private:
     /**

--- a/src/linux/wpa-controller/include/Wpa/WpaResponseParser.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaResponseParser.hxx
@@ -5,8 +5,8 @@
 #include <initializer_list>
 #include <memory>
 #include <string_view>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include <Wpa/WpaKeyValuePair.hxx>
 #include <Wpa/WpaResponse.hxx>
@@ -17,7 +17,7 @@ struct WpaCommand;
 
 /**
  * @brief Interface and base class for a parser that parses a response payload
- * into a WpaResponse object, typically a derived class of WpaResponse. 
+ * into a WpaResponse object, typically a derived class of WpaResponse.
  */
 struct WpaResponseParser
 {
@@ -25,7 +25,7 @@ struct WpaResponseParser
 
     /**
      * @brief Construct a new WpaResponseParser object.
-     * 
+     *
      * @param command The command associated with the response payload to be parsed
      * @param responsePayload The response payload to parse.
      * @param propertiesToParse The properties to parse from the response payload.
@@ -35,10 +35,11 @@ struct WpaResponseParser
     /**
      * @brief Parses the response payload, returning a WpaResponse object if
      * successful.
-     * 
+     *
      * @return std::shared_ptr<WpaResponse>
      */
-    virtual std::shared_ptr<WpaResponse> Parse();
+    virtual std::shared_ptr<WpaResponse>
+    Parse();
 
     const WpaCommand* Command;
     const std::string_view ResponsePayload;
@@ -48,17 +49,19 @@ protected:
      * @brief Parse the payload. This function is only called if all properties
      * have been resolved and placed into the m_properties map, so this
      * implementation may rely on and make use of that.
-     * 
-     * @return std::shared_ptr<WpaResponse> 
+     *
+     * @return std::shared_ptr<WpaResponse>
      */
-    virtual std::shared_ptr<WpaResponse> ParsePayload() = 0;
+    virtual std::shared_ptr<WpaResponse>
+    ParsePayload() = 0;
 
     /**
      * @brief Obtain the map of parsed properties.
-     * 
-     * @return const std::unordered_map<std::string_view, std::string_view>& 
+     *
+     * @return const std::unordered_map<std::string_view, std::string_view>&
      */
-    const std::unordered_map<std::string_view, std::string_view>& GetProperties() const noexcept;
+    const std::unordered_map<std::string_view, std::string_view>&
+    GetProperties() const noexcept;
 
 private:
     /**
@@ -66,11 +69,12 @@ private:
      * each property successfully parsed, an entry will be added to the
      * m_properties map, and the corresponding entry in m_propertiesToParse is
      * removed.
-     * 
+     *
      * @return true If all properties were successully parsed.
      * @return false If not all properties were successully parsed.
      */
-    bool TryParseProperties();
+    bool
+    TryParseProperties();
 
 private:
     std::vector<WpaKeyValuePair> m_propertiesToParse;
@@ -86,12 +90,13 @@ struct WpaResponseParserFactory
 
     /**
      * @brief Create a response parser object.
-     * 
+     *
      * @param command The command to create the parser object for.
      * @param responsePayload The payload the parser should parse.
-     * @return std::unique_ptr<WpaResponseParser> 
+     * @return std::unique_ptr<WpaResponseParser>
      */
-    virtual std::unique_ptr<WpaResponseParser> CreateResponseParser(const WpaCommand* command, std::string_view responsePayload) const = 0;
+    virtual std::unique_ptr<WpaResponseParser>
+    CreateResponseParser(const WpaCommand* command, std::string_view responsePayload) const = 0;
 };
 } // namespace Wpa
 

--- a/src/linux/wpa-controller/include/Wpa/WpaResponseStatus.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaResponseStatus.hxx
@@ -2,16 +2,15 @@
 #ifndef WPA_RESPONSE_STATUS_HXX
 #define WPA_RESPONSE_STATUS_HXX
 
-#include <Wpa/WpaResponse.hxx>
 #include <Wpa/ProtocolHostapd.hxx>
+#include <Wpa/WpaResponse.hxx>
 
 namespace Wpa
 {
 /**
  * @brief Representation of the response to the "STATUS" command.
  */
-struct WpaResponseStatus
-    : public WpaResponse
+struct WpaResponseStatus : public WpaResponse
 {
     WpaResponseStatus() = default;
 

--- a/src/linux/wpa-controller/include/Wpa/WpaResponseStatus.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaResponseStatus.hxx
@@ -10,7 +10,8 @@ namespace Wpa
 /**
  * @brief Representation of the response to the "STATUS" command.
  */
-struct WpaResponseStatus : public WpaResponse
+struct WpaResponseStatus :
+    public WpaResponse
 {
     WpaResponseStatus() = default;
 

--- a/src/windows/server/Main.cxx
+++ b/src/windows/server/Main.cxx
@@ -2,12 +2,13 @@
 #include <format>
 #include <iostream>
 
-#include <microsoft/net/remote/NetRemoteServerConfiguration.hxx>
 #include <microsoft/net/remote/NetRemoteServer.hxx>
+#include <microsoft/net/remote/NetRemoteServerConfiguration.hxx>
 
 using namespace Microsoft::Net::Remote;
 
-int main(int argc, char* argv[])
+int
+main(int argc, char* argv[])
 {
     const auto configuration = NetRemoteServerConfiguration::FromCommandLineArguments(argc, argv);
 

--- a/tests/unit/TestNetRemoteCommon.cxx
+++ b/tests/unit/TestNetRemoteCommon.cxx
@@ -8,11 +8,11 @@ using namespace Microsoft::Net::Remote;
 using namespace Microsoft::Net::Remote::Test;
 using namespace Microsoft::Net::Remote::Service;
 
-std::vector<std::tuple<std::shared_ptr<grpc::Channel>, std::unique_ptr<NetRemote::Stub>>> Microsoft::Net::Remote::Test::EstablishClientConnections(std::size_t numConnectionsToEstablish, std::string_view serverAddress)
+std::vector<std::tuple<std::shared_ptr<grpc::Channel>, std::unique_ptr<NetRemote::Stub>>>
+Microsoft::Net::Remote::Test::EstablishClientConnections(std::size_t numConnectionsToEstablish, std::string_view serverAddress)
 {
     std::vector<std::tuple<std::shared_ptr<grpc::Channel>, std::unique_ptr<NetRemote::Stub>>> clients(numConnectionsToEstablish);
-    std::ranges::transform(clients, std::begin(clients), [&](auto&&)
-    {
+    std::ranges::transform(clients, std::begin(clients), [&](auto &&) {
         auto channel = grpc::CreateChannel(std::data(serverAddress), grpc::InsecureChannelCredentials());
         auto client = NetRemote::NewStub(channel);
         REQUIRE(channel->WaitForConnected(std::chrono::system_clock::now() + RemoteServiceConnectionTimeout));

--- a/tests/unit/TestNetRemoteCommon.hxx
+++ b/tests/unit/TestNetRemoteCommon.hxx
@@ -29,13 +29,14 @@ constexpr auto RemoteServiceConnectionTimeout = 3s;
 /**
  * @brief Establish the specified number of connections to a netremote server
  * with specified address and default credentials.
- * 
+ *
  * @param numConnectionsToEstablish The number of client connections to establish.
  * @param serverAddress The server address to connect to. Defaults to RemoteServiceAddressHttp.
- * @return std::vector<std::tuple<std::shared_ptr<grpc::Channel>, std::unique_ptr<Microsoft::Net::Remote::Service::NetRemote::Stub>>> 
+ * @return std::vector<std::tuple<std::shared_ptr<grpc::Channel>, std::unique_ptr<Microsoft::Net::Remote::Service::NetRemote::Stub>>>
  */
-std::vector<std::tuple<std::shared_ptr<grpc::Channel>, std::unique_ptr<Microsoft::Net::Remote::Service::NetRemote::Stub>>> EstablishClientConnections(std::size_t numConnectionsToEstablish, std::string_view serverAddress = RemoteServiceAddressHttp);
+std::vector<std::tuple<std::shared_ptr<grpc::Channel>, std::unique_ptr<Microsoft::Net::Remote::Service::NetRemote::Stub>>>
+EstablishClientConnections(std::size_t numConnectionsToEstablish, std::string_view serverAddress = RemoteServiceAddressHttp);
 
-} // namespace Micosoft::Net::Remote::Test
+} // namespace Microsoft::Net::Remote::Test
 
 #endif // TEST_NET_REMOTE_COMMON_HXX

--- a/tests/unit/TestNetRemoteServer.cxx
+++ b/tests/unit/TestNetRemoteServer.cxx
@@ -86,8 +86,7 @@ TEST_CASE("NetRemoteServer shuts down correctly", "[basic][rpc][remote]")
         REQUIRE_NOTHROW(server.Stop());
 
         // Validate each channel is in IDLE state.
-        for (const auto& [channel, _] : clients)
-        {
+        for (const auto& [channel, _] : clients) {
             REQUIRE(channel->GetState(false) == GRPC_CHANNEL_IDLE);
         }
     }
@@ -123,8 +122,7 @@ TEST_CASE("NetRemoteServer can be cycled through run/stop states", "[basic][rpc]
     {
         const auto numCycles = Catch::Generators::range(1, 3);
 
-        for ([[maybe_unused]] auto _ : std::views::iota(0, numCycles.get()))
-        {
+        for ([[maybe_unused]] auto _ : std::views::iota(0, numCycles.get())) {
             REQUIRE_NOTHROW(server.Stop());
             REQUIRE_NOTHROW(server.Run());
 

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -24,10 +24,8 @@ TEST_CASE("WifiConfigureAccessPoint API", "[basic][rpc][client][remote]")
 
     SECTION("Can be called")
     {
-        for (const auto& band : magic_enum::enum_values<Microsoft::Net::Wifi::RadioBand>())
-        {
-            for (const auto& phyType : magic_enum::enum_values<Microsoft::Net::Wifi::Dot11PhyType>())
-            {
+        for (const auto& band : magic_enum::enum_values<Microsoft::Net::Wifi::RadioBand>()) {
+            for (const auto& phyType : magic_enum::enum_values<Microsoft::Net::Wifi::Dot11PhyType>()) {
                 Microsoft::Net::Wifi::AccessPointConfiguration apConfiguration{};
                 apConfiguration.set_phytype(phyType);
 
@@ -70,7 +68,9 @@ TEST_CASE("WifiEnumerateAccessPoints API", "[basic][rpc][client][remote]")
 
         auto status = client->WifiEnumerateAccessPoints(&clientContext, request, &result);
         REQUIRE(status.ok());
-        REQUIRE_NOTHROW([&]{ [[maybe_unused]] const auto& accessPoints = result.accesspoints(); });
+        REQUIRE_NOTHROW([&] {
+            [[maybe_unused]] const auto& accessPoints = result.accesspoints();
+        });
     }
 
     SECTION("Initial enablement status is disabled")
@@ -83,8 +83,7 @@ TEST_CASE("WifiEnumerateAccessPoints API", "[basic][rpc][client][remote]")
         auto status = client->WifiEnumerateAccessPoints(&clientContext, request, &result);
         REQUIRE(status.ok());
 
-        for (const auto& accessPoint : result.accesspoints())
-        {
+        for (const auto& accessPoint : result.accesspoints()) {
             REQUIRE(!accessPoint.isenabled());
         }
     }

--- a/tests/unit/linux/wifi/core/TestAccessPointFactoryLinux.cxx
+++ b/tests/unit/linux/wifi/core/TestAccessPointFactoryLinux.cxx
@@ -47,7 +47,7 @@ TEST_CASE("Create() function", "[wifi][core][ap][linux]")
     SECTION("Create() with empty/null inteface doesn't cause a crash")
     {
         AccessPointFactoryLinux accessPointFactory{};
-        REQUIRE_NOTHROW(accessPointFactory.Create({})) ;
+        REQUIRE_NOTHROW(accessPointFactory.Create({}));
     }
 
     SECTION("Create() with valid input arguments returns non-nullptr instance")

--- a/tests/unit/linux/wifi/core/TestAccessPointLinux.cxx
+++ b/tests/unit/linux/wifi/core/TestAccessPointLinux.cxx
@@ -11,7 +11,7 @@ TEST_CASE("Create an AccessPointLinux instance", "[wifi][core][ap][linux]")
 {
     using namespace Microsoft::Net::Wifi;
 
-     SECTION("Create doesn't cause a crash")
+    SECTION("Create doesn't cause a crash")
     {
         std::optional<AccessPointLinux> accessPoint;
         REQUIRE_NOTHROW(accessPoint.emplace(Test::InterfaceNameDefault));

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -2,9 +2,9 @@
 #include <optional>
 #include <thread>
 
-#include <catch2/catch_test_macros.hpp>
 #include <Wpa/Hostapd.hxx>
 #include <Wpa/ProtocolHostapd.hxx>
+#include <catch2/catch_test_macros.hpp>
 
 #include "detail/WpaDaemonManager.hxx"
 

--- a/tests/unit/linux/wpa-controller/TestWpaController.cxx
+++ b/tests/unit/linux/wpa-controller/TestWpaController.cxx
@@ -13,7 +13,7 @@ namespace TestDetail
 constexpr auto WpaTypesSupported = {
     Wpa::WpaType::Hostapd,
 };
-} // namespace TestDetail  
+} // namespace TestDetail
 
 TEST_CASE("Send/receive WpaController request/response", "[wpa][hostapd][client][remote]")
 {
@@ -22,8 +22,7 @@ TEST_CASE("Send/receive WpaController request/response", "[wpa][hostapd][client]
 
     SECTION("Send/receive WpaCommand/WpaResponse")
     {
-        for (const auto& wpaType : TestDetail::WpaTypesSupported)
-        {
+        for (const auto& wpaType : TestDetail::WpaTypesSupported) {
             WpaController wpaController(WpaDaemonManager::InterfaceNameDefault, wpaType);
 
             WpaCommand wpaCommand("PING");
@@ -47,16 +46,14 @@ TEST_CASE("Create a WpaController", "[wpa][client][local]")
     SECTION("Create for each daemon type doesn't cause a crash")
     {
         std::optional<WpaController> wpaController;
-        for (const auto& wpaType : magic_enum::enum_values<WpaType>())
-        {
+        for (const auto& wpaType : magic_enum::enum_values<WpaType>()) {
             REQUIRE_NOTHROW(wpaController.emplace(WpaDaemonManager::InterfaceNameDefault, wpaType));
         }
     }
 
     SECTION("Create for each daemon type reflects correct type")
     {
-        for (const auto& wpaType : magic_enum::enum_values<WpaType>())
-        {
+        for (const auto& wpaType : magic_enum::enum_values<WpaType>()) {
             WpaController wpaController(WpaDaemonManager::InterfaceNameDefault, wpaType);
             REQUIRE(wpaController.Type() == wpaType);
         }
@@ -65,8 +62,7 @@ TEST_CASE("Create a WpaController", "[wpa][client][local]")
     SECTION("Create with specific control socket path encoded as std::filesystem::path doesn't cause a crash")
     {
         std::optional<WpaController> wpaController;
-        for (const auto& wpaType : magic_enum::enum_values<WpaType>())
-        {
+        for (const auto& wpaType : magic_enum::enum_values<WpaType>()) {
             REQUIRE_NOTHROW(wpaController.emplace(WpaDaemonManager::InterfaceNameDefault, wpaType, ControlSocketPath));
         }
     }
@@ -74,8 +70,7 @@ TEST_CASE("Create a WpaController", "[wpa][client][local]")
     SECTION("Create with specific control socket path encoded as std::string_view doesn't cause a crash")
     {
         std::optional<WpaController> wpaController;
-        for (const auto& wpaType : magic_enum::enum_values<WpaType>())
-        {
+        for (const auto& wpaType : magic_enum::enum_values<WpaType>()) {
             REQUIRE_NOTHROW(wpaController.emplace(WpaDaemonManager::InterfaceNameDefault, wpaType, ControlSocketPathStringView));
         }
     }
@@ -83,16 +78,14 @@ TEST_CASE("Create a WpaController", "[wpa][client][local]")
     SECTION("Create with default control socket path doesn't cause a crash")
     {
         std::optional<WpaController> wpaController;
-        for (const auto& wpaType : magic_enum::enum_values<WpaType>())
-        {
+        for (const auto& wpaType : magic_enum::enum_values<WpaType>()) {
             REQUIRE_NOTHROW(wpaController.emplace(WpaDaemonManager::InterfaceNameDefault, wpaType));
         }
     }
 
     SECTION("Create with specific control socket path reflects correct path")
     {
-        for (const auto& wpaType : magic_enum::enum_values<WpaType>())
-        {
+        for (const auto& wpaType : magic_enum::enum_values<WpaType>()) {
             // Create with control socket path encoded as std::filesystem::path.
             WpaController wpaController(WpaDaemonManager::InterfaceNameDefault, wpaType, ControlSocketPath);
             REQUIRE(wpaController.ControlSocketPath() == ControlSocketPath);

--- a/tests/unit/linux/wpa-controller/detail/WifiVirtualDeviceManager.cxx
+++ b/tests/unit/linux/wpa-controller/detail/WifiVirtualDeviceManager.cxx
@@ -9,7 +9,8 @@
 
 #include "WifiVirtualDeviceManager.hxx"
 
-std::unordered_set<std::string> WifiVirtualDeviceManager::CreateInterfaces(uint32_t numberOfInterfaces, std::string_view driverName)
+std::unordered_set<std::string>
+WifiVirtualDeviceManager::CreateInterfaces(uint32_t numberOfInterfaces, std::string_view driverName)
 {
     auto interfacesCreated = CreateInterfacesForDriver(numberOfInterfaces, driverName);
     auto& interfacesExisting = m_interfaces[driverName];
@@ -18,22 +19,23 @@ std::unordered_set<std::string> WifiVirtualDeviceManager::CreateInterfaces(uint3
     return interfacesCreated;
 }
 
-std::unordered_map<std::string_view, std::unordered_set<std::string>> WifiVirtualDeviceManager::EnumerateInterfaces() const
+std::unordered_map<std::string_view, std::unordered_set<std::string>>
+WifiVirtualDeviceManager::EnumerateInterfaces() const
 {
     return m_interfaces;
 }
 
-bool WifiVirtualDeviceManager::RemoveInterfaces(std::string_view driverName)
+bool
+WifiVirtualDeviceManager::RemoveInterfaces(std::string_view driverName)
 {
     return RemoveInterfacesForDriver(driverName);
 }
 
-bool WifiVirtualDeviceManager::RemoveAllInterfaces()
+bool
+WifiVirtualDeviceManager::RemoveAllInterfaces()
 {
-    for (auto it = std::begin(m_interfaces); it != std::end(m_interfaces); )
-    {
-        if (!RemoveInterfacesForDriver(it->first))
-        {
+    for (auto it = std::begin(m_interfaces); it != std::end(m_interfaces);) {
+        if (!RemoveInterfacesForDriver(it->first)) {
             return false;
         }
 
@@ -44,22 +46,21 @@ bool WifiVirtualDeviceManager::RemoveAllInterfaces()
 }
 
 /* static */
-std::unordered_set<std::string> WifiVirtualDeviceManager::CreateInterfacesForDriver(uint32_t numberOfInterfaces, std::string_view driverName)
+std::unordered_set<std::string>
+WifiVirtualDeviceManager::CreateInterfacesForDriver(uint32_t numberOfInterfaces, std::string_view driverName)
 {
     static constexpr auto InterfaceNamePrefixDefault = "wlan";
 
     // Prepare the driver modprobe arguments, if necessary.
     std::string driverArguments{};
-    if (driverName == DriverMac80211HwsimName)
-    {
+    if (driverName == DriverMac80211HwsimName) {
         driverArguments = std::format("radios={}", numberOfInterfaces);
     }
 
     // Load the specified kernel module, which should create the simulated wireless interface(s).
     const auto driverLoadCommand = std::format("sudo modprobe {} {}", driverName, driverArguments);
     int ret = std::system(driverLoadCommand.c_str());
-    if (ret == -1)
-    {
+    if (ret == -1) {
         ret = WEXITSTATUS(ret);
         std::cerr << std::format("Failed to load {} driver, load command '{}' failed (ret={})\n", driverName, driverLoadCommand, ret);
         return {};
@@ -73,19 +74,19 @@ std::unordered_set<std::string> WifiVirtualDeviceManager::CreateInterfacesForDri
     });
 
     return {
-        std::make_move_iterator(std::begin(interfaces)), 
+        std::make_move_iterator(std::begin(interfaces)),
         std::make_move_iterator(std::end(interfaces))
     };
 }
 
 /* static */
-bool WifiVirtualDeviceManager::RemoveInterfacesForDriver(std::string_view driverName)
+bool
+WifiVirtualDeviceManager::RemoveInterfacesForDriver(std::string_view driverName)
 {
     // Forcefully remove any existing loaded kernel module for this driver.
     const auto driverUnloadCommand = std::format("sudo modprobe -rf {}", driverName);
     int ret = std::system(driverUnloadCommand.c_str());
-    if (ret == -1)
-    {
+    if (ret == -1) {
         ret = WEXITSTATUS(ret);
         std::cerr << std::format("Failed to unload {} driver, unload command '{}' failed (ret={})\n", driverName, driverUnloadCommand, ret);
         return false;

--- a/tests/unit/linux/wpa-controller/detail/WifiVirtualDeviceManager.hxx
+++ b/tests/unit/linux/wpa-controller/detail/WifiVirtualDeviceManager.hxx
@@ -3,14 +3,14 @@
 #define WIFI_VIRTUAL_DEVICE_MANAGER_HXX
 
 #include <cstdint>
-#include <string_view>
 #include <string>
-#include <unordered_set>
+#include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 
 /**
  * @brief Manages virtual wlan devices.
- * 
+ *
  * Note: this class is not thread-safe.
  */
 struct WifiVirtualDeviceManager
@@ -27,52 +27,58 @@ struct WifiVirtualDeviceManager
 
     /**
      * @brief Create a certain number of virtual wlan interfaces using the specified driver.
-     * 
+     *
      * @param numberOfInterfaces The number of virtual wlan interfaces to create.
      * @param driverName The driver to use to create the virtual wlan interfaces.
-     * @return std::unordered_set<std::string> 
+     * @return std::unordered_set<std::string>
      */
-    std::unordered_set<std::string> CreateInterfaces(uint32_t numberOfInterfaces, std::string_view driverName = DriverDefault);
+    std::unordered_set<std::string>
+    CreateInterfaces(uint32_t numberOfInterfaces, std::string_view driverName = DriverDefault);
 
     /**
      * @brief Get a list of all virtual wlan interfaces.
-     * 
-     * @return std::unordered_map<std::string_view, std::unordered_set<std::string>> 
+     *
+     * @return std::unordered_map<std::string_view, std::unordered_set<std::string>>
      */
-    std::unordered_map<std::string_view, std::unordered_set<std::string>> EnumerateInterfaces() const;
+    std::unordered_map<std::string_view, std::unordered_set<std::string>>
+    EnumerateInterfaces() const;
 
     /**
      * @brief Remove all virtual wlan interfaces for the specified driver.
-     * 
+     *
      * @param driverName The driver name to remove the virtual wlan interfaces for.
-     * @return true 
-     * @return false 
+     * @return true
+     * @return false
      */
-    bool RemoveInterfaces(std::string_view driverName = DriverDefault);
+    bool
+    RemoveInterfaces(std::string_view driverName = DriverDefault);
 
     /**
      * @brief Remove all virtual wlan interfaces for all drivers.
      */
-    bool RemoveAllInterfaces();
+    bool
+    RemoveAllInterfaces();
 
 public:
     /**
      * @brief Create a certain number of virtual wlan interfaces using the specified driver.
-     * 
+     *
      * @param numberOfInterfaces The number of virtual wlan interfaces to create.
      * @param driverName The driver to use to create the virtual wlan interfaces.
      * @return std::unordered_set<std::string> A list of interface names that were created.
      */
-    static std::unordered_set<std::string> CreateInterfacesForDriver(uint32_t numberOfInterfaces, std::string_view driverName);
+    static std::unordered_set<std::string>
+    CreateInterfacesForDriver(uint32_t numberOfInterfaces, std::string_view driverName);
 
     /**
      * @brief Remove all virtual wlan interfaces for the specified driver.
-     * 
+     *
      * @param driverName The driver name to remove the virtual wlan interfaces for.
      * @return true All virtual wlan interfaces for the specified driver were removed.
      * @return false Not all virtual wlan interfaces for the specified driver were removed.
      */
-    static bool RemoveInterfacesForDriver(std::string_view driverName);
+    static bool
+    RemoveInterfacesForDriver(std::string_view driverName);
 
 private:
     std::unordered_map<std::string_view, std::unordered_set<std::string>> m_interfaces;

--- a/tests/unit/linux/wpa-controller/detail/WpaDaemonCatch2EventListener.cxx
+++ b/tests/unit/linux/wpa-controller/detail/WpaDaemonCatch2EventListener.cxx
@@ -19,17 +19,18 @@ namespace detail
 {
 /**
  * @brief Get the first wpa daemon type from the specified test tags.
- * 
+ *
  * This function searching the specified list of tags for the first tag which
  * matches the enum name of a WpaType. A case insensitive comparison is used to
  * allow the tags to be lower case, which is idiomatic for Catch2.
- * 
+ *
  * TODO: change this to return a vector or unordered_set of WpaType values.
- * 
+ *
  * @param tags The list of test tags to search.
- * @return std::optional<Wpa::WpaType> 
+ * @return std::optional<Wpa::WpaType>
  */
-std::optional<Wpa::WpaType> GetWpaDaemonTypeFromTags(const std::vector<Catch::Tag>& tags)
+std::optional<Wpa::WpaType>
+GetWpaDaemonTypeFromTags(const std::vector<Catch::Tag>& tags)
 {
     using Strings::CaseInsensitiveStringEquals;
 
@@ -38,14 +39,13 @@ std::optional<Wpa::WpaType> GetWpaDaemonTypeFromTags(const std::vector<Catch::Ta
     // type and does not provide an implicit conversion to std::string, so the
     // explicit conversion operator is used directly here.
     const auto wpaNames = magic_enum::enum_names<Wpa::WpaType>();
-    const auto tagNames = tags | std::views::transform([](const auto& tag){
+    const auto tagNames = tags | std::views::transform([](const auto& tag) {
         return tag.original.operator std::string();
     });
 
     // Find the first entry which matches the tag name, ignoring case.
     const auto result = std::ranges::find_first_of(wpaNames, tagNames, CaseInsensitiveStringEquals);
-    if (result != std::cend(wpaNames))
-    {
+    if (result != std::cend(wpaNames)) {
         return magic_enum::enum_cast<Wpa::WpaType>(*result).value();
     }
 
@@ -54,12 +54,12 @@ std::optional<Wpa::WpaType> GetWpaDaemonTypeFromTags(const std::vector<Catch::Ta
 
 } // namespace detail
 
-void WpaDaemonCatch2EventListener::testCaseStarting(Catch::TestCaseInfo const& testInfo)
+void
+WpaDaemonCatch2EventListener::testCaseStarting(Catch::TestCaseInfo const& testInfo)
 {
     // Determine if this test case has a tag corresponding to a wpa daemon type (WpaType).
     const auto wpaType = detail::GetWpaDaemonTypeFromTags(testInfo.tags);
-    if (!wpaType.has_value())
-    {
+    if (!wpaType.has_value()) {
         std::cout << "Test case does not contain WpaType tag." << std::endl;
         return;
     }
@@ -71,15 +71,13 @@ void WpaDaemonCatch2EventListener::testCaseStarting(Catch::TestCaseInfo const& t
     // Remove any existing mac80211_hwsim virtual wifi devices for the test case.
     const auto driverMac8021Hwsim = WifiVirtualDeviceManager::DriverMac80211HwsimName;
     const auto driverRemoved = m_wifiVirtualDeviceManager.RemoveInterfaces(driverMac8021Hwsim);
-    if (!driverRemoved)
-    {
+    if (!driverRemoved) {
         throw std::runtime_error(std::format("Failed to remove {} virtual wifi devices for test case.", driverMac8021Hwsim));
     }
 
     // Create 1 mac80211_hwsim virtualized wifi device for the test case.
     const auto wifiDevices = m_wifiVirtualDeviceManager.CreateInterfaces(1, WifiVirtualDeviceManager::DriverMac80211HwsimName);
-    if (std::empty(wifiDevices))
-    {
+    if (std::empty(wifiDevices)) {
         throw std::runtime_error(std::format("Failed to create {} virtual wifi device for test case.", driverMac8021Hwsim));
     }
 
@@ -88,8 +86,7 @@ void WpaDaemonCatch2EventListener::testCaseStarting(Catch::TestCaseInfo const& t
 
     // Start the wpa daemon instance for the test case.
     std::unique_ptr<IWpaDaemonInstance> wpaDaemonInstance;
-    switch (wpaType.value())
-    {
+    switch (wpaType.value()) {
     case Wpa::WpaType::Hostapd:
         wpaDaemonInstance = std::make_unique<WpaDaemonInstance<Wpa::WpaType::Hostapd>>();
         break;
@@ -100,8 +97,7 @@ void WpaDaemonCatch2EventListener::testCaseStarting(Catch::TestCaseInfo const& t
         break;
     }
 
-    if (wpaDaemonInstance == nullptr)
-    {
+    if (wpaDaemonInstance == nullptr) {
         throw std::runtime_error(std::format("Failed to create wpa {} daemon instance", wpaDaemon));
     }
 
@@ -111,11 +107,11 @@ void WpaDaemonCatch2EventListener::testCaseStarting(Catch::TestCaseInfo const& t
     std::cout << std::format("Started wpa {} daemon instance\n", wpaDaemon);
 }
 
-void WpaDaemonCatch2EventListener::testCaseEnded(Catch::TestCaseStats const& testCaseStats)
+void
+WpaDaemonCatch2EventListener::testCaseEnded(Catch::TestCaseStats const& testCaseStats)
 {
     const auto wpaType = detail::GetWpaDaemonTypeFromTags(testCaseStats.testInfo->tags);
-    if (!wpaType.has_value())
-    {
+    if (!wpaType.has_value()) {
         std::cout << "Test case does not contain WpaType tag." << std::endl;
         return;
     }
@@ -124,8 +120,7 @@ void WpaDaemonCatch2EventListener::testCaseEnded(Catch::TestCaseStats const& tes
 
     std::cout << std::format("Test case for {} daemon stopping\n", wpaDaemon);
     auto wpaDaemonInstanceNode = m_wpaDaemonInstances.extract(wpaType.value());
-    if (wpaDaemonInstanceNode.empty())
-    {
+    if (wpaDaemonInstanceNode.empty()) {
         std::cout << std::format("Test case for {} daemon does not have an instance.", wpaDaemon) << std::endl;
         return;
     }

--- a/tests/unit/linux/wpa-controller/detail/WpaDaemonCatch2EventListener.hxx
+++ b/tests/unit/linux/wpa-controller/detail/WpaDaemonCatch2EventListener.hxx
@@ -12,7 +12,8 @@
 #include "WifiVirtualDeviceManager.hxx"
 #include "WpaDaemonInstance.hxx"
 
-struct WpaDaemonCatch2EventListener : public Catch::EventListenerBase
+struct WpaDaemonCatch2EventListener :
+    public Catch::EventListenerBase
 {
     // Inherit base class constructor.
     using EventListenerBase::EventListenerBase;

--- a/tests/unit/linux/wpa-controller/detail/WpaDaemonCatch2EventListener.hxx
+++ b/tests/unit/linux/wpa-controller/detail/WpaDaemonCatch2EventListener.hxx
@@ -5,9 +5,9 @@
 #include <memory>
 #include <unordered_map>
 
+#include <Wpa/WpaCore.hxx>
 #include <catch2/reporters/catch_reporter_event_listener.hpp>
 #include <catch2/reporters/catch_reporter_registrars.hpp>
-#include <Wpa/WpaCore.hxx>
 
 #include "WifiVirtualDeviceManager.hxx"
 #include "WpaDaemonInstance.hxx"
@@ -15,22 +15,24 @@
 struct WpaDaemonCatch2EventListener : public Catch::EventListenerBase
 {
     // Inherit base class constructor.
-    using EventListenerBase::EventListenerBase; 
+    using EventListenerBase::EventListenerBase;
 
     /**
      * @brief Runs when a test case is started.
-     * 
-     * @param testInfo 
+     *
+     * @param testInfo
      */
-    void testCaseStarting(Catch::TestCaseInfo const& testInfo) override;
+    void
+    testCaseStarting(Catch::TestCaseInfo const& testInfo) override;
 
     /**
      * @brief Runs when the last test case has ended.
-     * 
-     * @param testCaseStats 
-     * @return * void 
+     *
+     * @param testCaseStats
+     * @return * void
      */
-    void testCaseEnded(Catch::TestCaseStats const& testCaseStats) override;
+    void
+    testCaseEnded(Catch::TestCaseStats const& testCaseStats) override;
 
 private:
     std::unordered_map<Wpa::WpaType, std::unique_ptr<IWpaDaemonInstance>> m_wpaDaemonInstances;

--- a/tests/unit/linux/wpa-controller/detail/WpaDaemonInstance.hxx
+++ b/tests/unit/linux/wpa-controller/detail/WpaDaemonInstance.hxx
@@ -5,8 +5,8 @@
 #include <format>
 #include <iostream>
 
-#include <Wpa/WpaCore.hxx>
 #include "WpaDaemonManager.hxx"
+#include <Wpa/WpaCore.hxx>
 
 /**
  * @brief Represents a running instance of a WPA daemon.
@@ -15,28 +15,31 @@ struct IWpaDaemonInstance
 {
     virtual ~IWpaDaemonInstance() = default;
 
-    virtual bool Start() = 0;
-    virtual bool Stop() = 0;
+    virtual bool
+    Start() = 0;
+
+    virtual bool
+    Stop() = 0;
 };
 
 /**
  * @brief Concrete implementation of IWpaDaemonInstance for a specific WPA daemon type.
- * 
+ *
  * @tparam wpaType The type of wpa instance to manage.
  */
 template <Wpa::WpaType wpaType>
 struct WpaDaemonInstance : public IWpaDaemonInstance
 {
-    WpaDaemonInstance()
-        : m_wpaDaemonName(Wpa::GetWpaTypeDaemonBinaryName(m_wpaType))
+    WpaDaemonInstance() :
+        m_wpaDaemonName(Wpa::GetWpaTypeDaemonBinaryName(m_wpaType))
     {
     }
 
-    bool Start() override
+    bool
+    Start() override
     {
         auto instanceToken = WpaDaemonManager::StartDefault(m_wpaType);
-        if (!instanceToken.has_value())
-        {
+        if (!instanceToken.has_value()) {
             std::cerr << std::format("Failed to start {} daemon instance\n", m_wpaDaemonName);
             return false;
         }
@@ -45,16 +48,15 @@ struct WpaDaemonInstance : public IWpaDaemonInstance
         return true;
     }
 
-    bool Stop() override
+    bool
+    Stop() override
     {
-        if (!m_instanceToken.has_value())
-        {
+        if (!m_instanceToken.has_value()) {
             std::cout << std::format("Warning: No {} daemon instance running\n", m_wpaDaemonName);
             return true;
         }
 
-        if (!WpaDaemonManager::Stop(m_instanceToken.value()))
-        {
+        if (!WpaDaemonManager::Stop(m_instanceToken.value())) {
             std::cerr << std::format("Failed to stop {} daemon instance\n", m_wpaDaemonName);
             return false;
         }

--- a/tests/unit/linux/wpa-controller/detail/WpaDaemonInstance.hxx
+++ b/tests/unit/linux/wpa-controller/detail/WpaDaemonInstance.hxx
@@ -28,7 +28,8 @@ struct IWpaDaemonInstance
  * @tparam wpaType The type of wpa instance to manage.
  */
 template <Wpa::WpaType wpaType>
-struct WpaDaemonInstance : public IWpaDaemonInstance
+struct WpaDaemonInstance :
+    public IWpaDaemonInstance
 {
     WpaDaemonInstance() :
         m_wpaDaemonName(Wpa::GetWpaTypeDaemonBinaryName(m_wpaType))

--- a/tests/unit/linux/wpa-controller/detail/WpaDaemonManager.hxx
+++ b/tests/unit/linux/wpa-controller/detail/WpaDaemonManager.hxx
@@ -6,8 +6,8 @@
 #include <optional>
 #include <string_view>
 
-#include <unistd.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #include "detail/WpaDaemonManager.hxx"
 #include <Wpa/WpaCore.hxx>
@@ -30,53 +30,57 @@ struct WpaDaemonManager
     /**
      * @brief The default interface name used, if not provided.
      */
-    static constexpr auto InterfaceNameDefault{"wlan0"};
+    static constexpr auto InterfaceNameDefault{ "wlan0" };
 
     /**
      * @brief The default path to the daemon control socket, if not specified.
      */
-    static constexpr auto ControlSocketPathBase{"/run/"};
+    static constexpr auto ControlSocketPathBase{ "/run/" };
 
     /**
      * @brief Create and write a default configuration file to disk for the
      * specified wpa daemon type. The configuration file will be written to the
      * system tmeporary directory, and so will not persist across reboots.
-     * 
+     *
      * @param wpaType The type of wpa daemon to create the configuration file for.
      * @param interfaceName The wlan interface for the daemon to use.
      * @return std::filesystem::path The path to the created configuration file.
      */
-    static std::filesystem::path CreateAndWriteDefaultConfigurationFile(Wpa::WpaType wpaType, std::string_view interfaceName = InterfaceNameDefault);
+    static std::filesystem::path
+    CreateAndWriteDefaultConfigurationFile(Wpa::WpaType wpaType, std::string_view interfaceName = InterfaceNameDefault);
 
     /**
      * @brief Starts an instance of the specified daemon type using a default
      * configuration file.
-     * 
-     * @param wpaType The type of wpa daemon to start. 
+     *
+     * @param wpaType The type of wpa daemon to start.
      * @param interfaceName The optional wlan interface for the daemon to use.
-     * @return std::optional<WpaDaemonInstanceHandle> 
+     * @return std::optional<WpaDaemonInstanceHandle>
      */
-    static std::optional<WpaDaemonInstanceHandle> StartDefault(Wpa::WpaType wpaType, std::string_view interfaceName = InterfaceNameDefault);
+    static std::optional<WpaDaemonInstanceHandle>
+    StartDefault(Wpa::WpaType wpaType, std::string_view interfaceName = InterfaceNameDefault);
 
     /**
      * @brief Starts an instance of the specified wpa daemon type.
-     * 
-     * @param wpaType The type of wpa daemon to start. 
+     *
+     * @param wpaType The type of wpa daemon to start.
      * @param interfaceName The wlan interface for the daemon to use.
      * @param configurationFilePath The path to the daemon configuration file.
      * @param extraCommandLineArguments The command line arguments to be passed to the daemon binary.
-     * @return std::optional<WpaDaemonInstanceHandle> 
+     * @return std::optional<WpaDaemonInstanceHandle>
      */
-    static std::optional<WpaDaemonInstanceHandle> Start(Wpa::WpaType wpaType, std::string_view interfaceName, const std::filesystem::path& configurationFilePath, std::string_view extraCommandLineArguments = "");
+    static std::optional<WpaDaemonInstanceHandle>
+    Start(Wpa::WpaType wpaType, std::string_view interfaceName, const std::filesystem::path& configurationFilePath, std::string_view extraCommandLineArguments = "");
 
     /**
      * @brief Stop a running instance of the specified wpa daemon.
-     * 
-     * @param instanceHandle The handle to the daemon instance to stop. 
-     * @return true 
-     * @return false 
+     *
+     * @param instanceHandle The handle to the daemon instance to stop.
+     * @return true
+     * @return false
      */
-    static bool Stop(const WpaDaemonInstanceHandle& instanceHandle);
+    static bool
+    Stop(const WpaDaemonInstanceHandle& instanceHandle);
 };
 
 #endif // WPA_DAEMON_MANAGER_HXX

--- a/tests/unit/wifi/helpers/AccessPointFactoryTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointFactoryTest.cxx
@@ -5,7 +5,8 @@
 using namespace Microsoft::Net::Wifi;
 using namespace Microsoft::Net::Wifi::Test;
 
-std::shared_ptr<IAccessPoint> AccessPointFactoryTest::Create(std::string_view interface)
+std::shared_ptr<IAccessPoint>
+AccessPointFactoryTest::Create(std::string_view interface)
 {
     return std::make_shared<AccessPoint>(interface);
 }

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointFactoryTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointFactoryTest.hxx
@@ -1,6 +1,6 @@
 
 #ifndef ACCESS_POIINT_FACTORY_TEST_HXX
-#define ACCESS_POIINT_FACTORY_TEST_HXX 
+#define ACCESS_POIINT_FACTORY_TEST_HXX
 
 #include <memory>
 #include <string_view>
@@ -22,13 +22,14 @@ struct AccessPointFactoryTest :
 
     /**
      * @brief Create an AccessPoint for testing purposes.
-     * 
+     *
      * @param interface The interface to create the AccessPoint for. This can be
      * any string and does not have to correspond to a real device interface.
-     * 
-     * @return std::shared_ptr<IAccessPoint> 
+     *
+     * @return std::shared_ptr<IAccessPoint>
      */
-    std::shared_ptr<IAccessPoint> Create(std::string_view interface) override;
+    std::shared_ptr<IAccessPoint>
+    Create(std::string_view interface) override;
 };
 } // namespace Microsoft::Net::Wifi::Test
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure
- [X] Code style

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Ensure the codebase uses a consistent coding style.

### Technical Details

* Apple `clang-format` tool across the entire codebase.

### Test Results

* Builds successfully, all unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
