### PR TITLE
Use nl80211 via nl-genl for netlink events.

### DIFF
--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -74,7 +74,7 @@ AccessPointDiscoveryAgentOperationsNetlink::Start(AccessPointPresenceEventCallba
 
     // TODO: This function needs to signal errors either through its return type, or an exception.
 
-    // moved to a separate function and done only once per instance.
+    // Allocate a new netlink socket.
     auto netlinkSocket{ NetlinkSocket::Allocate() };
     if (netlinkSocket == nullptr) {
         LOG_ERROR << "Failed to allocate new netlink socket for nl control";

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -6,9 +6,12 @@
 #include <linux/if.h>
 #include <linux/if_link.h>
 #include <linux/rtnetlink.h>
+#include <linux/nl80211.h>
 #include <magic_enum.hpp>
 #include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
 #include <microsoft/net/wifi/IAccessPoint.hxx>
+#include <netlink/genl/ctrl.h>
+#include <netlink/genl/genl.h>
 #include <netlink/handlers.h>
 #include <notstd/Scope.hxx>
 #include <plog/Log.h>
@@ -69,28 +72,52 @@ AccessPointDiscoveryAgentOperationsNetlink::Start(AccessPointPresenceEventCallba
         Stop();
     }
 
-    // Open a new netlink socket with the routing/networking family group.
+    // TODO: This function needs to signal errors either through its return type, or an exception.
+
+    // moved to a separate function and done only once per instance.
     auto netlinkSocket{ NetlinkSocket::Allocate() };
     if (netlinkSocket == nullptr) {
-        // TODO: this function needs to signal the error either through its return type, or an exception.
-        const auto err = errno;
-        LOG_ERROR << std::format("Failed to allocate new netlink socket with error {} ({})", err, strerror(err));
+        LOG_ERROR << "Failed to allocate new netlink socket for nl control";
         return;
     }
 
-    // Connect the socket to the netlink routing family.
-    int ret = nl_connect(netlinkSocket, NETLINK_ROUTE);
+    // Connect the socket to the generic netlink family.
+    int ret = genl_connect(netlinkSocket);
     if (ret < 0) {
         const auto err = errno;
-        LOG_ERROR << std::format("Failed to connect netlink socket with error {} ({})", err, strerror(err));
+        LOG_ERROR << std::format("Failed to connect netlink socket for nl control with error {} ({})", err, strerror(err));
         return;
     }
 
-    // Subscribe to the link group of messages.
-    ret = nl_socket_add_membership(netlinkSocket, RTMGRP_LINK);
+    // Lookup the nl80211 netlink id if not already done.
+    int nl80211NetlinkId = m_nl80211NetlinkId;
+    if (nl80211NetlinkId == -1) {
+        nl80211NetlinkId = genl_ctrl_resolve(netlinkSocket, NL80211_GENL_NAME);
+        if (nl80211NetlinkId < 0) {
+            LOG_ERROR << std::format("Failed to resolve nl80211 netlink id with error {}", nl80211NetlinkId);
+            return;
+        }
+        m_nl80211NetlinkId = nl80211NetlinkId;
+    }
+
+    // Lookup the membership id for the "config" multicast group if not already done.
+    int nl80211MulticastGroupIdConfig = m_nl80211MulticastGroupIdConfig;
+    if (nl80211MulticastGroupIdConfig == -1) {
+        static constexpr auto NetlinkGenlControlFamilyName = "nlctrl";
+
+        nl80211MulticastGroupIdConfig = genl_ctrl_resolve_grp(netlinkSocket, NetlinkGenlControlFamilyName, NL80211_MULTICAST_GROUP_CONFIG);
+        if (nl80211MulticastGroupIdConfig < 0) {
+            LOG_ERROR << std::format("Failed to resolve nl80211 multicast group id for config with error {}", nl80211MulticastGroupIdConfig);
+            return;
+        }
+        m_nl80211MulticastGroupIdConfig = nl80211MulticastGroupIdConfig;
+    }
+
+    // Subscribe to configuration messages.
+    ret = nl_socket_add_membership(netlinkSocket, nl80211MulticastGroupIdConfig);
     if (ret < 0) {
         const auto err = errno;
-        LOG_ERROR << std::format("Failed to add netlink socket membership with error {} ({})", err, strerror(err));
+        LOG_ERROR << std::format("Failed to add netlink socket membership for '" NL80211_MULTICAST_GROUP_CONFIG "' group with error {} ({})", err, strerror(err));
         return;
     }
 

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -5,8 +5,8 @@
 
 #include <linux/if.h>
 #include <linux/if_link.h>
-#include <linux/rtnetlink.h>
 #include <linux/nl80211.h>
+#include <linux/rtnetlink.h>
 #include <magic_enum.hpp>
 #include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
 #include <microsoft/net/wifi/IAccessPoint.hxx>
@@ -172,7 +172,7 @@ AccessPointDiscoveryAgentOperationsNetlink::ProcessNetlinkMessage(struct nl_msg 
     }
 
     const auto *interfaceName = static_cast<const char *>(RTA_DATA(interfaceNameAttribute));
-    const auto *interfaceInfoMessage{ static_cast<const struct ifinfomsg *>(NLMSG_DATA(netlinkMessageHeader)) }; 
+    const auto *interfaceInfoMessage{ static_cast<const struct ifinfomsg *>(NLMSG_DATA(netlinkMessageHeader)) };
     LOG_VERBOSE << std::format("Received netlink message with type {}, interface {}, index {}", netlinkMessageHeader->nlmsg_type, interfaceName, interfaceInfoMessage->ifi_index);
 
     switch (netlinkMessageHeader->nlmsg_type) {

--- a/src/linux/wifi/apmanager/CMakeLists.txt
+++ b/src/linux/wifi/apmanager/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(wifi-apmanager-linux
 target_link_libraries(wifi-apmanager-linux
     PRIVATE
         nl
+        nl-genl
         notstd
         plog::plog
     PUBLIC

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -86,6 +86,9 @@ private:
     // Cookie used to invalidate the callback context.
     static constexpr uint32_t CookieInvalid{ 0xDEADBEEFu };
 
+    int m_nl80211NetlinkId{ -1 };
+    int m_nl80211MulticastGroupIdConfig{ -1 };
+
     uint32_t m_cookie{ CookieInvalid };
     AccessPointPresenceEventCallback m_accessPointPresenceCallback{ nullptr };
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow differentiation of wi-fi vs non-wifi interface types.
* Resolve part of #85.

### Technical Details

* Switch to using the nl80211 genl netlink family instead of the route family.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None.

### Future Work

* The message parsing of nl80211 events is not yet implemented. The original implementation still handles link presence changes (`RTM_NEWLINK`, `RTM_DELLINK`) so the prior behavior is preserved.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
