### PR TITLE
Implement access point discovery operations for Linux using netlink

### DIFF
--- a/.docker/netremote-dev/Dockerfile
+++ b/.docker/netremote-dev/Dockerfile
@@ -22,7 +22,7 @@ LABEL org.label-schema.schema-version = "1.0"
 # sudo apt-get update
 #
 # 2. Install core build tools and dependencies:
-# sudo apt-get install -y --no-install-recommends build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip libnl-3-dev libssl-dev libnl-genl-3-dev libdbus-c++-dev libnl-route-3-dev
+# sudo apt-get install -y --no-install-recommends build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip libnl-3-200-dbg libnl-3-dev libssl-dev libnl-genl-3-dev libdbus-c++-dev libnl-route-3-dev
 #
 # 3. Remove llvm 16 toolchain packages to avoid conflicts with llvm 17 toolchain.
 # sudo apt-get remove -y --purge clang-16* lldb-16* llvm-16*
@@ -57,7 +57,8 @@ RUN apt-get update && \
         unzip \
         zip \
         # hostapd build dependencies.
-        # libnl-3-dev libssl-dev libnl-genl-3-dev
+        # libnl-3-200-dbg libnl-3-dev libssl-dev libnl-genl-3-dev
+        libnl-3-200-dbg \
         libnl-3-dev \
         libnl-genl-3-dev \
         libssl-dev \

--- a/.docker/netremote-dev/Dockerfile
+++ b/.docker/netremote-dev/Dockerfile
@@ -22,7 +22,7 @@ LABEL org.label-schema.schema-version = "1.0"
 # sudo apt-get update
 #
 # 2. Install core build tools and dependencies:
-# sudo apt-get install -y --no-install-recommends build-essential ca-certificates cmake curl dotnet7 git gnupg libmnl-dev linux-libc-dev ninja-build pkg-config tar unzip zip libnl-3-dev libssl-dev libnl-genl-3-dev libdbus-c++-dev libnl-route-3-dev
+# sudo apt-get install -y --no-install-recommends build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip libnl-3-dev libssl-dev libnl-genl-3-dev libdbus-c++-dev libnl-route-3-dev
 #
 # 3. Remove llvm 16 toolchain packages to avoid conflicts with llvm 17 toolchain.
 # sudo apt-get remove -y --purge clang-16* lldb-16* llvm-16*
@@ -42,7 +42,7 @@ LABEL org.label-schema.schema-version = "1.0"
 RUN apt-get update && \
     apt-get install -qq -y --no-install-recommends \
         # Core project build dependencies.
-        # build-essential ca-certificates cmake curl dotnet7 git gnupg libmnl-dev linux-libc-dev ninja-build pkg-config tar unzip zip
+        # build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip
         build-essential \
         ca-certificates \
         cmake \
@@ -50,7 +50,6 @@ RUN apt-get update && \
         dotnet7 \
         git \
         gnupg \
-        libmnl-dev \
         linux-libc-dev \
         ninja-build \
         pkg-config \

--- a/.docker/netremote-dev/Dockerfile
+++ b/.docker/netremote-dev/Dockerfile
@@ -22,7 +22,7 @@ LABEL org.label-schema.schema-version = "1.0"
 # sudo apt-get update
 #
 # 2. Install core build tools and dependencies:
-# sudo apt-get install -y --no-install-recommends build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip libnl-3-dev libssl-dev libnl-genl-3-dev libdbus-c++-dev libnl-route-3-dev
+# sudo apt-get install -y --no-install-recommends build-essential ca-certificates cmake curl dotnet7 git gnupg libmnl-dev linux-libc-dev ninja-build pkg-config tar unzip zip libnl-3-dev libssl-dev libnl-genl-3-dev libdbus-c++-dev libnl-route-3-dev
 #
 # 3. Remove llvm 16 toolchain packages to avoid conflicts with llvm 17 toolchain.
 # sudo apt-get remove -y --purge clang-16* lldb-16* llvm-16*
@@ -42,7 +42,7 @@ LABEL org.label-schema.schema-version = "1.0"
 RUN apt-get update && \
     apt-get install -qq -y --no-install-recommends \
         # Core project build dependencies.
-        # build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip
+        # build-essential ca-certificates cmake curl dotnet7 git gnupg libmnl-dev linux-libc-dev ninja-build pkg-config tar unzip zip
         build-essential \
         ca-certificates \
         cmake \
@@ -50,6 +50,7 @@ RUN apt-get update && \
         dotnet7 \
         git \
         gnupg \
+        libmnl-dev \
         linux-libc-dev \
         ninja-build \
         pkg-config \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ include(protoc)
 include(cmake-properties)
 
 # Enable verbose output until project is bootstrapped.
-set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "ON" FORCE)
 
 # Pull in external dependencies.
 # Look for protobuf-config.cmake.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ include(ExternalProject)
 include(GNUInstallDirs)
 include(grpc)
 include(protoc)
+include(cmake-properties)
 
 # Enable verbose output until project is bootstrapped.
 set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,6 @@ include(ExternalProject)
 include(GNUInstallDirs)
 include(grpc)
 include(protoc)
-include(cmake-properties)
 
 # Enable to debug CMake issues.
 set(CMAKE_VERBOSE_MAKEFILE OFF CACHE BOOL "Verbose Makefile Generation")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,8 @@ include(grpc)
 include(protoc)
 include(cmake-properties)
 
