### PR TITLE
Conditionally compile _GHz literal operator for non-MSVC.

### DIFF
--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -15,6 +15,7 @@ enum class IeeeFrequencyBand {
 
 namespace Literals
 {
+#ifndef _MSC_VER
 /**
  * @brief User-defined literal operator for allowing use of _GHz to specify
  * frequency band enumeration values.
@@ -46,6 +47,8 @@ operator"" _GHz(long double value) noexcept
         return Microsoft::Net::Wifi::IeeeFrequencyBand::Unknown;
     }
 }
+
+#endif // _MSC_VER
 
 /**
  * @brief User-defined literal operator for allowing use of _MHz to specify

--- a/tests/unit/wifi/core/TestIeee80211.cxx
+++ b/tests/unit/wifi/core/TestIeee80211.cxx
@@ -6,6 +6,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#ifndef _MSC_VER 
 TEST_CASE("IeeeFrequencyBand GHz literals translate correctly", "[wifi][core]")
 {
     using namespace Microsoft::Net::Wifi::Literals;
@@ -47,6 +48,8 @@ TEST_CASE("IeeeFrequencyBand GHz literals translate correctly", "[wifi][core]")
         }
     }
 }
+
+#endif // _MSC_VER
 
 TEST_CASE("IeeeFrequencyBand MHz literals translate correctly", "[wifi][core]")
 {


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the Windows build succeeds.

### Technical Details

* Conditionally compile the `_GHz` literal operator since MSVC is applying more strict checking than clang.

### Test Results

* All unit tests now pass.

### Reviewer Focus

* None

### Future Work

#91 
* Figure out how to implement the operator without trigger MSVC errors. This should be possible since all operations are `constexpr`, but `std::fabs` is not marked as such until C++23. A solution is probably to just add the `constexpr` declaration of `std::fabs` from a C++ 23 implementation in the `notstd` helper library.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
