### PR TITLE
Replace spot-use of runtime nl80211 protocol data with Nl80211ProtocolState helper 

### DIFF
--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -95,29 +95,8 @@ AccessPointDiscoveryAgentOperationsNetlink::Start(AccessPointPresenceEventCallba
         return;
     }
 
-    // Lookup the nl80211 netlink id if not already done.
-    int nl80211NetlinkId = m_nl80211NetlinkId;
-    if (nl80211NetlinkId == -1) {
-        nl80211NetlinkId = genl_ctrl_resolve(netlinkSocket, NL80211_GENL_NAME);
-        if (nl80211NetlinkId < 0) {
-            LOG_ERROR << std::format("Failed to resolve nl80211 netlink id with error {} ({})", nl80211NetlinkId, nl_geterror(nl80211NetlinkId));
-            return;
-        }
-        m_nl80211NetlinkId = nl80211NetlinkId;
-    }
-
-    // Lookup the membership id for the "config" multicast group if not already done.
-    int nl80211MulticastGroupIdConfig = m_nl80211MulticastGroupIdConfig;
-    if (nl80211MulticastGroupIdConfig == -1) {
-        nl80211MulticastGroupIdConfig = genl_ctrl_resolve_grp(netlinkSocket, NL80211_GENL_NAME, NL80211_MULTICAST_GROUP_CONFIG);
-        if (nl80211MulticastGroupIdConfig < 0) {
-            LOG_ERROR << std::format("Failed to resolve nl80211 multicast group id for config with error {} ({})", nl80211MulticastGroupIdConfig, nl_geterror(nl80211MulticastGroupIdConfig));
-            return;
-        }
-        m_nl80211MulticastGroupIdConfig = nl80211MulticastGroupIdConfig;
-    }
-
     // Subscribe to configuration messages.
+    int nl80211MulticastGroupIdConfig = m_netlink80211ProtocolState.MulticastGroupId[Nl80211MulticastGroup::Configuration];
     ret = nl_socket_add_membership(netlinkSocket, nl80211MulticastGroupIdConfig);
     if (ret < 0) {
         const auto err = errno;

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -28,9 +28,11 @@ using namespace Microsoft::Net::Netlink::Nl80211;
 
 using Microsoft::Net::Netlink::NetlinkMessage;
 using Microsoft::Net::Netlink::NetlinkSocket;
+using Microsoft::Net::Netlink::Nl80211::Nl80211ProtocolState;
 
 AccessPointDiscoveryAgentOperationsNetlink::AccessPointDiscoveryAgentOperationsNetlink() :
-    m_cookie(CookieValid)
+    m_cookie(CookieValid),
+    m_netlink80211ProtocolState(Nl80211ProtocolState::Instance())
 {}
 
 AccessPointDiscoveryAgentOperationsNetlink::~AccessPointDiscoveryAgentOperationsNetlink()

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -6,16 +6,15 @@
 #include <string_view>
 
 #include <linux/if.h>
-#include <linux/if_link.h>
-#include <linux/rtnetlink.h>
 #include <magic_enum.hpp>
 #include <microsoft/net/netlink/nl80211/Netlink80211.hxx>
 #include <microsoft/net/wifi/AccessPoint.hxx>
 #include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
 #include <microsoft/net/wifi/IAccessPoint.hxx>
-#include <netlink/genl/ctrl.h>
 #include <netlink/genl/genl.h>
-#include <netlink/handlers.h>
+#include <netlink/msg.h>
+#include <netlink/netlink.h>
+#include <netlink/socket.h>
 #include <notstd/Scope.hxx>
 #include <plog/Log.h>
 #include <sys/epoll.h>

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -90,9 +90,6 @@ private:
     // Cookie used to invalidate the callback context.
     static constexpr uint32_t CookieInvalid{ 0xDEADBEEFu };
 
-    int m_nl80211NetlinkId{ -1 };
-    int m_nl80211MulticastGroupIdConfig{ -1 };
-
     uint32_t m_cookie{ CookieInvalid };
     AccessPointPresenceEventCallback m_accessPointPresenceCallback{ nullptr };
 
@@ -106,7 +103,7 @@ private:
     };
 
     std::unordered_map<int, WifiInterfaceInfo> m_interfaceInfo;
-    Microsoft::Net::Netlink::Nl80211::Nl80211ProtocolState& m_netlink80211ProtocolState;
+    Microsoft::Net::Netlink::Nl80211::Nl80211ProtocolState &m_netlink80211ProtocolState;
 };
 } // namespace Microsoft::Net::Wifi
 

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -11,6 +11,7 @@
 #include <linux/nl80211.h>
 #include <microsoft/net/netlink/NetlinkMessage.hxx>
 #include <microsoft/net/netlink/NetlinkSocket.hxx>
+#include <microsoft/net/netlink/nl80211/Netlink80211ProtocolState.hxx>
 #include <microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx>
 #include <netlink/netlink.h>
 
@@ -105,6 +106,7 @@ private:
     };
 
     std::unordered_map<int, WifiInterfaceInfo> m_interfaceInfo;
+    Microsoft::Net::Netlink::Nl80211::Nl80211ProtocolState& m_netlink80211ProtocolState;
 };
 } // namespace Microsoft::Net::Wifi
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Eliminate duplicate calls to retrieve nl80211 runtime information that does not change, including the driver id and multicast group ids.

### Technical Details

* Replace members for nl80211 driver id and multicast group ids and their respective code to populate them with the `Nl80211ProtocolState` helper. 

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