-# Enable verbose output until project is bootstrapped.
-set(CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "ON" FORCE)
+# Enable to debug CMake issues.
+set(CMAKE_VERBOSE_MAKEFILE OFF CACHE BOOL "Verbose Makefile Generation")
 
 # Pull in external dependencies.
 # Look for protobuf-config.cmake.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -45,7 +45,7 @@
             "cacheVariables": {
                 "CMAKE_CXX_COMPILER": "/usr/bin/clang++-17",
                 "CMAKE_C_COMPILER": "/usr/bin/clang-17",
-                "CMAKE_GENERATOR": "Ninja"
+                "CMAKE_GENERATOR": "Ninja Multi-Config"
             }
         },
         {
@@ -106,10 +106,7 @@
                 "os-linux",
                 "linux-base",
                 "release-base"
-            ],
-            "cacheVariables": {
-                "CMAKE_GENERATOR": "Ninja Multi-Config"
-            }
+            ]
         },
         {
             "name": "release-windows",
@@ -123,7 +120,8 @@
     "buildPresets": [
         {
             "name": "dev-linux",
-            "configurePreset": "dev-linux"
+            "configurePreset": "dev-linux",
+            "configuration": "Debug"
         },
         {
             "name": "dev-windows",

--- a/src/common/shared/notstd/CMakeLists.txt
+++ b/src/common/shared/notstd/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(notstd
     FILES
         ${NOTSTD_PUBLIC_INCLUDE_PREFIX}/Exceptions.hxx
         ${NOTSTD_PUBLIC_INCLUDE_PREFIX}/Memory.hxx
+        ${NOTSTD_PUBLIC_INCLUDE_PREFIX}/Scope.hxx
         ${NOTSTD_PUBLIC_INCLUDE_PREFIX}/Utility.hxx
 )
 

--- a/src/common/shared/notstd/include/notstd/Scope.hxx
+++ b/src/common/shared/notstd/include/notstd/Scope.hxx
@@ -1,0 +1,129 @@
+#ifndef NOT_STD_SCOPE_HXX
+#define NOT_STD_SCOPE_HXX
+
+#include <type_traits>
+#include <utility>
+
+namespace notstd
+{
+namespace details
+{
+/**
+ * @brief Executes a given lambda when destroyed.
+ * 
+ * @tparam TLambda 
+ */
+template <typename TLambda>
+class lambda_call
+{
+public:
+    lambda_call(const lambda_call&) = delete;
+    lambda_call&
+    operator=(const lambda_call&) = delete;
+    lambda_call&
+    operator=(lambda_call&& other) = delete;
+
+    /**
+     * @brief Construct a new lambda call object.
+     * 
+     * @param lambda 
+     */
+    explicit lambda_call(TLambda&& lambda) noexcept :
+        m_lambda(std::move(lambda))
+    {
+        static_assert(std::is_same<decltype(lambda()), void>::value, "scope_exit lambdas must not have a return value");
+        static_assert(!std::is_lvalue_reference<TLambda>::value && !std::is_rvalue_reference<TLambda>::value,
+            "scope_exit should only be directly used with a lambda");
+    }
+
+    /**
+     * @brief Construct a new lambda call object.
+     * 
+     * @param other 
+     */
+    lambda_call(lambda_call&& other) noexcept :
+        m_lambda(std::move(other.m_lambda)),
+        m_call(other.m_call)
+    {
+        other.m_call = false;
+    }
+
+    /**
+     * @brief Destroy the lambda call object.
+     */
+    ~lambda_call() noexcept
+    {
+        reset();
+    }
+
+    /**
+     * @brief Ensures the scope_exit lambda will not be called.
+     */
+    void
+    release() noexcept
+    {
+        m_call = false;
+    }
+
+    /**
+     * @brief Executes the scope_exit lambda immediately if not yet run; ensures
+     * it will not run again.
+     */
+    void
+    reset() noexcept
+    {
+        if (m_call) {
+            m_call = false;
+            m_lambda();
+        }
+    }
+
+    /**
+     * @brief Returns true if the scope_exit lambda is still going to be
+     * executed.
+     * 
+     * @return true 
+     * @return false 
+     */
+    explicit operator bool() const noexcept
+    {
+        return m_call;
+    }
+
+private:
+    TLambda m_lambda;
+    bool m_call = true;
+};
+} // namespace details
+
+/**
+ * @brief Returns an object that executes the given lambda when destroyed. 
+ * 
+ * @tparam TLambda 
+ * @param lambda 
+ * @return auto 
+ */
+template <typename TLambda>
+[[nodiscard]] inline auto
+scope_exit(TLambda&& lambda) noexcept
+{
+    return details::lambda_call<TLambda>(std::forward<TLambda>(lambda));
+}
+
+/**
+ * @brief Name alias for scope_exit.
+ * 
+ * @tparam TLambda 
+ * @param lambda 
+ * @return auto 
+ */
+template <typename TLambda>
+[[nodiscard]] inline auto
+ScopeExit(TLambda&& lambda) noexcept
+{
+    return scope_exit(std::forward<TLambda>(lambda));
+}
+
+} // namespace notstd
+
+#endif // NOT_STD_SCOPE_HXX

--- a/src/linux/CMakeLists.txt
+++ b/src/linux/CMakeLists.txt
@@ -2,5 +2,6 @@
 add_subdirectory(external)
 add_subdirectory(libnl-helpers)
 add_subdirectory(server)
+add_subdirectory(tools)
 add_subdirectory(wifi)
 add_subdirectory(wpa-controller)

--- a/src/linux/CMakeLists.txt
+++ b/src/linux/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_subdirectory(external)
+add_subdirectory(libnl-helpers)
 add_subdirectory(server)
 add_subdirectory(wifi)
 add_subdirectory(wpa-controller)

--- a/src/linux/external/CMakeLists.txt
+++ b/src/linux/external/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 add_subdirectory(hostap)
-add_subdirectory(libmnl)
+add_subdirectory(libnl)

--- a/src/linux/external/CMakeLists.txt
+++ b/src/linux/external/CMakeLists.txt
@@ -1,2 +1,3 @@
 
 add_subdirectory(hostap)
+add_subdirectory(libmnl)

--- a/src/linux/external/libmnl/CMakeLists.txt
+++ b/src/linux/external/libmnl/CMakeLists.txt
@@ -1,13 +1,8 @@
 
 # Requires that libmnl development package is installed (libmnl-dev on ubuntu).
-find_library(LIBMNL mnl libmnl REQUIRED)
 find_path(LIBMNL_INCLUDE_DIR libmnl/libmnl.h REQUIRED)
 
-add_library(mnl-static STATIC IMPORTED)
-set_target_properties(mnl-static PROPERTIES IMPORTED_LOCATION ${LIBMNL})
-target_include_directories(mnl-static INTERFACE ${LIBMNL_INCLUDE_DIR})
-
-add_library(mnl-shared SHARED IMPORTED)
-add_library(mnl ALIAS mnl-shared)
-set_target_properties(mnl-shared PROPERTIES IMPORTED_LOCATION ${LIBMNL})
-target_include_directories(mnl-shared INTERFACE ${LIBMNL_INCLUDE_DIR})
+find_library(LIBMNL NAMES libmnl.a REQUIRED)
+add_library(mnl STATIC IMPORTED)
+set_target_properties(mnl PROPERTIES IMPORTED_LOCATION ${LIBMNL_STATIC}/libmnl.a)
+target_include_directories(mnl INTERFACE ${LIBMNL_INCLUDE_DIR})

--- a/src/linux/external/libmnl/CMakeLists.txt
+++ b/src/linux/external/libmnl/CMakeLists.txt
@@ -1,8 +1,0 @@
-
-# Requires that libmnl development package is installed (libmnl-dev on ubuntu).
-find_path(LIBMNL_INCLUDE_DIR libmnl/libmnl.h REQUIRED)
-
-find_library(LIBMNL NAMES libmnl.a REQUIRED)
-add_library(mnl STATIC IMPORTED)
-set_target_properties(mnl PROPERTIES IMPORTED_LOCATION ${LIBMNL_STATIC}/libmnl.a)
-target_include_directories(mnl INTERFACE ${LIBMNL_INCLUDE_DIR})

--- a/src/linux/external/libmnl/CMakeLists.txt
+++ b/src/linux/external/libmnl/CMakeLists.txt
@@ -1,0 +1,13 @@
+
+# Requires that libmnl development package is installed (libmnl-dev on ubuntu).
+find_library(LIBMNL mnl libmnl REQUIRED)
+find_path(LIBMNL_INCLUDE_DIR libmnl/libmnl.h REQUIRED)
+
+add_library(mnl-static STATIC IMPORTED)
+set_target_properties(mnl-static PROPERTIES IMPORTED_LOCATION ${LIBMNL})
+target_include_directories(mnl-static INTERFACE ${LIBMNL_INCLUDE_DIR})
+
+add_library(mnl-shared SHARED IMPORTED)
+add_library(mnl ALIAS mnl-shared)
+set_target_properties(mnl-shared PROPERTIES IMPORTED_LOCATION ${LIBMNL})
+target_include_directories(mnl-shared INTERFACE ${LIBMNL_INCLUDE_DIR})

--- a/src/linux/external/libnl/CMakeLists.txt
+++ b/src/linux/external/libnl/CMakeLists.txt
@@ -7,8 +7,23 @@ find_path(LIBNL_INCLUDE_DIR netlink/netlink.h
     REQUIRED
 )
 
+# libnl core
 find_library(LIBNL_STATIC NAMES libnl-3.a REQUIRED)
 add_library(nl STATIC IMPORTED GLOBAL)
 set_target_properties(nl PROPERTIES IMPORTED_LOCATION ${LIBNL_STATIC})
 set_target_properties(nl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBNL_INCLUDE_DIR})
 target_include_directories(nl INTERFACE ${LIBNL_INCLUDE_DIR})
+
+# libnl-genl
+find_library(LIBNL_GENL_STATIC NAMES libnl-genl-3.a REQUIRED)
+add_library(nl-genl STATIC IMPORTED GLOBAL)
+set_target_properties(nl-genl PROPERTIES IMPORTED_LOCATION ${LIBNL_GENL_STATIC})
+set_target_properties(nl-genl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBNL_INCLUDE_DIR})
+target_include_directories(nl-genl INTERFACE ${LIBNL_INCLUDE_DIR})
+
+# libnl-route
+find_library(LIBNL_ROUTE_STATIC NAMES libnl-route-3.a REQUIRED)
+add_library(nl-route STATIC IMPORTED GLOBAL)
+set_target_properties(nl-route PROPERTIES IMPORTED_LOCATION ${LIBNL_ROUTE_STATIC})
+set_target_properties(nl-route PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBNL_INCLUDE_DIR})
+target_include_directories(nl-route INTERFACE ${LIBNL_INCLUDE_DIR})

--- a/src/linux/external/libnl/CMakeLists.txt
+++ b/src/linux/external/libnl/CMakeLists.txt
@@ -1,0 +1,14 @@
+
+# Requires that libnl development package is installed (libnl-3-dev on ubuntu).
+find_path(LIBNL_INCLUDE_DIR netlink/netlink.h 
+    PATHS 
+        /usr/include/libnl3 
+        /usr/local/include/libnl3
+    REQUIRED
+)
+
+find_library(LIBNL_STATIC NAMES libnl-3.a REQUIRED)
+add_library(nl STATIC IMPORTED GLOBAL)
+set_target_properties(nl PROPERTIES IMPORTED_LOCATION ${LIBNL_STATIC}/libnl-3.a)
+set_target_properties(nl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBNL_INCLUDE_DIR})
+target_include_directories(nl INTERFACE ${LIBNL_INCLUDE_DIR})

