### PR TITLE
Remove creation logic from access point discovery agent

### DIFF
--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgent.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgent.hxx
@@ -7,6 +7,7 @@
 #include <future>
 #include <memory>
 #include <shared_mutex>
+#include <string>
 
 #include <microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx>
 
@@ -50,7 +51,7 @@ struct AccessPointDiscoveryAgent :
      * @param onDevicePresenceChanged The callback to register.
      */
     void
-    RegisterDiscoveryEventCallback(std::function<void(AccessPointPresenceEvent presence, std::shared_ptr<IAccessPoint> accessPointChanged)> onDevicePresenceChanged);
+    RegisterDiscoveryEventCallback(AccessPointPresenceEventCallback onDevicePresenceChanged);
 
     /**
      * @brief indicates the started/running state.
@@ -76,9 +77,9 @@ struct AccessPointDiscoveryAgent :
     /**
      * @brief Probe for all existing devices.
      *
-     * @return std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+     * @return std::future<std::vector<std::string>>
      */
-    std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+    std::future<std::vector<std::string>>
     ProbeAsync();
 
 protected:
@@ -93,17 +94,17 @@ protected:
      * @brief Wrapper for safely invoking any device presence changed registered callback.
      *
      * @param presence The presence change that occurred.
-     * @param accessPointChanged The device the change occurred for.
+     * @param interfaceName The name of the network interface of the access point that changed.
      */
     void
-    DevicePresenceChanged(AccessPointPresenceEvent presence, std::shared_ptr<IAccessPoint> accessPointChanged) const noexcept;
+    DevicePresenceChanged(AccessPointPresenceEvent presence, std::string interfaceName) const noexcept;
 
 private:
     std::unique_ptr<IAccessPointDiscoveryAgentOperations> m_operations;
     std::atomic<bool> m_started{ false };
 
     mutable std::shared_mutex m_onDevicePresenceChangedGate;
-    std::function<void(AccessPointPresenceEvent presence, std::shared_ptr<IAccessPoint> accessPointChanged)> m_onDevicePresenceChanged;
+    AccessPointPresenceEventCallback m_onDevicePresenceChanged;
 };
 
 } // namespace Microsoft::Net::Wifi

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx
@@ -5,6 +5,7 @@
 #include <functional>
 #include <future>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace Microsoft::Net::Wifi
@@ -19,7 +20,7 @@ struct IAccessPoint;
 /**
  * @brief Prototype for the callback invoked when an access point is discovered or removed.
  */
-using AccessPointPresenceEventCallback = std::function<void(AccessPointPresenceEvent, std::shared_ptr<IAccessPoint>)>;
+using AccessPointPresenceEventCallback = std::function<void(AccessPointPresenceEvent, std::string interfaceName)>;
 
 /**
  * @brief Operations used to perform discovery of access points, used by
@@ -31,7 +32,7 @@ struct IAccessPointDiscoveryAgentOperations
 
     /**
      * @brief Start the discovery process.
-     * 
+     *
      * @param callback The callback to invoke when an access point is discovered or removed.
      */
     virtual void
@@ -46,9 +47,9 @@ struct IAccessPointDiscoveryAgentOperations
     /**
      * @brief Perform an asynchronous discovery probe.
      *
-     * @return std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+     * @return std::future<std::vector<std::string>>
      */
-    virtual std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+    virtual std::future<std::vector<std::string>>
     ProbeAsync() = 0;
 };
 

--- a/src/linux/tools/apmonitor/Main.cxx
+++ b/src/linux/tools/apmonitor/Main.cxx
@@ -2,9 +2,9 @@
 #include <format>
 
 #include <magic_enum.hpp>
-#include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <microsoft/net/wifi/AccessPointDiscoveryAgent.hxx>
 #include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
+#include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <plog/Appenders/ColorConsoleAppender.h>
 #include <plog/Formatters/MessageOnlyFormatter.h>
 #include <plog/Init.h>
