### PR TITLE
Add IEEE 80211 definitions.

### DIFF
--- a/src/common/wifi/core/CMakeLists.txt
+++ b/src/common/wifi/core/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(wifi-core
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPoint.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/IAccessPoint.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/IAccessPointFactory.hxx
+        ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/Ieee80211.hxx
 )
 
 install(

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -1,0 +1,123 @@
+
+#ifndef IEEE_80211_HXX
+#define IEEE_80211_HXX
+
+#include <cmath>
+
+namespace Microsoft::Net::Wifi
+{
+enum class IeeeFrequencyBand {
+    Unknown,
+    TwoPointFourGHz,
+    FiveGHz,
+    SixGHz,
+};
+
+namespace Literals
+{
+/**
+ * @brief User-defined literal operator for allowing use of _GHz to specify
+ * frequency band enumeration values.
+ */
+inline constexpr Microsoft::Net::Wifi::IeeeFrequencyBand
+operator"" _GHz(long double value) noexcept
+{
+    /**
+     * @brief Floating point values with non-zero fractional parts cannot be
+     * compared for equality directly due to binary floating point encoding,
+     * which approximates decimal values.
+     *
+     * As such, a tolerance value is used to determine if the specified
+     * value is practically equal to the expected value, given the tolerance.
+     * The below tolerance value(s) were defined empirically using a few
+     * different processors. Since this function only needs to map to an
+     * enumeration value, the range the tolerance value need not be very
+     * precise.
+     */
+    constexpr auto TwoPointFourGHzTolerance = 8.89045781438113635886e-17L;
+
+    if (std::fabs(value - 2.4) <= TwoPointFourGHzTolerance) {
+        return Microsoft::Net::Wifi::IeeeFrequencyBand::TwoPointFourGHz;
+    } else if (value == 5.0) {
+        return Microsoft::Net::Wifi::IeeeFrequencyBand::FiveGHz;
+    } else if (value == 6.0) {
+        return Microsoft::Net::Wifi::IeeeFrequencyBand::SixGHz;
+    } else {
+        return Microsoft::Net::Wifi::IeeeFrequencyBand::Unknown;
+    }
+}
+
+/**
+ * @brief User-defined literal operator for allowing use of _MHz to specify
+ * frequency band enumeration values.
+ */
+inline constexpr Microsoft::Net::Wifi::IeeeFrequencyBand
+operator"" _MHz(unsigned long long int value) noexcept
+{
+    if (value == 2400) {
+        return Microsoft::Net::Wifi::IeeeFrequencyBand::TwoPointFourGHz;
+    } else if (value == 5000) {
+        return Microsoft::Net::Wifi::IeeeFrequencyBand::FiveGHz;
+    } else if (value == 6000) {
+        return Microsoft::Net::Wifi::IeeeFrequencyBand::SixGHz;
+    } else {
+        return Microsoft::Net::Wifi::IeeeFrequencyBand::Unknown;
+    }
+}
+} // namespace Literals
+
+enum class IeeeProtocol {
+    Unknown,
+    B,
+    G,
+    N,
+    A,
+    AC,
+    AD,
+    AX,
+    BE,
+};
+
+enum class IeeeAuthenticationAlgorithm {
+    Unknown,
+    Open,
+    SharedKey,
+    Wpa,
+    WpaPsk,
+    WpaNone,
+    Rsna,
+    RsnaPsk,
+    Wpa3,
+    Wpa3Enterprise192,
+    Wpa3Enterprise,
+    Sae,
+    Owe,
+};
+
+constexpr auto Wpa3Enterprise192 = IeeeAuthenticationAlgorithm::Wpa3;
+constexpr auto Wpa3Personal = IeeeAuthenticationAlgorithm::Sae;
+
+enum class IeeeCipherAlgorithm {
+    Unknown,
+    None,
+    Wep,
+    Wep40,
+    Wep104,
+    Tkip,
+    BipCmac128,
+    BipGmac128,
+    BipGmac256,
+    BipCmac256,
+    Gcmp128,
+    Gcmp256,
+    Ccmp256,
+    WpaUseGroup,
+};
+
+constexpr auto Bip = IeeeCipherAlgorithm::BipCmac128;
+constexpr auto Gcmp = IeeeCipherAlgorithm::Gcmp128;
+constexpr auto RsnUseGroup = IeeeCipherAlgorithm::WpaUseGroup;
+
+} // namespace Microsoft::Net::Wifi
+
+#endif // IEEE_80211_HXX

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -31,7 +31,7 @@ operator"" _GHz(long double value) noexcept
      * value is practically equal to the expected value, given the tolerance.
      * The below tolerance value(s) were defined empirically using a few
      * different processors. Since this function only needs to map to an
-     * enumeration value, the range the tolerance value need not be very
+     * enumeration value, the range of the tolerance value need not be very
      * precise.
      */
     constexpr auto TwoPointFourGHzTolerance = 8.89045781438113635886e-17L;

--- a/tests/unit/wifi/core/CMakeLists.txt
+++ b/tests/unit/wifi/core/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(wifi-core-test-unit)
 target_sources(wifi-core-test-unit
     PRIVATE
         TestAccessPoint.cxx
+        TestIeee80211.cxx
 )
 
 target_include_directories(wifi-core-test-unit

--- a/tests/unit/wifi/core/TestIeee80211.cxx
+++ b/tests/unit/wifi/core/TestIeee80211.cxx
@@ -1,0 +1,87 @@
+
+#include <initializer_list>
+#include <unordered_map>
+
+#include <microsoft/net/wifi/Ieee80211.hxx>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("IeeeFrequencyBand GHz literals translate correctly", "[wifi][core]")
+{
+    using namespace Microsoft::Net::Wifi::Literals;
+
+    using Microsoft::Net::Wifi::IeeeFrequencyBand;
+
+    SECTION("Valid literal values are correct")
+    {
+        REQUIRE(2.4_GHz == IeeeFrequencyBand::TwoPointFourGHz);
+        REQUIRE(5.0_GHz == IeeeFrequencyBand::FiveGHz);
+        REQUIRE(6.0_GHz == IeeeFrequencyBand::SixGHz);
+    }
+
+    SECTION("Invalid literal values translate to 'Unknown'")
+    {
+        static constexpr std::initializer_list<IeeeFrequencyBand> InvalidBandValues{
+            0.0_GHz,
+            1.0_GHz,
+            2.0_GHz,
+            2.3_GHz,
+            2.39_GHz,
+            2.44_GHz,
+            4.0_GHz,
+            4.99999_GHz,
+            5.1_GHz,
+            5.01_GHz,
+            5.9999999999_GHz,
+            6.01_GHz,
+            6.0000000000000001_GHz,
+            7.0_GHz,
+            2000.00_GHz,
+            2400.00_GHz,
+            5000.12_GHz,
+            123456.7890_GHz,
+        };
+
+        for (const auto& invalidBand : InvalidBandValues) {
+            REQUIRE(invalidBand == IeeeFrequencyBand::Unknown);
+        }
+    }
+}
+
+TEST_CASE("IeeeFrequencyBand MHz literals translate correctly", "[wifi][core]")
+{
+    using namespace Microsoft::Net::Wifi::Literals;
+
+    using Microsoft::Net::Wifi::IeeeFrequencyBand;
+
+    SECTION("Valid literal values are correct")
+    {
+        REQUIRE(2400_MHz == IeeeFrequencyBand::TwoPointFourGHz);
+        REQUIRE(5000_MHz == IeeeFrequencyBand::FiveGHz);
+        REQUIRE(6000_MHz == IeeeFrequencyBand::SixGHz);
+    }
+
+    SECTION("Invalid literal values translate to 'Unknown'")
+    {
+        static constexpr std::initializer_list<IeeeFrequencyBand> InvalidBandValues{
+            0_MHz,
+            1_MHz,
+            2_MHz,
+            4_MHz,
+            7_MHz,
+            2000_MHz,
+            2399_MHz,
+            2401_MHz,
+            4999_MHz,
+            5001_MHz,
+            5999_MHz,
+            6001_MHz,
+            123456789_MHz,
+            4294967295_MHz,
+        };
+
+        for (const auto& invalidBand : InvalidBandValues) {
+            REQUIRE(invalidBand == IeeeFrequencyBand::Unknown);
+        }
+    }
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow use of IEEE 802.11 concepts in an OS-agnostic way.

### Technical Details

* Introduce enumerations for supported frequency bands, high-level protocols (eg. 802.11 a/b/g/n/...), authentication methods, and cipher algorithms.
* Add user-defined literals `_MHz` and `_GHz` to allow easier use of `IeeeFrequencyBand` constants.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Add other IEEE 802.11 definitions for radio capabilities as needed for existing APIs.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