--- a/src/linux/external/libnl/CMakeLists.txt
+++ b/src/linux/external/libnl/CMakeLists.txt
@@ -9,6 +9,6 @@ find_path(LIBNL_INCLUDE_DIR netlink/netlink.h
 
 find_library(LIBNL_STATIC NAMES libnl-3.a REQUIRED)
 add_library(nl STATIC IMPORTED GLOBAL)
-set_target_properties(nl PROPERTIES IMPORTED_LOCATION ${LIBNL_STATIC}/libnl-3.a)
+set_target_properties(nl PROPERTIES IMPORTED_LOCATION ${LIBNL_STATIC})
 set_target_properties(nl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBNL_INCLUDE_DIR})
 target_include_directories(nl INTERFACE ${LIBNL_INCLUDE_DIR})

--- a/src/linux/libnl-helpers/CMakeLists.txt
+++ b/src/linux/libnl-helpers/CMakeLists.txt
@@ -1,0 +1,30 @@
+
+add_library(libnl-helpers STATIC "")
+
+set(LIBNL_HELPERS_PUBLIC_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/include)
+set(LIBNL_HELPERS_PUBLIC_INCLUDE_SUFFIX microsoft/net/netlink)
+set(LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX ${LIBNL_HELPERS_PUBLIC_INCLUDE}/${LIBNL_HELPERS_PUBLIC_INCLUDE_SUFFIX})
+
+target_sources(libnl-helpers
+    PRIVATE
+        NetlinkSocket.cxx
+        NetlinkMessage.cxx
+    PUBLIC
+    FILE_SET HEADERS
+    BASE_DIRS ${LIBNL_HELPERS_PUBLIC_INCLUDE}
+    FILES
+        ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkMessage.hxx
+        ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkSocket.hxx
+)
+
+target_link_libraries(libnl-helpers
+    PUBLIC
+        nl
+)
+
+install(
+    TARGETS libnl-helpers
+    EXPORT ${PROJECT_NAME}
+    FILE_SET HEADERS
+    PUBLIC_HEADER DESTINATION "${NETREMOTE_DIR_INSTALL_PUBLIC_HEADER_BASE}/${LIBNL_HELPERS_PUBLIC_INCLUDE_SUFFIX}"
+)

--- a/src/linux/libnl-helpers/NetlinkMessage.cxx
+++ b/src/linux/libnl-helpers/NetlinkMessage.cxx
@@ -1,18 +1,16 @@
 
 #include <microsoft/net/netlink/NetlinkMessage.hxx>
-#include <netlink/msg.h>
 
 using namespace Microsoft::Net::Netlink;
 
