### PR TITLE
Remove WifiConfigureAccessPoint API

### DIFF
--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -8,7 +8,6 @@ import "NetRemoteWifi.proto";
 
 service NetRemote
 {
-    rpc WifiConfigureAccessPoint (Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointRequest) returns (Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointResult);
     rpc WifiEnumerateAccessPoints (Microsoft.Net.Remote.Wifi.WifiEnumerateAccessPointsRequest) returns (Microsoft.Net.Remote.Wifi.WifiEnumerateAccessPointsResult);
     rpc WifiAccessPointEnable (Microsoft.Net.Remote.Wifi.WifiAccessPointEnableRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointEnableResult);
     rpc WifiAccessPointDisable (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableResult);

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -6,37 +6,6 @@ package Microsoft.Net.Remote.Wifi;
 import "google/protobuf/any.proto";
 import "WifiCore.proto";
 
-message WifiConfigureAccessPointRequest
-{
-    // The unique identifier of the access point to configure.
-    string AccessPointId = 1;
-
-    // The default band the AP should be configured for.
-    Microsoft.Net.Wifi.RadioBand DefaultBand = 2;
-
-    // All the possible configurations for the AP. The key field *must* be a
-    // Microsoft.Net.Wifi.RadioBand enumeration value. This is to workaround the
-    // inability to use enums as map keys in proto3. So it must be used as if
-    // the 'Configurations' field was defined with type:
-    //      map<Microsoft.Net.Wifi.RadioBand, Microsoft.Net.Wifi.AccessPointConfiguration>
-    //
-    map<int32, Microsoft.Net.Wifi.AccessPointConfiguration> Configurations = 3;
-}
-
-message WifiConfigureAccessPointResult
-{
-    // The unique identifier of the access point that was requested to be configured.
-    string AccessPointId = 1;
-
-    // Whether the configuration succeeded or not.
-    // TODO: 
-    //  - this seems too coarse. Should we return a map<int32, bool> instead?
-    //      - Would that information be actionable?
-    //  - is an error code better?
-    //
-    bool Succeeded = 2;
-}
-
 message WifiEnumerateAccessPointsResultItem
 {
     string AccessPointId = 1;

--- a/src/common/dotnet/NetRemoteClientUnitTest/UnitTestNetRemoteClient.cs
+++ b/src/common/dotnet/NetRemoteClientUnitTest/UnitTestNetRemoteClient.cs
@@ -34,31 +34,5 @@ namespace Microsoft.Net.Remote.Client.Test
 
             return new GrpcConnection(channel, client);
         }
-
-        [TestMethod]
-        public void TestWifiConfigureAccessPoint()
-        {
-            var connection = CreateConnection(ConnectionType.Http);
-            using var channel = connection.Channel;
- 
-            foreach (var band in Enum.GetValues(typeof(Net.Wifi.RadioBand)).Cast<Net.Wifi.RadioBand>())
-            {
-                foreach (var phyType in Enum.GetValues(typeof(Net.Wifi.Dot11PhyType)).Cast<Net.Wifi.Dot11PhyType>())
-                {
-                    var request = new WifiConfigureAccessPointRequest
-                    {
-                        AccessPointId = string.Format("TestWifiConfigureAccessPoint{0}", band),
-                        DefaultBand = band,
-                    };
-
-                    request.Configurations.Add((int)phyType, new Net.Wifi.AccessPointConfiguration { PhyType = phyType });
-                    var result = connection.Client.WifiConfigureAccessPoint(request);
-
-                    Assert.IsNotNull(result);
-                    Assert.IsTrue(result.Succeeded);
-                    Assert.AreEqual(request.AccessPointId, result.AccessPointId);
-                }
-            }
-        }
     }
 }

--- a/src/common/dotnet/NetRemoteService/Services/NetRemoteService.cs
+++ b/src/common/dotnet/NetRemoteService/Services/NetRemoteService.cs
@@ -11,14 +11,5 @@ namespace Microsoft.Net.Remote.Service
         {
             _logger = logger;
         }
