### PR TITLE
Implement ProbeAsync for AccessPointDiscoveryAgentOperationsNetlink

### DIFF
--- a/src/linux/libnl-helpers/CMakeLists.txt
+++ b/src/linux/libnl-helpers/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX ${LIBNL_HELPERS_PUBLIC_INCLUDE}/${LIBNL_
 target_sources(libnl-helpers
     PRIVATE
         Netlink80211.cxx
+        Netlink80211Interface.cxx
         Netlink80211ProtocolState.cxx
         NetlinkMessage.cxx
         NetlinkSocket.cxx
@@ -18,6 +19,7 @@ target_sources(libnl-helpers
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkMessage.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkSocket.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211.hxx
+        ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211Interface.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211ProtocolState.hxx
 )
 

--- a/src/linux/libnl-helpers/Netlink80211Interface.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Interface.cxx
@@ -10,7 +10,6 @@
 #include <microsoft/net/netlink/nl80211/Netlink80211Interface.hxx>
 #include <microsoft/net/netlink/nl80211/Netlink80211ProtocolState.hxx>
 #include <netlink/genl/genl.h>
-#include <netlink/msg.h>
 #include <plog/Log.h>
 
 using namespace Microsoft::Net::Netlink::Nl80211;
@@ -18,7 +17,7 @@ using namespace Microsoft::Net::Netlink::Nl80211;
 using Microsoft::Net::Netlink::NetlinkMessage;
 using Microsoft::Net::Netlink::NetlinkSocket;
 
-Nl80211Interface::Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index) :
+Nl80211Interface::Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index) noexcept :
     Name(name),
     Type(type),
     Index(index)
@@ -33,7 +32,7 @@ Nl80211Interface::ToString() const
 
 /* static */
 std::optional<Nl80211Interface>