-NetlinkMessage::NetlinkMessage(struct nl_msg *message)
-    : Message(message)
+NetlinkMessage::NetlinkMessage(struct nl_msg *message) :
+    Message(message)
 {
 }
 
 NetlinkMessage::~NetlinkMessage()
 {
-    if (Message != nullptr)
-    {
+    if (Message != nullptr) {
         nlmsg_free(Message);
         Message = nullptr;
     }
@@ -21,4 +19,10 @@ NetlinkMessage::~NetlinkMessage()
 NetlinkMessage::operator struct nl_msg *() const noexcept
 {
     return Message;
+}
+
+struct nlmsghdr *
+NetlinkMessage::Header() const noexcept
+{
+    return nlmsg_hdr(Message);
 }

--- a/src/linux/libnl-helpers/NetlinkMessage.cxx
+++ b/src/linux/libnl-helpers/NetlinkMessage.cxx
@@ -1,0 +1,24 @@
+
+#include <microsoft/net/netlink/NetlinkMessage.hxx>
+#include <netlink/msg.h>
+
+using namespace Microsoft::Net::Netlink;
+
+NetlinkMessage::NetlinkMessage(struct nl_msg *message)
+    : Message(message)
+{
+}
+
+NetlinkMessage::~NetlinkMessage()
+{
+    if (Message != nullptr)
+    {
+        nlmsg_free(Message);
+        Message = nullptr;
+    }
+}
+
+NetlinkMessage::operator struct nl_msg *() const noexcept
+{
+    return Message;
+}

--- a/src/linux/libnl-helpers/NetlinkMessage.cxx
+++ b/src/linux/libnl-helpers/NetlinkMessage.cxx
@@ -3,12 +3,36 @@
 
 using namespace Microsoft::Net::Netlink;
 
-NetlinkMessage::NetlinkMessage(struct nl_msg *message) :
+NetlinkMessage::NetlinkMessage(struct nl_msg* message) :
     Message(message)
 {
 }
 
+NetlinkMessage::NetlinkMessage(NetlinkMessage&& other) :
+    Message(other.Message)
+{
+    other.Message = nullptr;
+}
+
+NetlinkMessage&
+NetlinkMessage::operator=(NetlinkMessage&& other)
+{
+    if (this != &other) {
+        Reset();
+        Message = other.Message;
+        other.Message = nullptr;
+    }
+
+    return *this;
+}
+
 NetlinkMessage::~NetlinkMessage()
+{
+    Reset();
+}
+
+void
+NetlinkMessage::Reset()
 {
     if (Message != nullptr) {
         nlmsg_free(Message);
@@ -16,12 +40,20 @@ NetlinkMessage::~NetlinkMessage()
     }
 }
 
+struct nl_msg*
+NetlinkMessage::Release() noexcept
+{
+    auto message = Message;
+    Message = nullptr;
+    return message;
+}
+
 NetlinkMessage::operator struct nl_msg *() const noexcept
 {
     return Message;
 }
 
-struct nlmsghdr *
+struct nlmsghdr*
 NetlinkMessage::Header() const noexcept
 {
     return nlmsg_hdr(Message);

--- a/src/linux/libnl-helpers/NetlinkSocket.cxx
+++ b/src/linux/libnl-helpers/NetlinkSocket.cxx
@@ -48,6 +48,14 @@ NetlinkSocket::Reset()
     }
 }
 
+struct nl_sock*
+NetlinkSocket::Release() noexcept
+{
+    auto socket = Socket;
+    Socket = nullptr;
+    return socket;
+}
+
 NetlinkSocket::operator struct nl_sock *() const noexcept
 {
     return Socket;

--- a/src/linux/libnl-helpers/NetlinkSocket.cxx
+++ b/src/linux/libnl-helpers/NetlinkSocket.cxx
@@ -1,0 +1,23 @@
+
+#include <microsoft/net/netlink/NetlinkSocket.hxx>
+
+using namespace Microsoft::Net::Netlink;
+
+NetlinkSocket::NetlinkSocket(struct nl_sock *socket)
+    : Socket(socket)
+{
+}
+
+NetlinkSocket::~NetlinkSocket()
+{
+    if (Socket != nullptr)
+    {
+        nl_socket_free(Socket);
+        Socket = nullptr;
+    }
+}
+
+NetlinkSocket::operator struct nl_sock *() const noexcept
+{
+    return Socket;
+}

--- a/src/linux/libnl-helpers/NetlinkSocket.cxx
+++ b/src/linux/libnl-helpers/NetlinkSocket.cxx
@@ -4,21 +4,27 @@
 using namespace Microsoft::Net::Netlink;
 
 /* static */
-NetlinkSocket NetlinkSocket::Allocate()
+NetlinkSocket
+NetlinkSocket::Allocate()
 {
     auto socket = nl_socket_alloc();
     return NetlinkSocket{ socket };
 }
 
-NetlinkSocket::NetlinkSocket(struct nl_sock *socket)
-    : Socket(socket)
+NetlinkSocket::NetlinkSocket(struct nl_sock *socket) :
+    Socket(socket)
 {
 }
 
 NetlinkSocket::~NetlinkSocket()
 {
-    if (Socket != nullptr)
-    {
+    Reset();
+}
+
+void
+NetlinkSocket::Reset()
+{
+    if (Socket != nullptr) {
         nl_socket_free(Socket);
         Socket = nullptr;
     }

--- a/src/linux/libnl-helpers/NetlinkSocket.cxx
+++ b/src/linux/libnl-helpers/NetlinkSocket.cxx
@@ -11,9 +11,27 @@ NetlinkSocket::Allocate()
     return NetlinkSocket{ socket };
 }
 
-NetlinkSocket::NetlinkSocket(struct nl_sock *socket) :
+NetlinkSocket::NetlinkSocket(struct nl_sock* socket) :
     Socket(socket)
 {
+}
+
+NetlinkSocket::NetlinkSocket(NetlinkSocket&& other) :
+    Socket(other.Socket)
+{
+    other.Socket = nullptr;
+}
+
+NetlinkSocket&
+NetlinkSocket::operator=(NetlinkSocket&& other)
+{
+    if (this != &other) {
+        Reset();
+        Socket = other.Socket;
+        other.Socket = nullptr;
+    }
+
+    return *this;
 }
 
 NetlinkSocket::~NetlinkSocket()

--- a/src/linux/libnl-helpers/NetlinkSocket.cxx
+++ b/src/linux/libnl-helpers/NetlinkSocket.cxx
@@ -3,6 +3,13 @@
 
 using namespace Microsoft::Net::Netlink;
 
+/* static */
+NetlinkSocket NetlinkSocket::Allocate()
+{
+    auto socket = nl_socket_alloc();
+    return NetlinkSocket{ socket };
+}
+
 NetlinkSocket::NetlinkSocket(struct nl_sock *socket)
     : Socket(socket)
 {

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkMessage.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkMessage.hxx
@@ -2,6 +2,7 @@
 #ifndef MICROSOFT_NET_NETLINK_NETLINK_MESSAGE_HXX
 #define MICROSOFT_NET_NETLINK_NETLINK_MESSAGE_HXX
 
+#include <netlink/msg.h>
 #include <netlink/netlink.h>
 
 namespace Microsoft::Net::Netlink
@@ -27,8 +28,8 @@ struct NetlinkMessage
      * @brief Construct a new NetlinkMessage object that manages a pre-existing
      * struct nl_msg object. Note that once construction is complete, this
      * object owns the message and will free it when it is destroyed.
-     * 
-     * @param message The netlink message to manage. 
+     *
+     * @param message The netlink message to manage.
      */
     NetlinkMessage(struct nl_msg *message);
 
@@ -41,10 +42,18 @@ struct NetlinkMessage
     /**
      * @brief Implicit conversion operator to struct nl_msg *, allowing this
      * class to be used in netlink API calls.
-     * 
+     *
      * @return struct nl_msg * The netlink message managed by this object.
      */
     operator struct nl_msg *() const noexcept;
+
+    /**
+     * @brief Obtain the message header.
+     *
+     * @return struct nlmsghdr*
+     */
+    struct nlmsghdr *
+    Header() const noexcept;
 };
 } // namespace Microsoft::Net::Netlink
 

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkMessage.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkMessage.hxx
@@ -16,7 +16,7 @@ struct NetlinkMessage
     /**
      * @brief The netlink message owned by this object.
      */
-    struct nl_msg *Message{ nullptr };
+    struct nl_msg* Message{ nullptr };
 
     /**
      * @brief Construct a new NetlinkMessage object that does not own a netlink
@@ -31,13 +31,57 @@ struct NetlinkMessage
      *
      * @param message The netlink message to manage.
      */
-    NetlinkMessage(struct nl_msg *message);
+    NetlinkMessage(struct nl_msg* message);
+
+    /**
+     * @brief Delete the copy constructor to enforce unique ownership.
+     */
+    NetlinkMessage(const NetlinkMessage&) = delete;
+
+    /**
+     * @brief Delete the copy assignment operator to enforce unique ownership.
+     *
+     * @return NetlinkMessage&
+     */
+    NetlinkMessage&
+    operator=(const NetlinkMessage&) = delete;
+
+    /**
+     * @brief Move-construct a new NetlinkMessage object. This takes ownership of
+     * the other instance.
+     *
+     * @param other The other instance to move from.
+     */
+    NetlinkMessage(NetlinkMessage&& other);
+
+    /**
+     * @brief Move-assign this instance from another instance. This takes
+     * ownership of the other instance.
+     *
+     * @param other The other instance to move from.
+     * @return NetlinkMessage&
+     */
+    NetlinkMessage&
+    operator=(NetlinkMessage&& other);
 
     /**
      * @brief Destroy the NetlinkMessage object, freeing the managed netlink
      * message if it exists.
      */
     ~NetlinkMessage();
+
+    /**
+     * @brief Reset the managed netlink message, freeing it if it exists.
+     */
+    void
+    Reset();
+
+    /**
+     * @brief Release ownership of the managed netlink message, returning it to
+     * the caller.
+     */
+    struct nl_msg*
+    Release() noexcept;
 
     /**
      * @brief Implicit conversion operator to struct nl_msg *, allowing this
@@ -52,7 +96,7 @@ struct NetlinkMessage
      *
      * @return struct nlmsghdr*
      */
-    struct nlmsghdr *
+    struct nlmsghdr*
     Header() const noexcept;
 };
 } // namespace Microsoft::Net::Netlink

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkMessage.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkMessage.hxx
@@ -1,0 +1,20 @@
+
+#ifndef MICROSOFT_NET_NETLINK_NETLINK_MESSAGE_HXX
+#define MICROSOFT_NET_NETLINK_NETLINK_MESSAGE_HXX
+
+#include <netlink/netlink.h>
+
+namespace Microsoft::Net::Netlink
+{
+struct NetlinkMessage
+{
+    struct nl_msg *Message{ nullptr };
+
+    NetlinkMessage(struct nl_msg *message);
+    ~NetlinkMessage();
+
+    operator struct nl_msg *() const noexcept;
+};
+} // namespace Microsoft::Net::Netlink
+
+#endif // MICROSOFT_NET_NETLINK_NETLINK_MESSAGE_HXX

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkMessage.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkMessage.hxx
@@ -6,13 +6,44 @@
 
 namespace Microsoft::Net::Netlink
 {
+/**
+ * @brief Heler for managing a netlink message, struct nl_msg. This class is not
+ * thread-safe.
+ */
 struct NetlinkMessage
 {
+    /**
+     * @brief The netlink message owned by this object.
+     */
     struct nl_msg *Message{ nullptr };
 
+    /**
+     * @brief Construct a new NetlinkMessage object that does not own a netlink
+     * message object.
+     */
+    NetlinkMessage() = default;
+
+    /**
+     * @brief Construct a new NetlinkMessage object that manages a pre-existing
+     * struct nl_msg object. Note that once construction is complete, this
+     * object owns the message and will free it when it is destroyed.
+     * 
+     * @param message The netlink message to manage. 
+     */
     NetlinkMessage(struct nl_msg *message);
+
+    /**
+     * @brief Destroy the NetlinkMessage object, freeing the managed netlink
+     * message if it exists.
+     */
     ~NetlinkMessage();
 
+    /**
+     * @brief Implicit conversion operator to struct nl_msg *, allowing this
+     * class to be used in netlink API calls.
+     * 
+     * @return struct nl_msg * The netlink message managed by this object.
+     */
     operator struct nl_msg *() const noexcept;
 };
 } // namespace Microsoft::Net::Netlink

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
@@ -2,6 +2,7 @@
 #ifndef MICROSOFT_NET_NETLINK_NETLINK_SOCKET_HXX
 #define MICROSOFT_NET_NETLINK_NETLINK_SOCKET_HXX
 
+#include <netlink/socket.h>
 #include <netlink/netlink.h>
 
 namespace Microsoft::Net::Netlink

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
@@ -6,13 +6,51 @@
 
 namespace Microsoft::Net::Netlink
 {
+/**
+ * @brief Helper for managing a netlink socket, struct nl_sock. This class is
+ * not thread-safe.
+ */
 struct NetlinkSocket
 {
+    /**
+     * @brief The netlink socket owned by this object.
+     */
     struct nl_sock *Socket{ nullptr };
 
+    /**
+     * @brief Allocate a new struct nl_sock, and wrap it in a NetlinkSocket.
+     * 
+     * @return NetlinkSocket 
+     */
+    static NetlinkSocket Allocate();
+
+    /**
+     * @brief Construct a default NetlinkSocket object that does not own a
+     * netlink socket object.
+     */
+    NetlinkSocket() = default;
+
+    /**
+     * @brief Construct a new NetlinkSocket that manages a pre-existing struct
+     * nl_sock object. Note that once construction is complete, this object owns
+     * the socket and will free it when it is destroyed.
+     * 
+     * @param socket The netlink socket to manage.
+     */
     NetlinkSocket(struct nl_sock *socket);
+
+    /**
+     * @brief Destroy the NetlinkSocket object, freeing the managed netlink
+     * socket if it exists.
+     */
     ~NetlinkSocket();
 
+    /**
+     * @brief Implicit conversion operator to struct nl_sock *, allowing this
+     * class to be used in netlink API calls.
+     * 
+     * @return struct nl_sock * The netlink socket managed by this object.
+     */
     operator struct nl_sock *() const noexcept;
 };
 } // namespace Microsoft::Net::Netlink

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
@@ -15,7 +15,7 @@ struct NetlinkSocket
     /**
      * @brief The netlink socket owned by this object.
      */