@@ -12,11 +12,11 @@
 #include <signal.h>
 
 using Microsoft::Net::Wifi::AccessPointDiscoveryAgent;
-using Microsoft::Net::Wifi::IAccessPointDiscoveryAgentOperations;
 using Microsoft::Net::Wifi::AccessPointDiscoveryAgentOperationsNetlink;
+using Microsoft::Net::Wifi::IAccessPointDiscoveryAgentOperations;
 
 int
-main([[maybe_unused]] int argc, [[maybe_unused]] char *argv[])
+main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
 {
     // Configure console logging.
     static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
@@ -25,8 +25,8 @@ main([[maybe_unused]] int argc, [[maybe_unused]] char *argv[])
     // Configure monitoring with the netlink protocol.
     auto accessPointDiscoveryAgentOperationsNetlink{ std::make_unique<AccessPointDiscoveryAgentOperationsNetlink>() };
     auto accessPointDiscoveryAgent{ AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperationsNetlink)) };
-    accessPointDiscoveryAgent->RegisterDiscoveryEventCallback([](auto&& presence, auto&& accessPointChanged) {
-        PLOG_INFO << std::format("{} -> {}", accessPointChanged != nullptr ? accessPointChanged->GetInterface() : "<unknown>", magic_enum::enum_name(presence));
+    accessPointDiscoveryAgent->RegisterDiscoveryEventCallback([](auto&& presence, auto&& interfaceName) {
+        PLOG_INFO << std::format("{} -> {}", interfaceName, magic_enum::enum_name(presence));
     });
 
     LOG_INFO << "starting access point discovery agent";

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -142,14 +142,14 @@ AccessPointDiscoveryAgentOperationsNetlink::Stop()
     }
 }
 
