### PR TITLE
Enable CI/CD workflow on PRs to develop and main

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,6 +7,10 @@ name: CI/CD
 # on pushes and PRs to the main branches to enforce code quality and test
 # coverage.
 on:
+  pull_request:
+    branches:
+      - develop
+      - main
   workflow_dispatch:
   workflow_call:
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Enforce code quality on PRs.

### Technical Details

* Trigger the existing CI/CD workflow on PRs to the `main` and `develop` branches.

### Test Results

* N/A

### Reviewer Focus

* None

### Future Work

* Configure status checks in `develop` branch settings to require the CI/CD workflow to complete successfully.

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