-    struct nl_sock *Socket{ nullptr };
+    struct nl_sock* Socket{ nullptr };
 
     /**
      * @brief Allocate a new struct nl_sock, and wrap it in a NetlinkSocket.
@@ -32,19 +32,50 @@ struct NetlinkSocket
     NetlinkSocket() = default;
 
     /**
+     * @brief Delete the copy constructor to enforce unique ownership.
+     */
+    NetlinkSocket(const NetlinkSocket&) = delete;
+
+    /**
+     * @brief Delete the copy assignment operator to enforce unique ownership.
+     *
+     * @return NetlinkSocket&
+     */
+    NetlinkSocket&
+    operator=(const NetlinkSocket&) = delete;
+
+    /**
+     * @brief Move-construct a new NetlinkSocket object. This takes ownership of
+     * the other instance.
+     *
+     * @param other The other instance to move from.
+     */
+    NetlinkSocket(NetlinkSocket&& other);
+
+    /**
+     * @brief Move-assign this instance from another instance. This takes
+     * ownership of the other instance.
+     *
+     * @param other The other instance to move from.
+     * @return NetlinkSocket&
+     */
+    NetlinkSocket&
+    operator=(NetlinkSocket&& other);
+
+    /**
      * @brief Construct a new NetlinkSocket that manages a pre-existing struct
      * nl_sock object. Note that once construction is complete, this object owns
      * the socket and will free it when it is destroyed.
      *
      * @param socket The netlink socket to manage.
      */
-    NetlinkSocket(struct nl_sock *socket);
+    NetlinkSocket(struct nl_sock* socket);
 
     /**
      * @brief Destroy the NetlinkSocket object, freeing the managed netlink
      * socket if it exists.
      */
-    ~NetlinkSocket();
+    virtual ~NetlinkSocket();
 
     /**
      * @brief Reset the managed netlink socket, freeing it if it exists.

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
@@ -84,6 +84,13 @@ struct NetlinkSocket
     Reset();
 
     /**
+     * @brief Release ownership of the managed netlink socket, returning it to
+     * the caller.
+     */
+    struct nl_sock*
+    Release() noexcept;
+
+    /**
      * @brief Implicit conversion operator to struct nl_sock *, allowing this
      * class to be used in netlink API calls.
      *

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
@@ -1,0 +1,20 @@
+
+#ifndef MICROSOFT_NET_NETLINK_NETLINK_SOCKET_HXX
+#define MICROSOFT_NET_NETLINK_NETLINK_SOCKET_HXX
+
+#include <netlink/netlink.h>
+
+namespace Microsoft::Net::Netlink
+{
+struct NetlinkSocket
+{
+    struct nl_sock *Socket{ nullptr };
+
+    NetlinkSocket(struct nl_sock *socket);
+    ~NetlinkSocket();
+
+    operator struct nl_sock *() const noexcept;
+};
+} // namespace Microsoft::Net::Netlink
+
+#endif // MICROSOFT_NET_NETLINK_NETLINK_SOCKET_HXX

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
@@ -19,10 +19,11 @@ struct NetlinkSocket
 
     /**
      * @brief Allocate a new struct nl_sock, and wrap it in a NetlinkSocket.
-     * 
-     * @return NetlinkSocket 
+     *
+     * @return NetlinkSocket
      */
-    static NetlinkSocket Allocate();
+    static NetlinkSocket
+    Allocate();
 
     /**
      * @brief Construct a default NetlinkSocket object that does not own a
@@ -34,7 +35,7 @@ struct NetlinkSocket
      * @brief Construct a new NetlinkSocket that manages a pre-existing struct
      * nl_sock object. Note that once construction is complete, this object owns
      * the socket and will free it when it is destroyed.
-     * 
+     *
      * @param socket The netlink socket to manage.
      */
     NetlinkSocket(struct nl_sock *socket);
@@ -46,9 +47,15 @@ struct NetlinkSocket
     ~NetlinkSocket();
 
     /**
+     * @brief Reset the managed netlink socket, freeing it if it exists.
+     */
+    void
+    Reset();
+
+    /**
      * @brief Implicit conversion operator to struct nl_sock *, allowing this
      * class to be used in netlink API calls.
-     * 
+     *
      * @return struct nl_sock * The netlink socket managed by this object.
      */
     operator struct nl_sock *() const noexcept;

--- a/src/linux/tools/CMakeLists.txt
+++ b/src/linux/tools/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_subdirectory(apmonitor)

--- a/src/linux/tools/apmonitor/CMakeLists.txt
+++ b/src/linux/tools/apmonitor/CMakeLists.txt
@@ -1,0 +1,19 @@
+
+add_executable(apmonitor-cli-linux)
+
+target_sources(apmonitor-cli-linux
+    PRIVATE
+        Main.cxx
+)
+
+target_link_libraries(apmonitor-cli-linux
+    PRIVATE
+        plog::plog
+        wifi-apmanager-linux
+        wifi-apmonitor
+)
+
+set_target_properties(apmonitor-cli-linux
+    PROPERTIES
+        OUTPUT_NAME apmonitor
+)

--- a/src/linux/tools/apmonitor/CMakeLists.txt
+++ b/src/linux/tools/apmonitor/CMakeLists.txt
@@ -10,7 +10,6 @@ target_link_libraries(apmonitor-cli-linux
     PRIVATE
         plog::plog
         wifi-apmanager-linux
-        wifi-apmonitor
 )
 
 set_target_properties(apmonitor-cli-linux

--- a/src/linux/tools/apmonitor/Main.cxx
+++ b/src/linux/tools/apmonitor/Main.cxx
@@ -1,0 +1,55 @@
+
+#include <format>
+
+#include <magic_enum.hpp>
+#include <microsoft/net/wifi/IAccessPoint.hxx>
+#include <microsoft/net/wifi/AccessPointDiscoveryAgent.hxx>
+#include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
+#include <plog/Appenders/ColorConsoleAppender.h>
+#include <plog/Formatters/MessageOnlyFormatter.h>
+#include <plog/Init.h>
+#include <plog/Log.h>
+#include <signal.h>
+
+using Microsoft::Net::Wifi::AccessPointDiscoveryAgent;
+using Microsoft::Net::Wifi::IAccessPointDiscoveryAgentOperations;
+using Microsoft::Net::Wifi::AccessPointDiscoveryAgentOperationsNetlink;
+
+int
+main([[maybe_unused]] int argc, [[maybe_unused]] char *argv[])
+{
+    // Configure console logging.
+    static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
+    plog::init(plog::verbose, &colorConsoleAppender);
+
+    // Configure monitoring with the netlink protocol.
+    auto accessPointDiscoveryAgentOperationsNetlink{ std::make_unique<AccessPointDiscoveryAgentOperationsNetlink>() };
+    auto accessPointDiscoveryAgent{ AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperationsNetlink)) };
+    accessPointDiscoveryAgent->RegisterDiscoveryEventCallback([](auto&& presence, auto&& accessPointChanged) {
+        PLOG_INFO << std::format("{} {}", magic_enum::enum_name(presence), accessPointChanged != nullptr ? accessPointChanged->GetInterface() : "<unknown>");
+    });
+
+    LOG_INFO << "starting access point discovery agent";
+    accessPointDiscoveryAgent->Start();
+
+    // Mask SIGTERM and SIGINT so they can be explicitly waited on from the main thread.
+    int signal;
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGTERM);
+    sigaddset(&mask, SIGINT);
+
+    if (sigprocmask(SIG_BLOCK, &mask, nullptr) < 0) {
+        LOG_ERROR << "failed to block terminate signals";
+        return -1;
+    }
+
+    // Wait for the process to be signaled to exit.
+    while (sigwait(&mask, &signal) != 0)
+        ;
+
+    // Received interrupt or terminate signal, so shut down.
+    accessPointDiscoveryAgent->Stop();
+
+    return 0;
+}