-std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+std::future<std::vector<std::string>>
 AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync()
 {
-    std::promise<std::vector<std::shared_ptr<IAccessPoint>>> probePromise{};
+    std::promise<std::vector<std::string>> probePromise{};
     auto probeFuture = probePromise.get_future();
 
     // TODO: implement this.
-    std::vector<std::shared_ptr<IAccessPoint>> accessPoints{};
+    std::vector<std::string> accessPoints{};
     probePromise.set_value(std::move(accessPoints));
 
     return probeFuture;
@@ -235,7 +235,7 @@ AccessPointDiscoveryAgentOperationsNetlink::ProcessNetlinkMessage(struct nl_msg 
     if (accessPointPresenceEventCallback != nullptr) {
         auto accessPoint{ std::make_shared<AccessPoint>(interfaceName) };
         LOG_VERBOSE << std::format("Invoking access point presence event callback with event args 'interface={}, presence={}'", accessPoint->GetInterface(), magic_enum::enum_name(accessPointPresenceEvent));
-        accessPointPresenceEventCallback(accessPointPresenceEvent, std::move(accessPoint));
+        accessPointPresenceEventCallback(accessPointPresenceEvent, interfaceName);
     }
 
     return NL_OK;

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -35,7 +35,7 @@ struct AccessPointDiscoveryAgentOperationsNetlink :
     void
     Stop() override;
 
-    std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+    std::future<std::vector<std::string>>
     ProbeAsync() override;
 
 private:

--- a/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.cxx
+++ b/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.cxx
@@ -3,7 +3,9 @@
 
 #include "AccessPointDiscoveryAgentOperationsTest.hxx"
 
+using namespace Microsoft::Net::Wifi;
 using namespace Microsoft::Net::Wifi::Test;
+using Microsoft::Net::Wifi::AccessPointPresenceEvent;
 
 void
 AccessPointDiscoveryAgentOperationsTest::Start(AccessPointPresenceEventCallback callback)
@@ -17,36 +19,36 @@ AccessPointDiscoveryAgentOperationsTest::Stop()
     m_callback = nullptr;
 }
 
-std::future<std::vector<std::shared_ptr<Microsoft::Net::Wifi::IAccessPoint>>>
+std::future<std::vector<std::string>>
 AccessPointDiscoveryAgentOperationsTest::ProbeAsync()
 {
     return std::async(std::launch::async, [&]() {
-        return m_accessPoints;
+        return m_accessPointInterfaceNames;
     });
 }
 
 void
-AccessPointDiscoveryAgentOperationsTest::AddAccessPoint(std::shared_ptr<Microsoft::Net::Wifi::IAccessPoint> accessPointToAdd)
+AccessPointDiscoveryAgentOperationsTest::AddAccessPoint(std::string_view interfaceNameToAdd)
 {
-    m_accessPoints.push_back(std::move(accessPointToAdd));
+    m_accessPointInterfaceNames.push_back(std::string(interfaceNameToAdd));
 
     if (m_callback != nullptr) {
-        m_callback(Microsoft::Net::Wifi::AccessPointPresenceEvent::Arrived, m_accessPoints.back());
+        m_callback(AccessPointPresenceEvent::Arrived, m_accessPointInterfaceNames.back());
     }
 }
 
 void
-AccessPointDiscoveryAgentOperationsTest::RemoveAccessPoint(std::shared_ptr<Microsoft::Net::Wifi::IAccessPoint> accessPointToRemove)
+AccessPointDiscoveryAgentOperationsTest::RemoveAccessPoint(std::string_view interfaceNameToRemove)
 {
-    auto accessPointToRemoveIterator = std::ranges::find_if(m_accessPoints, [&](const auto& accessPoint) {
-        return accessPointToRemove->GetInterface() == accessPoint->GetInterface();
+    auto interfaceNameToRemoveIterator = std::ranges::find_if(m_accessPointInterfaceNames, [&](const auto& interfaceName) {
+        return (interfaceNameToRemove == interfaceName);
     });
 
-    if (accessPointToRemoveIterator != std::end(m_accessPoints)) {
+    if (interfaceNameToRemoveIterator != std::end(m_accessPointInterfaceNames)) {
         if (m_callback != nullptr) {
-            m_callback(Microsoft::Net::Wifi::AccessPointPresenceEvent::Departed, *accessPointToRemoveIterator);
+            m_callback(Microsoft::Net::Wifi::AccessPointPresenceEvent::Departed, *interfaceNameToRemoveIterator);
         }
 
-        m_accessPoints.erase(accessPointToRemoveIterator);
+        m_accessPointInterfaceNames.erase(interfaceNameToRemoveIterator);
     }
 }

--- a/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.hxx
+++ b/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.hxx
@@ -4,6 +4,9 @@
 
 #include <future>
 #include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
 
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx>
@@ -24,18 +27,18 @@ struct AccessPointDiscoveryAgentOperationsTest :
     void
     Stop() override;
 
-    std::future<std::vector<std::shared_ptr<Microsoft::Net::Wifi::IAccessPoint>>>
+    std::future<std::vector<std::string>>
     ProbeAsync() override;
 
     void
-    AddAccessPoint(std::shared_ptr<Microsoft::Net::Wifi::IAccessPoint> accessPointToAdd);
+    AddAccessPoint(std::string_view accessPointInterfaceNameToAdd);
 
     void
-    RemoveAccessPoint(std::shared_ptr<Microsoft::Net::Wifi::IAccessPoint> accessPointToRemove);
+    RemoveAccessPoint(std::string_view accessPointInterfaceNameToRemove);
 
 private:
     AccessPointPresenceEventCallback m_callback;
-    std::vector<std::shared_ptr<Microsoft::Net::Wifi::IAccessPoint>> m_accessPoints;
+    std::vector<std::string> m_accessPointInterfaceNames;
 };
 
 } // namespace Microsoft::Net::Wifi::Test


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure access point discovery logic does not require a particular creational pattern.
* Separate concerns of discovery and creation from existing code.

### Technical Details

* Change `AccessPointDiscoveryAgent` callback and probe result type to use interface names (`std::string`) instead of the concrete type `std::shared_ptr<IAccessPoint>`.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* `AccessPointManager` should now accept an `IAccessPointFactory` to be used for creating instances from interface names.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
