### PR TITLE
Switch to using insecure gRPC CMake targets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -94,6 +94,18 @@
             ]
         },
         {
+            "name": "dev-windows-arm64",
+            "displayName": "Development (ARM64)",
+            "description": "Development build for inner-loop on Windows ARM64",
+            "inherits":[
+                "dev-windows"
+            ],
+            "architecture": {
+                "value": "ARM64",
+                "strategy": "set"
+            }
+        },
+        {
             "name": "release-base",
             "hidden": true,
             "inherits": [

--- a/protocol/CMakeLists.txt
+++ b/protocol/CMakeLists.txt
@@ -49,8 +49,8 @@ target_sources(${PROJECT_NAME}-protocol
 target_link_libraries(${PROJECT_NAME}-protocol
     PUBLIC
         protobuf::libprotobuf
-        gRPC::grpc
-        gRPC::grpc++
+        gRPC::grpc_unsecure
+        gRPC::grpc++_unsecure
 )
 
 protobuf_generate(TARGET ${PROJECT_NAME}-protocol


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Attempt to enable building for Windows ARM64 architecture, specifically the ARM64EC ABI.

### Technical Details

* Replace use of standard gRPC CMake targets with "unsecure" ones, which do not link SSL dependents. 
* Add CMake configure preset for building ARM64 on Windows.

### Test Results

* Cross-compile build for ARM64 on Windows with `Debug` flavor succeeded.

### Reviewer Focus

* None

### Future Work

* Using the insecure targets is not desirable. While this framework is intended mostly for test environments where security may not be required or important, having a secure transport should be an option for corner cases. So, we need to figure out a workaround to enable use of the normal targets that support SSL.
* #95

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
