### PR TITLE
Add AccessPointManager unit tests

### DIFF
--- a/src/common/wifi/apmanager/AccessPointManager.cxx
+++ b/src/common/wifi/apmanager/AccessPointManager.cxx
@@ -84,7 +84,7 @@ AccessPointManager::GetAllAccessPoints() const
 }
 
 void
-AccessPointManager::AddDiscoveryAgent(std::unique_ptr<AccessPointDiscoveryAgent> discoveryAgent)
+AccessPointManager::AddDiscoveryAgent(std::shared_ptr<AccessPointDiscoveryAgent> discoveryAgent)
 {
     using namespace std::chrono_literals;
 

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
@@ -47,7 +47,7 @@ public:
      * @param discoveryAgent The discovery agent to add.
      */
     void
-    AddDiscoveryAgent(std::unique_ptr<AccessPointDiscoveryAgent> discoveryAgent);
+    AddDiscoveryAgent(std::shared_ptr<AccessPointDiscoveryAgent> discoveryAgent);
 
     /**
      * @brief Get the IAccessPoint object with the specified interface name.
@@ -129,7 +129,7 @@ private:
     std::vector<std::shared_ptr<IAccessPoint>> m_accessPoints{};
 
     mutable std::shared_mutex m_discoveryAgentsGate;
-    std::vector<std::unique_ptr<AccessPointDiscoveryAgent>> m_discoveryAgents;
+    std::vector<std::shared_ptr<AccessPointDiscoveryAgent>> m_discoveryAgents;
 };
 
 } // namespace Microsoft::Net::Wifi

--- a/tests/unit/wifi/apmanager/TestAccessPointManager.cxx
+++ b/tests/unit/wifi/apmanager/TestAccessPointManager.cxx
@@ -4,6 +4,7 @@
 #include <microsoft/net/wifi/AccessPointManager.hxx>
 
 #include "AccessPointDiscoveryAgentOperationsTest.hxx"
+#include "AccessPointTest.hxx"
 
 TEST_CASE("Create an AccessPointManager instance", "[wifi][core][apmanager]")
 {
@@ -47,5 +48,142 @@ TEST_CASE("AccessPointManager instance reflects basic properties", "[wifi][core]
     {
         auto accessPointManager{ AccessPointManager::Create() };
         REQUIRE(std::empty(accessPointManager->GetAllAccessPoints()));
+    }
+}
+
+TEST_CASE("AccessPointManager correctly manages lifetime of access points reported by discovery agents", "[wifi][core][apmanager]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using Test::AccessPointDiscoveryAgentOperationsTest;
+
+    auto accessPoint1{ std::make_shared<Test::AccessPointTest>("accessPointTest1") };
+    auto accessPoint2{ std::make_shared<Test::AccessPointTest>("accessPointTest2") };
+
+    auto accessPointDiscoveryAgentOperationsTest{ std::make_unique<AccessPointDiscoveryAgentOperationsTest>() };
+    auto* accessPointDiscoveryAgentOperationsTestPtr{ accessPointDiscoveryAgentOperationsTest.get() };
+    auto accessPointDiscoveryAgentTest{ AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperationsTest)) };
+
+    auto accessPointManager{ AccessPointManager::Create() };
+    accessPointManager->AddDiscoveryAgent(std::move(accessPointDiscoveryAgentTest));
+
+    SECTION("Adds reference to discovered access points")
+    {
+        const auto referenceCount{ accessPoint1.use_count() };
+        accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPoint1);
+        REQUIRE(accessPoint1.use_count() > referenceCount);
+    }
+
+    SECTION("Removes reference from departed access points")
+    {
+        accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPoint1);
+        const auto referenceCount{ accessPoint1.use_count() };
+        accessPointDiscoveryAgentOperationsTestPtr->RemoveAccessPoint(accessPoint1);
+        REQUIRE(accessPoint1.use_count() < referenceCount);
+    }
+}
+
+TEST_CASE("AccessPointManager persists access points reported by discovery agents", "[wifi][core][apmanager]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using Test::AccessPointDiscoveryAgentOperationsTest;
+
+    auto accessPoint1{ std::make_shared<Test::AccessPointTest>("accessPointTest1") };
+    auto accessPoint2{ std::make_shared<Test::AccessPointTest>("accessPointTest2") };
+
+    auto accessPointDiscoveryAgentOperationsTest{ std::make_unique<AccessPointDiscoveryAgentOperationsTest>() };
+    auto* accessPointDiscoveryAgentOperationsTestPtr{ accessPointDiscoveryAgentOperationsTest.get() };
+    auto accessPointDiscoveryAgentTest{ AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperationsTest)) };
+
+    auto accessPointManager{ AccessPointManager::Create() };
+    accessPointManager->AddDiscoveryAgent(std::move(accessPointDiscoveryAgentTest));
+
+    SECTION("Access points from arrival events are persisted via GetAccessPoint()")
+    {
+        accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPoint1);
+
+        auto accessPointRetrievedWeak{ accessPointManager->GetAccessPoint(accessPoint1->GetInterface()) };
+        auto accessPointRetrieved{ accessPointRetrievedWeak.lock() };
+        REQUIRE(accessPointRetrieved != nullptr);
+        REQUIRE(accessPointRetrieved->GetInterface() == accessPoint1->GetInterface());
+    }
+
+    SECTION("Access points from arrival events are persisted via GetAllAccessPoints()")
+    {
+        accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPoint1);
+
+        const auto accessPointsAll{ accessPointManager->GetAllAccessPoints() };
+        REQUIRE(std::size(accessPointsAll) == 1);
+
+        std::weak_ptr<IAccessPoint> accessPointRetrievedWeak{};
+        REQUIRE_NOTHROW(accessPointRetrievedWeak = accessPointsAll[0]);
+        auto accessPointRetrieved{ accessPointRetrievedWeak.lock() };
+        REQUIRE(accessPointRetrieved != nullptr);
+        REQUIRE(accessPointRetrieved->GetInterface() == accessPoint1->GetInterface());
+    }
+
+    SECTION("Access points from arrival events are persisted via GetAccessPoint() after additional access points have been added")
+    {
+        accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPoint1);
+        accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPoint2);
+
+        auto accessPointRetrievedWeak{ accessPointManager->GetAccessPoint(accessPoint1->GetInterface()) };
+        auto accessPointRetrieved{ accessPointRetrievedWeak.lock() };
+        REQUIRE(accessPointRetrieved != nullptr);
+        REQUIRE(accessPointRetrieved->GetInterface() == accessPoint1->GetInterface());
+    }
+
+    SECTION("Access points from arrival events are persisted via GetAllAccessPoints() after additional access points have been added")
+    {
+        accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPoint1);
+        accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPoint2);
+
+        const auto accessPointsAll{ accessPointManager->GetAllAccessPoints() };
+        REQUIRE(std::size(accessPointsAll) == 2);
+
+        std::weak_ptr<IAccessPoint> accessPointRetrievedWeak{};
+        REQUIRE_NOTHROW(accessPointRetrievedWeak = accessPointsAll[0]);
+        auto accessPointRetrieved{ accessPointRetrievedWeak.lock() };
+        REQUIRE(accessPointRetrieved != nullptr);
+        REQUIRE(accessPointRetrieved->GetInterface() == accessPoint1->GetInterface());
+    }
+}
+
+TEST_CASE("AccessPointManager discards access points reported to have departed by discovery agents", "[wifi][core][apmanager]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using Test::AccessPointDiscoveryAgentOperationsTest;
+
+    auto accessPoint1{ std::make_shared<Test::AccessPointTest>("accessPointTest1") };
+    auto accessPoint2{ std::make_shared<Test::AccessPointTest>("accessPointTest2") };
+
+    auto accessPointDiscoveryAgentOperationsTest{ std::make_unique<AccessPointDiscoveryAgentOperationsTest>() };
+    auto* accessPointDiscoveryAgentOperationsTestPtr{ accessPointDiscoveryAgentOperationsTest.get() };
+    auto accessPointDiscoveryAgentTest{ AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperationsTest)) };
+
+    auto accessPointManager{ AccessPointManager::Create() };
+    accessPointManager->AddDiscoveryAgent(std::move(accessPointDiscoveryAgentTest));
+
+    SECTION("Access points reported to have departed are not accessible via GetAccessPoint()")
+    {
+        accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPoint1);
+        auto accessPointWeak{ accessPointManager->GetAccessPoint(accessPoint1->GetInterface()) };
+        auto accessPoint{ accessPointWeak.lock() };
+
+        accessPointDiscoveryAgentOperationsTestPtr->RemoveAccessPoint(accessPoint);
+        auto accessPointRetrieved{ accessPointManager->GetAccessPoint(accessPoint1->GetInterface()) };
+        REQUIRE(accessPointRetrieved.expired());
+    }
+
+    SECTION("Access points reported to have departed are not accessible via GetAllAccessPoints()")
+    {
+        accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPoint1);
+
+        auto accessPointWeak{ accessPointManager->GetAccessPoint(accessPoint1->GetInterface()) };
+        auto accessPoint{ accessPointWeak.lock() };
+
+        accessPointDiscoveryAgentOperationsTestPtr->RemoveAccessPoint(accessPoint);
+
+        const auto accessPointsAll{ accessPointManager->GetAllAccessPoints() };
+        REQUIRE(std::empty(accessPointsAll));
     }
 }

--- a/tests/unit/wifi/apmanager/TestAccessPointManager.cxx
+++ b/tests/unit/wifi/apmanager/TestAccessPointManager.cxx
@@ -1,6 +1,9 @@
 
 #include <catch2/catch_test_macros.hpp>
+#include <microsoft/net/wifi/AccessPointDiscoveryAgent.hxx>
 #include <microsoft/net/wifi/AccessPointManager.hxx>
+
+#include "AccessPointDiscoveryAgentOperationsTest.hxx"
 
 TEST_CASE("Create an AccessPointManager instance", "[wifi][core][apmanager]")
 {
@@ -16,9 +19,22 @@ TEST_CASE("Destroy an AccessPointManager instance", "[wifi][core][apmanager]")
 {
     using namespace Microsoft::Net::Wifi;
 
+    using Test::AccessPointDiscoveryAgentOperationsTest;
+
     SECTION("Destroy doesn't cause a crash")
     {
         auto accessPointManager{ AccessPointManager::Create() };
+        REQUIRE_NOTHROW(accessPointManager.reset());
+    }
+
+    SECTION("Destroy doesn't cause a crash when there are registered discovery agents")
+    {
+        auto accessPointDiscoveryAgent1{ AccessPointDiscoveryAgent::Create(std::make_unique<AccessPointDiscoveryAgentOperationsTest>()) };
+        auto accessPointDiscoveryAgent2{ AccessPointDiscoveryAgent::Create(std::make_unique<AccessPointDiscoveryAgentOperationsTest>()) };
+
+        auto accessPointManager{ AccessPointManager::Create() };
+        accessPointManager->AddDiscoveryAgent(std::move(accessPointDiscoveryAgent1));
+        accessPointManager->AddDiscoveryAgent(std::move(accessPointDiscoveryAgent2));
         REQUIRE_NOTHROW(accessPointManager.reset());
     }
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure `AccessPointManager` functionality is tested.


### Technical Details

* Update `AccessPointManager` to use `std::shared_ptr<AccessPointDiscoveryAgent>` instances instead of `std::unique_ptr<>`.
* Add series of unit tests validating `AccessPointManager` functionality.

### Test Results

* All unit tests, including newly added ones, pass.

### Reviewer Focus

* Consider whether any important test cases were missed.

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
