### PR TITLE
Fix module configuration ordering in mac80211_hwsim module build script

### DIFF
--- a/.docker/netremote-dev/build-mac80211_hwsim-kmod.sh
+++ b/.docker/netremote-dev/build-mac80211_hwsim-kmod.sh
@@ -78,7 +78,11 @@ fi
 
 # Update the configuration to build the mac80211_hwsim module and its dependencies.
 echo "Updating kernel configuration to build mac80211_hwsim module and its dependencies..."
-${KERNEL_CONFIG_UTIL} --module CONFIG_RFKILL --module CONFIG_CFG80211 --module CONFIG_MAC80211 --module CONFIG_MAC80211_HWSIM
+${KERNEL_CONFIG_UTIL} \
+    --module CONFIG_RFKILL \
+    --module CONFIG_CFG80211 \
+    --module CONFIG_MAC80211 \
+    --module CONFIG_MAC80211_HWSIM
 
 # Supply defaults for any new/unspecified options in the configuration.
 make olddefconfig


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the `mac80211_hwsim` kernel module can be built and used in a Linux development environment.
* Fix #97.

### Technical Details

* Re-arrange the kernel configuration such that default values are provided for new kernel features (compared to those in the running kernel).
* Update some variables to use absolute paths.
* Remove `-x` bash flag to make script output quieter.

### Test Results

* Invoked the `build-mac80211_hwsim-kmod.sh` script in both a vanilla and existing dev environment and verified `lsmod` output showed `mac80211_hwsim`.
* Invoked the `build-mac80211_hwsim-kmod.sh` script repeatedly and ensured the `mac80211_hwsim` module was re-built and re-installed.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
