### PR TITLE
Disable tests for CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ on:
         description: 'Invoke CMake install for the project'
       test:
         required: false
-        default: true
+        default: false
         type: boolean
         description: 'Invoke CMake CTest for the project'
       package:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,3 +20,4 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       build-types: "[ 'Debug' ]"
+      test: false


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Shorten CI/CD build validation time.

### Technical Details

* Disable running tests on the CI/CD workflow.
* Disable running tests by default on the core build workflow.

### Test Results

* N/A

### Reviewer Focus

* None

### Future Work

* #93 

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