--- a/src/linux/wifi/CMakeLists.txt
+++ b/src/linux/wifi/CMakeLists.txt
@@ -1,2 +1,3 @@
 
+add_subdirectory(apmanager)
 add_subdirectory(core)

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -58,7 +58,14 @@ AccessPointDiscoveryAgentOperationsNetlink::Stop()
 std::future<std::vector<std::shared_ptr<IAccessPoint>>>
 AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync()
 {
-    return {};
+    std::promise<std::vector<std::shared_ptr<IAccessPoint>>> probePromise{};
+    auto probeFuture = probePromise.get_future();
+
+    // TODO: implement this.
+    std::vector<std::shared_ptr<IAccessPoint>> accessPoints{};
+    probePromise.set_value(std::move(accessPoints));
+
+    return probeFuture;
 }
 
 void

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -1,0 +1,20 @@
+
+#include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
+
+using namespace Microsoft::Net::Wifi;
+
+void
+AccessPointDiscoveryAgentOperationsNetlink::Start([[maybe_unused]] AccessPointPresenceEventCallback callback)
+{
+}
+
+void
+AccessPointDiscoveryAgentOperationsNetlink::Stop()
+{
+}
+
+std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync()
+{
+    return {};
+}

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -92,7 +92,7 @@ AccessPointDiscoveryAgentOperationsNetlink::Start(AccessPointPresenceEventCallba
     // Update the access point presence callback for the netlink message handler to use.
     // Note: This is not thread-safe.
     m_accessPointPresenceCallback = std::move(accessPointPresenceEventCallback);
-    m_netlinkMessageProcessingThread = std::jthread([this, netlinkSocket = std::move(netlinkSocket)](std::stop_token stopToken) {
+    m_netlinkMessageProcessingThread = std::jthread([this, netlinkSocket = std::move(netlinkSocket)](std::stop_token stopToken) mutable {
         ProcessNetlinkMessagesThread(std::move(netlinkSocket), std::move(stopToken));
     });
 }

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -285,8 +285,8 @@ AccessPointDiscoveryAgentOperationsNetlink::ProcessNetlinkMessagesThread(Netlink
         }
 
         // Wait for at least one event file descriptor to become ready.
-        int numEvents = epoll_wait(fdEpoll, events, EpollEventsMax, -1);
-        if (numEvents < 0) {
+        int numEventsReady = epoll_wait(fdEpoll, events, EpollEventsMax, -1);
+        if (numEventsReady < 0) {
             const auto err = errno;
             if (err == EINTR) {
                 LOG_VERBOSE << "Interrupted while waiting for epoll events, retrying";
@@ -298,7 +298,7 @@ AccessPointDiscoveryAgentOperationsNetlink::ProcessNetlinkMessagesThread(Netlink
         }
 
         // Determine which file descriptor(s) became ready and handle them.
-        for (auto i = 0; i < EpollEventsMax; i++) {
+        for (auto i = 0; i < numEventsReady; i++) {
             const auto &eventReady = events[i];
             if (eventReady.data.fd == netlinkSocketFileDescriptor) {
                 HandleNetlinkSocketReady(netlinkSocket);

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -1,20 +1,68 @@
 
+#include <cerrno>
+#include <format>
+
+#include <linux/rtnetlink.h>
 #include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
+#include <notstd/Scope.hxx>
+#include <plog/Log.h>
 
 using namespace Microsoft::Net::Wifi;
 
 void
-AccessPointDiscoveryAgentOperationsNetlink::Start([[maybe_unused]] AccessPointPresenceEventCallback callback)
+AccessPointDiscoveryAgentOperationsNetlink::Start(AccessPointPresenceEventCallback callback)
 {
+    // Don't start a new thread if one is already running.
+    if (m_netlinkThread.joinable()) {
+        return;
+    }
+
+    // Open a new netlink socket with the routing/networking family group.
+    auto* netlinkSocket = mnl_socket_open(NETLINK_ROUTE);
+    if (netlinkSocket == nullptr) {
+        // TODO: this function needs to signal the error either through its return type, or an exception.
+        const auto err = errno;
+        LOG_ERROR << std::format("Failed to open netlink socket with error %d (%s)", err, strerror(err));
+        return;
+    }
+
+    auto closeSocketOnFailure = notstd::ScopeExit([&netlinkSocket]() {
+        mnl_socket_close(netlinkSocket);
+    });
+
+    // Find the socket to the link group of messages.
+    const auto bindResult = mnl_socket_bind(netlinkSocket, RTMGRP_LINK, MNL_SOCKET_AUTOPID);
+    if (bindResult < 0) {
+        const auto err = errno;
+        LOG_ERROR << std::format("Failed to bind netlink socket with error %d (%s)", err, strerror(err));
+        return;
+    }
+
+    closeSocketOnFailure.release();
+
+    // Start a thread to process netlink messages.
+    m_netlinkThread = std::jthread([this, netlinkSocket, callback = std::move(callback)](std::stop_token stopToken) {
+        ProcessNetlinkMessages(netlinkSocket, std::move(callback), stopToken);
+    });
 }
 
 void
 AccessPointDiscoveryAgentOperationsNetlink::Stop()
 {
+    if (m_netlinkThread.joinable()) {
+        m_netlinkThread.request_stop();
+        m_netlinkThread.join();
+    }
 }
 
 std::future<std::vector<std::shared_ptr<IAccessPoint>>>
 AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync()
 {
     return {};
+}
+
+void
+AccessPointDiscoveryAgentOperationsNetlink::ProcessNetlinkMessages([[maybe_unused]] mnl_socket* netlinkSocket, [[maybe_unused]] AccessPointPresenceEventCallback callback, [[maybe_unused]] std::stop_token stopToken)
+{
+    // TODO:
 }

--- a/src/linux/wifi/apmanager/CMakeLists.txt
+++ b/src/linux/wifi/apmanager/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(wifi-apmanager-linux
     PRIVATE
         mnl-static
         notstd
+        plog::plog
     PUBLIC
         wifi-apmanager
         wifi-core

--- a/src/linux/wifi/apmanager/CMakeLists.txt
+++ b/src/linux/wifi/apmanager/CMakeLists.txt
@@ -17,10 +17,10 @@ target_sources(wifi-apmanager-linux
 
 target_link_libraries(wifi-apmanager-linux
     PRIVATE
-        mnl
         notstd
         plog::plog
     PUBLIC
+        nl
         wifi-apmanager
         wifi-core
 )

--- a/src/linux/wifi/apmanager/CMakeLists.txt
+++ b/src/linux/wifi/apmanager/CMakeLists.txt
@@ -1,0 +1,31 @@
+
+add_library(wifi-apmanager-linux STATIC "")
+
+set(WIFI_APMANAGER_LINUX_PUBLIC_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/include)
+set(WIFI_APMANAGER_LINUX_PUBLIC_INCLUDE_SUFFIX microsoft/net/wifi)
+set(WIFI_APMANAGER_LINUX_PUBLIC_INCLUDE_PREFIX ${WIFI_APMANAGER_LINUX_PUBLIC_INCLUDE}/${WIFI_APMANAGER_LINUX_PUBLIC_INCLUDE_SUFFIX})
+
+target_sources(wifi-apmanager-linux
+    PRIVATE
+        AccessPointDiscoveryAgentOperationsNetlink.cxx
+    PUBLIC
+    FILE_SET HEADERS
+    BASE_DIRS ${WIFI_APMANAGER_LINUX_PUBLIC_INCLUDE}
+    FILES
+        ${WIFI_APMANAGER_LINUX_PUBLIC_INCLUDE_PREFIX}/AccessPointDiscoveryAgentOperationsNetlink.hxx
+)
+
+target_link_libraries(wifi-apmanager-linux
+    PRIVATE
+        notstd
+    PUBLIC
+        wifi-apmanager
+        wifi-core
+)
+
+install(
+    TARGETS wifi-apmanager-linux
+    EXPORT ${PROJECT_NAME}
+    FILE_SET HEADERS
+    PUBLIC_HEADER DESTINATION "${NETREMOTE_DIR_INSTALL_PUBLIC_HEADER_BASE}/${WIFI_APMANAGER_LINUX_PUBLIC_INCLUDE_SUFFIX}"
+)

--- a/src/linux/wifi/apmanager/CMakeLists.txt
+++ b/src/linux/wifi/apmanager/CMakeLists.txt
@@ -17,10 +17,10 @@ target_sources(wifi-apmanager-linux
 
 target_link_libraries(wifi-apmanager-linux
     PRIVATE
-        notstd
+        nl
         plog::plog
     PUBLIC
-        nl
+        libnl-helpers
         wifi-apmanager
         wifi-core
 )

--- a/src/linux/wifi/apmanager/CMakeLists.txt
+++ b/src/linux/wifi/apmanager/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(wifi-apmanager-linux
 target_link_libraries(wifi-apmanager-linux
     PRIVATE
         nl
+        notstd
         plog::plog
     PUBLIC
         libnl-helpers

--- a/src/linux/wifi/apmanager/CMakeLists.txt
+++ b/src/linux/wifi/apmanager/CMakeLists.txt
@@ -17,7 +17,7 @@ target_sources(wifi-apmanager-linux
 
 target_link_libraries(wifi-apmanager-linux
     PRIVATE
-        mnl-static
+        mnl
         notstd
         plog::plog
     PUBLIC

--- a/src/linux/wifi/apmanager/CMakeLists.txt
+++ b/src/linux/wifi/apmanager/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(wifi-apmanager-linux
 
 target_link_libraries(wifi-apmanager-linux
     PRIVATE
+        mnl-static
         notstd
     PUBLIC
         wifi-apmanager

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -72,22 +72,12 @@ private:
     ProcessNetlinkMessagesCallback(struct nl_msg *netlinkMessage, void *contextArgument);
 
     /**
-     * @brief Process a series of netlink messages.
-     *
-     * @param netlinkMessage The first/parent netlink message to process.
-     * @param accessPointPresenceEventCallback The callback to invoke when an access point presence event occurs.
-     * @return int
-     */
-    int
-    ProcessNetlinkMessages(struct nl_msg *netlinkMessage, AccessPointPresenceEventCallback &accessPointPresenceEventCallback);
-
-    /**
      * @brief Process a single netlink message.
      *
      * @param netlinkMessage The netlink message to process.
      * @param accessPointPresenceEventCallback The callback to invoke when an access point presence event occurs.
      */
-    void
+    int
     ProcessNetlinkMessage(struct nl_msg *netlinkMessage, AccessPointPresenceEventCallback &accessPointPresenceEventCallback);
 
 private:

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -2,6 +2,10 @@
 #ifndef ACCESS_POINT_DISCOVERY_AGENT_OPERATIONS_NETLINK_HXX
 #define ACCESS_POINT_DISCOVERY_AGENT_OPERATIONS_NETLINK_HXX
 
+#include <stop_token>
+#include <thread>
+
+#include <libmnl/libmnl.h>
 #include <microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx>
 
 namespace Microsoft::Net::Wifi
@@ -9,6 +13,8 @@ namespace Microsoft::Net::Wifi
 /**
  * @brief Access point discovery agent operations that use netlink for
  * discovering devices and monitoring device presence.
+ * 
+ * Note that this class is not thread-safe.
  */
 struct AccessPointDiscoveryAgentOperationsNetlink :
     public IAccessPointDiscoveryAgentOperations
@@ -21,6 +27,13 @@ struct AccessPointDiscoveryAgentOperationsNetlink :
 
     std::future<std::vector<std::shared_ptr<IAccessPoint>>>
     ProbeAsync() override;
+
+private:
+    void
+    ProcessNetlinkMessages(mnl_socket* netlinkSocket, AccessPointPresenceEventCallback callback, std::stop_token stopToken);
+
+private:
+    std::jthread m_netlinkThread;
 };
 } // namespace Microsoft::Net::Wifi
 

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -44,15 +44,15 @@ private:
 
     /**
      * @brief Handles when the netlink socket is ready for reading.
-     * 
+     *
      * @param netlinkSocket The netlink socket that is ready for reading.
      */
     void
-    HandleNetlinkSocketReady(Microsoft::Net::Netlink::NetlinkSocket& netlinkSocket);
+    HandleNetlinkSocketReady(Microsoft::Net::Netlink::NetlinkSocket &netlinkSocket);
 
     /**
      * @brief Thread function for processing netlink messages.
-     * 
+     *
      * @param netlinkSocket The netlink socket to use for processing messages.
      * @param stopToken The stop token to use for stopping the thread.
      */
@@ -79,7 +79,7 @@ private:
      * @return int
      */
     int
-    ProcessNetlinkMessages(Microsoft::Net::Netlink::NetlinkMessage &netlinkMessage, AccessPointPresenceEventCallback &accessPointPresenceEventCallback);
+    ProcessNetlinkMessages(struct nl_msg *netlinkMessage, AccessPointPresenceEventCallback &accessPointPresenceEventCallback);
 
     /**
      * @brief Process a single netlink message.
@@ -88,7 +88,7 @@ private:
      * @param accessPointPresenceEventCallback The callback to invoke when an access point presence event occurs.
      */
     void
-    ProcessNetlinkMessage(Microsoft::Net::Netlink::NetlinkMessage &netlinkMessage, AccessPointPresenceEventCallback &accessPointPresenceEventCallback);
+    ProcessNetlinkMessage(struct nl_msg *netlinkMessage, AccessPointPresenceEventCallback &accessPointPresenceEventCallback);
 
 private:
     // Cookie used to validate that the callback context is valid.

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -1,0 +1,27 @@
+
+#ifndef ACCESS_POINT_DISCOVERY_AGENT_OPERATIONS_NETLINK_HXX
+#define ACCESS_POINT_DISCOVERY_AGENT_OPERATIONS_NETLINK_HXX
+
+#include <microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx>
+
+namespace Microsoft::Net::Wifi
+{
+/**
+ * @brief Access point discovery agent operations that use netlink for
+ * discovering devices and monitoring device presence.
+ */
+struct AccessPointDiscoveryAgentOperationsNetlink :
+    public IAccessPointDiscoveryAgentOperations
+{
+    void
+    Start(AccessPointPresenceEventCallback callback) override;
+
+    void
+    Stop() override;
+
+    std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+    ProbeAsync() override;
+};
+} // namespace Microsoft::Net::Wifi
+
+#endif // ACCESS_POINT_DISCOVERY_AGENT_OPERATIONS_NETLINK_HXX

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -2,25 +2,30 @@
 #ifndef ACCESS_POINT_DISCOVERY_AGENT_OPERATIONS_NETLINK_HXX
 #define ACCESS_POINT_DISCOVERY_AGENT_OPERATIONS_NETLINK_HXX
 
-#include <stop_token>
-#include <thread>
+#include <cstdint>
 
-#include <libmnl/libmnl.h>
+#include <microsoft/net/netlink/NetlinkMessage.hxx>
+#include <microsoft/net/netlink/NetlinkSocket.hxx>
 #include <microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx>
+#include <netlink/netlink.h>
 
 namespace Microsoft::Net::Wifi
 {
 /**
  * @brief Access point discovery agent operations that use netlink for
  * discovering devices and monitoring device presence.
- * 
+ *
  * Note that this class is not thread-safe.
  */
 struct AccessPointDiscoveryAgentOperationsNetlink :
     public IAccessPointDiscoveryAgentOperations
 {
+    AccessPointDiscoveryAgentOperationsNetlink();
+
+    virtual ~AccessPointDiscoveryAgentOperationsNetlink();
+
     void
-    Start(AccessPointPresenceEventCallback callback) override;
+    Start(AccessPointPresenceEventCallback accessPointPresenceEventCallback) override;
 
     void
     Stop() override;
@@ -29,11 +34,37 @@ struct AccessPointDiscoveryAgentOperationsNetlink :
     ProbeAsync() override;
 
 private:
-    void
-    ProcessNetlinkMessages(mnl_socket* netlinkSocket, AccessPointPresenceEventCallback callback, std::stop_token stopToken);
+    /**
+     * @brief C-style function for use with netlink message callbacks.
+     *
+     * @param netlinkMessage The netlink message being processed.
+     * @param contextArgument The callback context argument. This must be a
+     * pointer to the class instance (AccessPointDiscoveryAgentOperationsNetlink*)
+     * which owns the callback.
+     * @return int
+     */
+    static int
+    ProcessNetlinkMessagesCallback(struct nl_msg *netlinkMessage, void *contextArgument);
+
+    /**
+     * @brief Process a netlink message.
+     *
+     * @param netlinkMessage The netlink message to process.
+     * @param accessPointPresenceEventCallback The callback to invoke when an access point presence event occurs.
+     * @return int
+     */
+    int
+    ProcessNetlinkMessage(Microsoft::Net::Netlink::NetlinkMessage &netlinkMessage, AccessPointPresenceEventCallback &accessPointPresenceEventCallback);
 
 private:
-    std::jthread m_netlinkThread;
+    // Cookie used to validate that the callback context is valid.
+    static constexpr uint32_t CookieValid{ 0x8BADF00Du };
+    // Cookie used to invalidate the callback context.
+    static constexpr uint32_t CookieInvalid{ 0xDEADBEEFu };
+
+    uint32_t m_cookie{ CookieInvalid };
+    AccessPointPresenceEventCallback m_accessPointPresenceCallback{ nullptr };
+    Microsoft::Net::Netlink::NetlinkSocket m_netlinkSocket;
 };
 } // namespace Microsoft::Net::Wifi
 

--- a/tests/unit/linux/wifi/CMakeLists.txt
+++ b/tests/unit/linux/wifi/CMakeLists.txt
@@ -1,2 +1,3 @@
 
+add_subdirectory(apmanager)
 add_subdirectory(core)

--- a/tests/unit/linux/wifi/apmanager/CMakeLists.txt
+++ b/tests/unit/linux/wifi/apmanager/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(wifi-apmanager-linux-test-unit)
 
 target_sources(wifi-apmanager-linux-test-unit
     PRIVATE
+        Main.cxx
         TestAccessPointDiscoveryAgentOperationsNetlink.cxx
 )
 
@@ -13,8 +14,9 @@ target_include_directories(wifi-apmanager-linux-test-unit
 
 target_link_libraries(wifi-apmanager-linux-test-unit
     PRIVATE
-        Catch2::Catch2WithMain
+        Catch2::Catch2
         magic_enum::magic_enum
+        plog::plog
         strings
         wifi-apmanager-linux
 )

--- a/tests/unit/linux/wifi/apmanager/CMakeLists.txt
+++ b/tests/unit/linux/wifi/apmanager/CMakeLists.txt
@@ -1,0 +1,22 @@
+
+add_executable(wifi-apmanager-linux-test-unit)
+
+target_sources(wifi-apmanager-linux-test-unit
+    PRIVATE
+        TestAccessPointDiscoveryAgentOperationsNetlink.cxx
+)
+
+target_include_directories(wifi-apmanager-linux-test-unit
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(wifi-apmanager-linux-test-unit
+    PRIVATE
+        Catch2::Catch2WithMain
+        magic_enum::magic_enum
+        strings
+        wifi-apmanager-linux
+)
+
+catch_discover_tests(wifi-apmanager-linux-test-unit)

--- a/tests/unit/linux/wifi/apmanager/Main.cxx
+++ b/tests/unit/linux/wifi/apmanager/Main.cxx
@@ -1,0 +1,15 @@
+
+#include <catch2/catch_session.hpp>
+#include <plog/Appenders/ColorConsoleAppender.h>
+#include <plog/Formatters/MessageOnlyFormatter.h>
+#include <plog/Init.h>
+#include <plog/Log.h>
+
+int main(int argc, char* argv[])
+{
+    static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
+
+    plog::init(plog::verbose, &colorConsoleAppender);
+
+    return Catch::Session().run(argc, argv);
+}

--- a/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -1,0 +1,28 @@
+
+#include <optional>
+#include <utility>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
+
+TEST_CASE("Create AccessPointDiscoveryAgentOperationsNetlink", "[wifi][core][apmanager]")
+{
+    SECTION("Create doesn't cause a crash")
+    {
+        using namespace Microsoft::Net::Wifi;
+
+        REQUIRE_NOTHROW(AccessPointDiscoveryAgentOperationsNetlink{});
+    }
+}
+
+TEST_CASE("Destroy AccessPointDiscoveryAgentOperationsNetlink", "[wifi][core][apmanager]")
+{
+    using namespace Microsoft::Net::Wifi;
+
+    SECTION("Destroy doesn't cause a crash")
+    {
+        std::optional<AccessPointDiscoveryAgentOperationsNetlink> accessPointDiscoveryAgent(std::in_place);
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.reset());
+    }
+}

--- a/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -130,4 +130,16 @@ TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync", "[wifi][core
         accessPointDiscoveryAgent.Start(nullptr);
         REQUIRE(accessPointDiscoveryAgent.ProbeAsync().valid());
     }
+
+    SECTION("ProbeAsync result can be obtained without causing a crash")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync().get());
+    }
+
+    SECTION("ProbeAsync result is valid")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync().get().clear());
+    }
 }

--- a/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -26,3 +26,101 @@ TEST_CASE("Destroy AccessPointDiscoveryAgentOperationsNetlink", "[wifi][core][ap
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.reset());
     }
 }
+
+TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::Start", "[wifi][core][apmanager]")
+{
+    using namespace Microsoft::Net::Wifi;
+
+    SECTION("Start doesn't cause a crash")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent;
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.Start([](auto &&, auto &&) {}));
+    }
+
+    SECTION("Start doesn't cause a crash when called twice")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent;
+        accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.Start([](auto &&, auto &&) {}));
+    }
+
+    SECTION("Start doesn't cause a crash when called with a null callback")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent;
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.Start(nullptr));
+    }
+}
+
+TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::Stop", "[wifi][core][apmanager]")
+{
+    using namespace Microsoft::Net::Wifi;
+
+    SECTION("Stop doesn't cause a crash when Start hasn't been called")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.Stop());
+    }
+
+    SECTION("Stop doesn't cause a crash when Start has been called")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.Stop());
+    }
+
+    SECTION("Stop doesn't cause a crash when called twice")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
+        accessPointDiscoveryAgent.Stop();
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.Stop());
+    }
+
+    SECTION("Stop doesn't cause a crash when called with a null callback")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        accessPointDiscoveryAgent.Start(nullptr);
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.Stop());
+    }
+}
+
+TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync", "[wifi][core][apmanager]")
+{
+    using namespace Microsoft::Net::Wifi;
+
+    SECTION("ProbeAsync doesn't cause a crash when Start hasn't been called")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
+    }
+
+    SECTION("ProbeAsync doesn't cause a crash when Start has been called")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
+    }
+
+    SECTION("ProbeAsync doesn't cause a crash when Stop has been called")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        accessPointDiscoveryAgent.Stop();
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
+    }
+
+    SECTION("ProbeAsync doesn't cause a crash when called twice")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
+        accessPointDiscoveryAgent.ProbeAsync();
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
+    }
+
+    SECTION("ProbeAsync doesn't cause a crash when called after a Start/Stop sequence")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        accessPointDiscoveryAgent.Start(nullptr);
+        accessPointDiscoveryAgent.Stop();
+        REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
+    }
+}