-
-        public override Task<Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointResult> WifiConfigureAccessPoint(Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointRequest request, Grpc::ServerCallContext context)
-        {
-            return Task.FromResult(new Microsoft.Net.Remote.Wifi.WifiConfigureAccessPointResult
-            {
-                AccessPointId = request.AccessPointId,
-                Succeeded = true,
-            });
-        }
     }
 }

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -9,17 +9,6 @@
 using namespace Microsoft::Net::Remote::Service;
 
 ::grpc::Status
-NetRemoteService::WifiConfigureAccessPoint([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response)
-{
-    LOG_VERBOSE << std::format("Received WifiConfigureAccessPoint request for access point id {} with {} configurations\n", request->accesspointid(), request->configurations_size());
-
-    response->set_accesspointid(request->accesspointid());
-    response->set_succeeded(true);
-
-    return grpc::Status::OK;
-}
-
-::grpc::Status
 NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerContext* context, [[maybe_unused]] const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, [[maybe_unused]] ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response)
 {
     LOG_VERBOSE << std::format("Received WifiEnumerateAccessPoints request\n");

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -10,9 +10,6 @@ class NetRemoteService :
     public NetRemote::Service
 {
     virtual ::grpc::Status
-    WifiConfigureAccessPoint(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointRequest* request, ::Microsoft::Net::Remote::Wifi::WifiConfigureAccessPointResult* response) override;
-
-    virtual ::grpc::Status
     WifiEnumerateAccessPoints(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response) override;
 
     virtual ::grpc::Status

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -12,43 +12,6 @@
 
 #include "TestNetRemoteCommon.hxx"
 
-TEST_CASE("WifiConfigureAccessPoint API", "[basic][rpc][client][remote]")
-{
-    using namespace Microsoft::Net::Remote;
-    using namespace Microsoft::Net::Remote::Service;
-    using namespace Microsoft::Net::Remote::Wifi;
-
-    NetRemoteServer server{ Test::RemoteServiceAddressHttp };
-    server.Run();
-
-    auto channel = grpc::CreateChannel(Test::RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());
-    auto client = NetRemote::NewStub(channel);
-
-    SECTION("Can be called")
-    {
-        for (const auto& band : magic_enum::enum_values<Microsoft::Net::Wifi::RadioBand>()) {
-            for (const auto& phyType : magic_enum::enum_values<Microsoft::Net::Wifi::Dot11PhyType>()) {
-                Microsoft::Net::Wifi::AccessPointConfiguration apConfiguration{};
-                apConfiguration.set_phytype(phyType);
-
-                WifiConfigureAccessPointRequest request{};
-                request.set_accesspointid(std::format("TestWifiConfigureAccessPoint{}", magic_enum::enum_name(band)));
-                request.set_defaultband(band);
-                request.mutable_configurations()->emplace(band, apConfiguration);
-
-                WifiConfigureAccessPointResult result{};
-                grpc::ClientContext clientContext{};
-
-                auto status = client->WifiConfigureAccessPoint(&clientContext, request, &result);
-
-                REQUIRE(status.ok());
-                REQUIRE(result.succeeded() == true);
-                REQUIRE(result.accesspointid() == request.accesspointid());
-            }
-        }
-    }
-}
-
 TEST_CASE("WifiEnumerateAccessPoints API", "[basic][rpc][client][remote]")
 {
     using namespace Microsoft::Net::Remote;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [X] Breaking change
- [ ] Non-functional change

### Goals

* Simplify the server API surface.

### Technical Details

* Remove the `WifiConfigureAccessPoint` API, which is superseded by the `WifiAccessPointEnable` API added in #78.

### Test Results

* All unit tests pass.

### Reviewer Focus

* Consider whether additional references to this API exist, particularly in documentation.

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