-Nl80211Interface::Parse(struct nl_msg *nl80211Message)
+Nl80211Interface::Parse(struct nl_msg* nl80211Message) noexcept
 {
     // Ensure the message is valid.
     if (nl80211Message == nullptr) {

--- a/src/linux/libnl-helpers/Netlink80211Interface.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Interface.cxx
@@ -1,0 +1,155 @@
+
+#include <array>
+#include <format>
+
+#include <linux/genetlink.h>
+#include <magic_enum.hpp>
+#include <microsoft/net/netlink/NetlinkMessage.hxx>
+#include <microsoft/net/netlink/NetlinkSocket.hxx>
+#include <microsoft/net/netlink/nl80211/Netlink80211.hxx>
+#include <microsoft/net/netlink/nl80211/Netlink80211Interface.hxx>
+#include <microsoft/net/netlink/nl80211/Netlink80211ProtocolState.hxx>
+#include <netlink/genl/genl.h>
+#include <netlink/msg.h>
+#include <plog/Log.h>
+
+using namespace Microsoft::Net::Netlink::Nl80211;
+
+using Microsoft::Net::Netlink::NetlinkMessage;
+using Microsoft::Net::Netlink::NetlinkSocket;
+
+Nl80211Interface::Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index) :
+    Name(name),
+    Type(type),
+    Index(index)
+{
+}
+
+std::string
+Nl80211Interface::ToString() const
+{
+    return std::format("[{}] {} {}", Index, Name, magic_enum::enum_name(Type));
+}
+
+/* static */
+std::optional<Nl80211Interface>
+Nl80211Interface::Parse(struct nl_msg *nl80211Message)
+{
+    // Ensure the message is valid.
+    if (nl80211Message == nullptr) {
+        LOGE << "Received null nl80211 message";
+        return std::nullopt;
+    }
+
+    // Ensure the message has a valid genl header.
+    auto *nl80211MessageHeader{ static_cast<struct nlmsghdr *>(nlmsg_hdr(nl80211Message)) };
+    if (genlmsg_valid_hdr(nl80211MessageHeader, 1) < 0) {
+        LOGE << "Received invalid nl80211 message header";
+        return std::nullopt;
+    }
+
+    // Extract the nl80211 (genl) message header.
+    const auto *genl80211MessageHeader{ static_cast<struct genlmsghdr *>(nlmsg_data(nl80211MessageHeader)) };
+
+    // Parse the message.
+    std::array<struct nlattr *, NL80211_ATTR_MAX + 1> newInterfaceMessageAttributes{};
+    int ret = nla_parse(std::data(newInterfaceMessageAttributes), std::size(newInterfaceMessageAttributes), genlmsg_attrdata(genl80211MessageHeader, 0), genlmsg_attrlen(genl80211MessageHeader, 0), nullptr);
+    if (ret < 0) {
+        LOG_ERROR << std::format("Failed to parse netlink message attributes with error {} ({})", ret, strerror(-ret));
+        return std::nullopt;
+    }
+
+    // Tease out parameters to populate the Nl80211Interface instance.
+    auto *interfaceName = static_cast<const char *>(nla_data(newInterfaceMessageAttributes[NL80211_ATTR_IFNAME]));
+    auto interfaceType = static_cast<nl80211_iftype>(nla_get_u32(newInterfaceMessageAttributes[NL80211_ATTR_IFTYPE]));
+    auto interfaceIndex = static_cast<uint32_t>(nla_get_u32(newInterfaceMessageAttributes[NL80211_ATTR_IFINDEX]));
+
+    return Nl80211Interface(interfaceName, interfaceType, interfaceIndex);
+}
+
+namespace detail
+{
+/**
+ * @brief Handler function for NL80211_CMD_GET_INTERFACE responses.
+ * 
+ * @param nl80211Message The response message to a NL80211_CMD_GET_INTERFACE dump request.
+ * @param context The context pointer provided to nl_socket_modify_cb. This must be a std::vector<Nl80211Interface>*.
+ * @return int 
+ */
+int
+HandleNl80211InterfaceDumpResponse(struct nl_msg *nl80211Message, void *context)
+{
+    if (context == nullptr) {
+        LOGE << "Received nl80211 interface dump response with null context";
+        return NL_SKIP;
+    }
+
+    // Extract vector to populate with interfaces.
+    auto &nl80211Interfaces = *static_cast<std::vector<Nl80211Interface> *>(context);
+
+    // Attempt to parse the message.
+    auto nl80211Interface = Nl80211Interface::Parse(nl80211Message);
+    if (!nl80211Interface.has_value()) {
+        LOGW << "Failed to parse nl80211 interface dump response";
+        return NL_SKIP;
+    } else {
+        LOGD << std::format("Parsed nl80211 interface dump response: {}", nl80211Interface->ToString());
+    }
+
+    nl80211Interfaces.push_back(std::move(nl80211Interface.value()));
+
+    return NL_OK;
+}
+} // namespace detail
+
+/* static */
+std::vector<Nl80211Interface>
+Nl80211Interface::Enumerate()
+{
+    // Allocate a new netlink socket.
+    auto nl80211SocketOpt{ CreateNl80211Socket() };
+    if (!nl80211SocketOpt.has_value()) {
+        LOGE << "Failed to create nl80211 socket";
+        return {};
+    }
+
+    // Allocate a new nl80211 message for sending the dump request for all interfaces.
+    auto nl80211Socket{ std::move(nl80211SocketOpt.value()) };
+    auto nl80211MessageGetInterfaces{ NetlinkMessage::Allocate() };
+    if (nl80211MessageGetInterfaces == nullptr) {
+        LOGE << "Failed to allocate nl80211 message for interface dump request";
+        return {};
+    }
+
+    // Populate the genl message for the interface dump request.
+    const int nl80211DriverId = Nl80211ProtocolState::Instance().DriverId;
+    const auto *genlMessageGetInterfaces = genlmsg_put(nl80211MessageGetInterfaces, NL_AUTO_PID, NL_AUTO_SEQ, nl80211DriverId, 0, NLM_F_DUMP, NL80211_CMD_GET_INTERFACE, 0);
+    if (genlMessageGetInterfaces == nullptr) {
+        LOGE << "Failed to populate genl message for interface dump request";
+        return {};
+    }
+
+    // Modify the socket callback to handle the response, providing a pointer to the vector to populate with interfaces.
+    std::vector<Nl80211Interface> nl80211Interfaces{};
+    int ret = nl_socket_modify_cb(nl80211Socket, NL_CB_VALID, NL_CB_CUSTOM, detail::HandleNl80211InterfaceDumpResponse, &nl80211Interfaces);
+    if (ret < 0) {
+        LOGE << std::format("Failed to modify socket callback with error {} ({})", ret, nl_geterror(ret));
+        return {};
+    }
+
+    // Send the request.
+    ret = nl_send_auto(nl80211Socket, nl80211MessageGetInterfaces);
+    if (ret < 0) {
+        LOGE << std::format("Failed to send interface dump request with error {} ({})", ret, nl_geterror(ret));
+        return {};
+    }
+
+    // Receive the response, which will invoke the configured callback for each message.
+    ret = nl_recvmsgs_default(nl80211Socket);
+    if (ret < 0) {
+        LOGE << std::format("Failed to receive interface dump response with error {} ({})", ret, nl_geterror(ret));
+        return {};
+    }
+
+    return nl80211Interfaces;
+}

--- a/src/linux/libnl-helpers/NetlinkMessage.cxx
+++ b/src/linux/libnl-helpers/NetlinkMessage.cxx
@@ -3,6 +3,14 @@
 
 using namespace Microsoft::Net::Netlink;
 
+/* static */
+NetlinkMessage
+NetlinkMessage::Allocate()
+{
+    auto message = nlmsg_alloc();
+    return NetlinkMessage{ message };
+}
+
 NetlinkMessage::NetlinkMessage(struct nl_msg* message) :
     Message(message)
 {

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkMessage.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkMessage.hxx
@@ -19,6 +19,14 @@ struct NetlinkMessage
     struct nl_msg* Message{ nullptr };
 
     /**
+     * @brief Allocate a new struct nl_msg, and wrap it in a NetlinkMessage.
+     *
+     * @return NetlinkMessage
+     */
+    static NetlinkMessage
+    Allocate();
+
+    /**
      * @brief Construct a new NetlinkMessage object that does not own a netlink
      * message object.
      */

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkSocket.hxx
@@ -26,9 +26,6 @@ struct NetlinkSocket
     static NetlinkSocket
     Allocate();
 
-    static NetlinkSocket
-    Create();
-
     /**
      * @brief Construct a default NetlinkSocket object that does not own a
      * netlink socket object.

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211.hxx
@@ -2,10 +2,12 @@
 #ifndef NETLINK_82011_HXX
 #define NETLINK_82011_HXX
 
+#include <optional>
 #include <string_view>
 #include <unordered_map>
 
 #include <linux/nl80211.h>
+#include <microsoft/net/netlink/NetlinkSocket.hxx>
 
 namespace Microsoft::Net::Netlink::Nl80211
 {
@@ -45,6 +47,16 @@ Nl80211CommandToString(nl80211_commands command) noexcept;
  */
 std::string_view
 Nl80211InterfaceTypeToString(nl80211_iftype type) noexcept;
+
+/**
+ * @brief Create a netlink socket for use with Nl80211.
+ *
+ * This creates a netlink socket and connects it to the nl80211 generic netlink family.
+ *
+ * @return std::optional<Microsoft::Net::Netlink::NetlinkSocket>
+ */
+std::optional<Microsoft::Net::Netlink::NetlinkSocket>
+CreateNl80211Socket();
 
 } // namespace Microsoft::Net::Netlink::Nl80211
 

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
@@ -8,28 +8,58 @@
 #include <string_view>
 #include <vector>
 
+#include <linux/netlink.h>
 #include <linux/nl80211.h>
+#include <netlink/msg.h>
 
 namespace Microsoft::Net::Netlink::Nl80211
 {
+/**
+ * @brief Represents a netlink 802.11 interface.
+ */
 struct Nl80211Interface
 {
-    static std::optional<Nl80211Interface>
-    Parse(struct nl_msg* nl80211Message);
+    std::string Name;
+    nl80211_iftype Type{ nl80211_iftype::NL80211_IFTYPE_UNSPECIFIED};
+    uint32_t Index;
 
+    /**
+     * @brief Parse a netlink message into an Nl80211Interface. The netlink message must contain a response to the
+     * NL80211_CMD_GET_INTERFACE command, which is encoded as a NL80211_CMD_NEW_INTERFACE.
+     * 
+     * @param nl80211Message The message to parse.
+     * @return std::optional<Nl80211Interface> Will contain a valid Nl80211Interface if the message was parsed
+     * successfully, otherwise has no value, indicating the message did not contain a valid NL80211_CMD_NEW_INTERFACE
+     * response
+     */
+    static std::optional<Nl80211Interface>
+    Parse(struct nl_msg* nl80211Message) noexcept;
+
+    /**
+     * @brief Enumerate all netlink 802.11 interfaces on the system.
+     * 
+     * @return std::vector<Nl80211Interface>
+     */
     static std::vector<Nl80211Interface>
     Enumerate();
 
+    /**
+     * @brief Convert the interface to a string representation.
+     * 
+     * @return std::string 
+     */
     std::string
     ToString() const;
 
-    std::string Name;
-    nl80211_iftype Type;
-    uint32_t Index;
-
 private:
-    Nl80211Interface() = default;
-    Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index);
+    /**
+     * @brief Construct a new Nl80211Interface object with the specified attributes.
+     * 
+     * @param name The name of the interface.
+     * @param type The nl80211_iftype of the interface.
+     * @param index The interface index in the kernel.
+     */
+    Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index) noexcept;
 };
 
 } // namespace Microsoft::Net::Netlink::Nl80211

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
@@ -1,0 +1,37 @@
+
+#ifndef NETLINK_82011_INTERFACE_HXX
+#define NETLINK_82011_INTERFACE_HXX
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <linux/nl80211.h>
+
+namespace Microsoft::Net::Netlink::Nl80211
+{
+struct Nl80211Interface
+{
+    static std::optional<Nl80211Interface>
+    Parse(struct nl_msg* nl80211Message);
+
+    static std::vector<Nl80211Interface>
+    Enumerate();
+
+    std::string
+    ToString() const;
+
+    std::string Name;
+    nl80211_iftype Type;
+    uint32_t Index;
+
+private:
+    Nl80211Interface() = default;
+    Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index);
+};
+
+} // namespace Microsoft::Net::Netlink::Nl80211
+
+#endif // NETLINK_82011_INTERFACE_HXX

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -79,24 +79,18 @@ AccessPointDiscoveryAgentOperationsNetlink::Start(AccessPointPresenceEventCallba
 
     // TODO: This function needs to signal errors either through its return type, or an exception.
 
-    // Allocate a new netlink socket.
-    auto netlinkSocket{ NetlinkSocket::Allocate() };
-    if (netlinkSocket == nullptr) {
+    // Allocate a new netlink socket for use with nl80211.
+    auto nl80211SocketOpt{ CreateNl80211Socket() };
+    if (nl80211SocketOpt == nullptr) {
         LOG_ERROR << "Failed to allocate new netlink socket for nl control";
         return;
     }
 
-    // Connect the socket to the generic netlink family.
-    int ret = genl_connect(netlinkSocket);
-    if (ret < 0) {
-        const auto err = errno;
-        LOG_ERROR << std::format("Failed to connect netlink socket for nl control with error {} ({})", err, strerror(err));
-        return;
-    }
+    auto nl80211Socket{ std::move(nl80211SocketOpt.value()) };
 
     // Subscribe to configuration messages.
     int nl80211MulticastGroupIdConfig = m_netlink80211ProtocolState.MulticastGroupId[Nl80211MulticastGroup::Configuration];
-    ret = nl_socket_add_membership(netlinkSocket, nl80211MulticastGroupIdConfig);
+    int ret = nl_socket_add_membership(nl80211Socket, nl80211MulticastGroupIdConfig);
     if (ret < 0) {
         const auto err = errno;
         LOG_ERROR << std::format("Failed to add netlink socket membership for '" NL80211_MULTICAST_GROUP_CONFIG "' group with error {} ({})", err, strerror(err));
@@ -106,7 +100,7 @@ AccessPointDiscoveryAgentOperationsNetlink::Start(AccessPointPresenceEventCallba
     // Update the access point presence callback for the netlink message handler to use.
     // Note: This is not thread-safe.
     m_accessPointPresenceCallback = std::move(accessPointPresenceEventCallback);
-    m_netlinkMessageProcessingThread = std::jthread([this, netlinkSocket = std::move(netlinkSocket)](std::stop_token stopToken) mutable {
+    m_netlinkMessageProcessingThread = std::jthread([this, netlinkSocket = std::move(nl80211Socket)](std::stop_token stopToken) mutable {
         ProcessNetlinkMessagesThread(std::move(netlinkSocket), std::move(stopToken));
     });
 }

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -1,4 +1,5 @@
 
+#include <algorithm>
 #include <array>
 #include <cerrno>
 #include <format>
@@ -8,6 +9,7 @@
 #include <linux/if.h>
 #include <magic_enum.hpp>
 #include <microsoft/net/netlink/nl80211/Netlink80211.hxx>
+#include <microsoft/net/netlink/nl80211/Netlink80211Interface.hxx>
 #include <microsoft/net/wifi/AccessPoint.hxx>
 #include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
 #include <microsoft/net/wifi/IAccessPoint.hxx>
@@ -122,8 +124,12 @@ AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync()
     std::promise<std::vector<std::string>> probePromise{};
     auto probeFuture = probePromise.get_future();
 
-    // TODO: implement this.
-    std::vector<std::string> accessPoints{};
+    auto nl80211Interfaces{ Nl80211Interface::Enumerate() };
+    std::vector<std::string> accessPoints(std::size(nl80211Interfaces));
+    std::ranges::transform(nl80211Interfaces, std::begin(accessPoints), [](const auto &nl80211Interface) {
+        return nl80211Interface.Name;
+    });
+
     probePromise.set_value(std::move(accessPoints));
 
     return probeFuture;

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -178,13 +178,6 @@ AccessPointDiscoveryAgentOperationsNetlink::ProcessNetlinkMessage(struct nl_msg 
         accessPointPresenceEvent = (interfaceType == NL80211_IFTYPE_AP) ? AccessPointPresenceEvent::Arrived : AccessPointPresenceEvent::Departed;
         break;
     }
-    // case NL80211_CMD_NEW_BEACON: {
-    //     break;
-    // }
-    // case NL80211_CMD_DEL_BEACON: {
-    //     interfaceIndex = static_cast<int32_t>(nla_get_u32(netlinkMessageAttributes[NL80211_ATTR_IFINDEX]));
-    //     break;
-    // }
     default: {
         PLOG_VERBOSE << std::format("Ignoring {} nl80211 command message", nl80211CommandName);
         return NL_SKIP;

--- a/tests/unit/linux/libnl-helpers/CMakeLists.txt
+++ b/tests/unit/linux/libnl-helpers/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(libnl-helpers-test-unit)
 
 target_sources(libnl-helpers-test-unit
     PRIVATE
+        TestNetlink80211Interface.cxx
         TestNetlink80211ProtocolState.cxx
 )
 

--- a/tests/unit/linux/libnl-helpers/TestNetlink80211Interface.cxx
+++ b/tests/unit/linux/libnl-helpers/TestNetlink80211Interface.cxx
@@ -1,0 +1,19 @@
+
+#include <catch2/catch_test_macros.hpp>
+#include <microsoft/net/netlink/nl80211/Netlink80211Interface.hxx>
+
+TEST_CASE("Nl80211Interface instance creation", "[linux][libnl-helpers]")
+{
+    using Microsoft::Net::Netlink::Nl80211::Nl80211Interface;
+
+    SECTION("Parse doesn't cause a crash with null input")
+    {
+        struct nl_msg *nl80211Message{ nullptr };
+        REQUIRE_NOTHROW(Nl80211Interface::Parse(nl80211Message));
+    }
+
+    SECTION("Enumerate doesn't cause a crash")
+    {
+        REQUIRE_NOTHROW(Nl80211Interface::Enumerate());
+    }
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow the subsystem to detect pre-existing interfaces when the server starts.

### Technical Details

* Implement `AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync()` using the nl80211 `NL80211_CMD_GET_INTERFACE` command with the dump flag.
* Add `Netlink80211Interface` helper class to represent nl80211 interfaces.
* Add helper function `CreateNl80211Socket` to create a socket which is connected with the nl80211 genl protocol.
* Add helper `Netlink::Allocate()` function to create a new wrapper with a pre-allocated netlink socket.

### Test Results

* All existing and new unit tests pass.

### Reviewer Focus

* None

### Future Work

* Make use of the `ProbeAsync` function to populate initial interfaces.
* Implement better error signaling (some `void` functions just return on error, some non-`void` functions return empty collections, etc.).

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