--- a/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -123,4 +123,11 @@ TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync", "[wifi][core
         accessPointDiscoveryAgent.Stop();
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
     }
+
+    SECTION("ProbeAsync returns a valid future")
+    {
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        accessPointDiscoveryAgent.Start(nullptr);
+        REQUIRE(accessPointDiscoveryAgent.ProbeAsync().valid());
+    }
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [x] Feature addition
- [X] Feature update
- [ ] Documentation
- [x] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow automatic detection of wi-fi interfaces to be used in the API.

### Technical Details

* Add `libnl` as dependencies (core, genl, route and modules plus debug package) with cmake targets and availability in Docker development container.
* Ensure all Linux CMake presets use the `Ninja Multi-Config` generator and set default configure and build presets to use the `Debug` configuration.
* Add generic scope-exit RAII helper to `notstd` library.
* Add libnl helper library `libnl-helpers` to aid in netlink resource management for `struct nl_socket` and `struct nl_msg`.
* Add test/utility program `apmonitor` on Linux to monitor access point presence changes.
* Add `IAccessPointDiscoveryAgentOperations` implementation `AccessPointDiscoveryAgentOperationsNetlink` for discovering and monitoring access point presence on Linux using netlink.
* Add unit tests for `AccessPointManager` and `AccessPointDiscoveryAgentOperationsNetlink` on Linux.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* The current implementation using netlink to monitor access point presence does not filter the interfaces for interface type (eg. wifi or not) nor their wifi interface type (eg. station vs ap). The netlink network 'link' group does not provide enough information to differentiate, so a solution using the nl80211 genl netlink interface might be used instead in a future PR as part of implementing #84.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
