### PR TITLE
Add helpers to parse nl80211 PHY information

### DIFF
--- a/src/linux/external/hostap/CMakeLists.txt
+++ b/src/linux/external/hostap/CMakeLists.txt
@@ -83,6 +83,12 @@ set(HOSTAPD_BIN
     "hostapd daemon binary"
 )
 
+set(HOSTAPD_CLI_BIN
+    ${HOSTAP_INSTALL_BIN_DIR}/hostapd_cli
+    CACHE FILEPATH    
+    "hostapd_cli binary"
+)
+
 install(
     FILES ${LIBWPA_CLIENT}
     TYPE LIB
@@ -91,6 +97,7 @@ install(
 install(
     PROGRAMS
         ${HOSTAPD_BIN}
+        ${HOSTAPD_CLI_BIN}
     DESTINATION
         ${CMAKE_INSTALL_SBINDIR}
 )

--- a/src/linux/libnl-helpers/CMakeLists.txt
+++ b/src/linux/libnl-helpers/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(libnl-helpers
         Netlink80211.cxx
         Netlink80211Interface.cxx
         Netlink80211ProtocolState.cxx
+        Netlink80211Wiphy.cxx
         NetlinkMessage.cxx
         NetlinkSocket.cxx
     PUBLIC
@@ -21,6 +22,7 @@ target_sources(libnl-helpers
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211Interface.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211ProtocolState.hxx
+        ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211Wiphy.hxx
 )
 
 target_link_libraries(libnl-helpers

--- a/src/linux/libnl-helpers/CMakeLists.txt
+++ b/src/linux/libnl-helpers/CMakeLists.txt
@@ -13,6 +13,8 @@ target_sources(libnl-helpers
         Netlink80211Wiphy.cxx
         NetlinkMessage.cxx
         NetlinkSocket.cxx
+        Netlink80211WiphyBand.cxx
+        Netlink80211WiphyBandFrequency.cxx
     PUBLIC
     FILE_SET HEADERS
     BASE_DIRS ${LIBNL_HELPERS_PUBLIC_INCLUDE}

--- a/src/linux/libnl-helpers/Netlink80211.cxx
+++ b/src/linux/libnl-helpers/Netlink80211.cxx
@@ -451,6 +451,52 @@ Nl80211InterfaceTypeToString(nl80211_iftype interfaceType) noexcept
     }
 }
 
+std::string_view
+Nl80211CipherSuiteToString(uint32_t cipherSuite) noexcept
+{
+    static constexpr uint32_t CipherTypeWep40 = 0x000fac01;
+    static constexpr uint32_t CipherTypeWep104 = 0x000fac05;
+    static constexpr uint32_t CipherTypeTkip = 0x000fac02;
+    static constexpr uint32_t CipherTypeCcmp128 = 0x000fac04;
+    static constexpr uint32_t CipherTypeCmac = 0x000fac06;
+    static constexpr uint32_t CipherTypeGcmp128 = 0x000fac08;
+    static constexpr uint32_t CipherTypeGcmp256 = 0x000fac09;
+    static constexpr uint32_t CipherTypeCcmp256 = 0x000fac0a;
+    static constexpr uint32_t CipherTypeGmac128 = 0x000fac0b;
+    static constexpr uint32_t CipherTypeGmac256 = 0x000fac0c;
+    static constexpr uint32_t CipherTypeCmac256 = 0x000fac0d;
+    static constexpr uint32_t CipherTypeWpiSms4 = 0x00147201;
+
+    switch (cipherSuite) {
+    case CipherTypeWep40:
+        return "WEP40";
+    case CipherTypeWep104:
+        return "WEP104";
+    case CipherTypeTkip:
+        return "TKIP";
+    case CipherTypeCcmp128:
+        return "CCMP-128";
+    case CipherTypeCmac:
+        return "CMAC";
+    case CipherTypeGcmp128:
+        return "GCMP-128";
+    case CipherTypeGcmp256:
+        return "GCMP-256";
+    case CipherTypeCcmp256:
+        return "CCMP-256";
+    case CipherTypeGmac128:
+        return "GMAC-128";
+    case CipherTypeGmac256:
+        return "GMAC-256";
+    case CipherTypeCmac256:
+        return "CMAC-256";
+    case CipherTypeWpiSms4:
+        return "WPI-SMS4";
+    default:
+        return "Uknown";
+    }
+}
+
 using Microsoft::Net::Netlink::NetlinkSocket;
 
 std::optional<NetlinkSocket>

--- a/src/linux/libnl-helpers/Netlink80211Interface.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Interface.cxx
@@ -17,22 +17,23 @@ using namespace Microsoft::Net::Netlink::Nl80211;
 using Microsoft::Net::Netlink::NetlinkMessage;
 using Microsoft::Net::Netlink::NetlinkSocket;
 
-Nl80211Interface::Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index) noexcept :
+Nl80211Interface::Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index, uint32_t wiphyIndex) noexcept :
     Name(name),
     Type(type),
-    Index(index)
+    Index(index),
+    WiphyIndex(wiphyIndex)
 {
 }
 
 std::string
 Nl80211Interface::ToString() const
 {
-    return std::format("[{}] {} {}", Index, Name, magic_enum::enum_name(Type));
+    return std::format("[{}/{}] {} {}", Index, WiphyIndex, Name, magic_enum::enum_name(Type));
 }
 
 /* static */
 std::optional<Nl80211Interface>
-Nl80211Interface::Parse(struct nl_msg* nl80211Message) noexcept
+Nl80211Interface::Parse(struct nl_msg *nl80211Message) noexcept
 {
     // Ensure the message is valid.
     if (nl80211Message == nullptr) {
@@ -62,18 +63,19 @@ Nl80211Interface::Parse(struct nl_msg* nl80211Message) noexcept
     auto *interfaceName = static_cast<const char *>(nla_data(newInterfaceMessageAttributes[NL80211_ATTR_IFNAME]));
     auto interfaceType = static_cast<nl80211_iftype>(nla_get_u32(newInterfaceMessageAttributes[NL80211_ATTR_IFTYPE]));
     auto interfaceIndex = static_cast<uint32_t>(nla_get_u32(newInterfaceMessageAttributes[NL80211_ATTR_IFINDEX]));
+    auto wiphyIndex = static_cast<uint32_t>(nla_get_u32(newInterfaceMessageAttributes[NL80211_ATTR_WIPHY]));
 
-    return Nl80211Interface(interfaceName, interfaceType, interfaceIndex);
+    return Nl80211Interface(interfaceName, interfaceType, interfaceIndex, wiphyIndex);
 }
 
 namespace detail
 {
 /**
  * @brief Handler function for NL80211_CMD_GET_INTERFACE responses.
- * 
+ *
  * @param nl80211Message The response message to a NL80211_CMD_GET_INTERFACE dump request.
  * @param context The context pointer provided to nl_socket_modify_cb. This must be a std::vector<Nl80211Interface>*.
- * @return int 
+ * @return int
  */
 int
 HandleNl80211InterfaceDumpResponse(struct nl_msg *nl80211Message, void *context)

--- a/src/linux/libnl-helpers/Netlink80211Interface.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Interface.cxx
@@ -154,3 +154,9 @@ Nl80211Interface::Enumerate()
 
     return nl80211Interfaces;
 }
+
+std::optional<Nl80211Wiphy>
+Nl80211Interface::GetWiphy() const
+{
+    return Nl80211Wiphy::FromIndex(WiphyIndex); 
+}

--- a/src/linux/libnl-helpers/Netlink80211Wiphy.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Wiphy.cxx
@@ -1,0 +1,140 @@
+
+#include <array>
+#include <format>
+
+#include <microsoft/net/netlink/NetlinkMessage.hxx>
+#include <microsoft/net/netlink/NetlinkSocket.hxx>
+#include <microsoft/net/netlink/nl80211/Netlink80211.hxx>
+#include <microsoft/net/netlink/nl80211/Netlink80211ProtocolState.hxx>
+#include <microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx>
+#include <netlink/genl/genl.h>
+#include <plog/Log.h>
+
+using namespace Microsoft::Net::Netlink::Nl80211;
+
+std::string
+Nl80211Wiphy::ToString() const
+{
+    return std::format("[{}] {}", Index, Name);
+}
+
+/* static */
+std::optional<Nl80211Wiphy>
+Nl80211Wiphy::Parse(struct nl_msg *nl80211Message) noexcept
+{
+    // Ensure the message is valid.
+    if (nl80211Message == nullptr) {
+        LOGE << "Received null nl80211 message";
+        return std::nullopt;
+    }
+
+    // Ensure the message has a valid genl header.
+    auto *nl80211MessageHeader{ static_cast<struct nlmsghdr *>(nlmsg_hdr(nl80211Message)) };
+    if (genlmsg_valid_hdr(nl80211MessageHeader, 1) < 0) {
+        LOGE << "Received invalid nl80211 message header";
+        return std::nullopt;
+    }
+
+    // Extract the nl80211 (genl) message header.
+    const auto *genl80211MessageHeader{ static_cast<struct genlmsghdr *>(nlmsg_data(nl80211MessageHeader)) };
+
+    // Parse the message.
+    std::array<struct nlattr *, NL80211_ATTR_MAX + 1> newInterfaceMessageAttributes{};
+    int ret = nla_parse(std::data(newInterfaceMessageAttributes), std::size(newInterfaceMessageAttributes), genlmsg_attrdata(genl80211MessageHeader, 0), genlmsg_attrlen(genl80211MessageHeader, 0), nullptr);
+    if (ret < 0) {
+        LOG_ERROR << std::format("Failed to parse netlink message attributes with error {} ({})", ret, strerror(-ret));
+        return std::nullopt;
+    }
+
+    // Tease out parameters to populate the Nl80211Wiphy instance.
+    auto wiphyIndex = static_cast<uint32_t>(nla_get_u32(newInterfaceMessageAttributes[NL80211_ATTR_WIPHY]));
+    auto wiphyName = static_cast<const char *>(nla_data(newInterfaceMessageAttributes[NL80211_ATTR_WIPHY_NAME]));
+
+    Nl80211Wiphy nl80211Wiphy{ wiphyIndex, wiphyName };
+    return nl80211Wiphy;
+}
+
+namespace detail
+{
+int
+HandleNl80211GetWiphyResponse(struct nl_msg *nl80211Message, void *context) noexcept
+{
+    if (context == nullptr) {
+        LOGE << "Received nl80211 get wiphy response with null context";
+        return NL_SKIP;
+    }
+
+    // Extract the std::optional<Nl80211Wiphy> from the context.
+    auto &nl80211WiphyResult = *static_cast<std::optional<Nl80211Wiphy> *>(context);
+
+    // Attempt to parse the message.
+    nl80211WiphyResult = Nl80211Wiphy::Parse(nl80211Message);
+    if (!nl80211WiphyResult.has_value()) {
+        LOGE << "Failed to parse nl80211 wiphy message";
+        return NL_SKIP;
+    } else {
+        LOGD << std::format("Parsed nl80211 wiphy message: {}", nl80211WiphyResult->ToString());
+    }
+
+    return NL_OK;
+}
+} // namespace detail
+
+/* static */
+std::optional<Nl80211Wiphy>
+Nl80211Wiphy::FromIndex(uint32_t wiphyIndex)
+{
+    // Allocate a new netlink socket.
+    auto nl80211SocketOpt{ CreateNl80211Socket() };
+    if (!nl80211SocketOpt.has_value()) {
+        LOGE << "Failed to create nl80211 socket";
+        return std::nullopt;
+    }
+
+    // Allocate a new nl80211 message for sending the dump request for all interfaces.
+    auto nl80211Socket{ std::move(nl80211SocketOpt.value()) };
+    auto nl80211MessageGetWiphy{ NetlinkMessage::Allocate() };
+    if (nl80211MessageGetWiphy == nullptr) {
+        LOGE << "Failed to allocate nl80211 message for wiphy request";
+        return std::nullopt;
+    }
+
+    // Populate the genl message for the wiphy request.
+    const int nl80211DriverId = Nl80211ProtocolState::Instance().DriverId;
+    const auto *genlMessageGetInterfaces = genlmsg_put(nl80211MessageGetWiphy, NL_AUTO_PID, NL_AUTO_SEQ, nl80211DriverId, 0, 0, NL80211_CMD_GET_WIPHY, 0);
+    if (genlMessageGetInterfaces == nullptr) {
+        LOGE << "Failed to populate genl message for interface dump request";
+        return std::nullopt;
+    }
+
+    // Add the wiphy index attribute so nl80211 knows what to lookup.
+    nla_put_u32(nl80211MessageGetWiphy, NL80211_ATTR_WIPHY, wiphyIndex);
+    std::optional<Nl80211Wiphy> nl80211Wiphy{};
+    int ret = nl_socket_modify_cb(nl80211Socket, NL_CB_VALID, NL_CB_CUSTOM, detail::HandleNl80211GetWiphyResponse, &nl80211Wiphy);
+    if (ret < 0) {
+        LOGE << std::format("Failed to modify socket callback with error {} ({})", ret, nl_geterror(ret));
+        return std::nullopt;
+    }
+
+    // Send the request.
+    ret = nl_send_auto(nl80211Socket, nl80211MessageGetWiphy);
+    if (ret < 0) {
+        LOGE << std::format("Failed to send get wiphy request with error {} ({})", ret, nl_geterror(ret));
+        return std::nullopt;
+    }
+
+    // Receive the response, which will invoke the configured callback.
+    ret = nl_recvmsgs_default(nl80211Socket);
+    if (ret < 0) {
+        LOGE << std::format("Failed to receive get wiphy response with error {} ({})", ret, nl_geterror(ret));
+        return std::nullopt;
+    }
+
+    return nl80211Wiphy;
+}
+
+Nl80211Wiphy::Nl80211Wiphy(uint32_t index, std::string_view name) noexcept :
+    Index(index),
+    Name(name)
+{
+}

--- a/src/linux/libnl-helpers/Netlink80211Wiphy.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Wiphy.cxx
@@ -14,9 +14,6 @@
 #include <netlink/genl/genl.h>
 #include <plog/Log.h>
 
-#include "ieee80211.h"
-#include <stdio.h>
-
 using namespace Microsoft::Net::Netlink::Nl80211;
 
 WiphyBandFrequency::WiphyBandFrequency(uint32_t frequency, std::optional<uint32_t> frequencyOffset, bool isDisabled) noexcept :

--- a/src/linux/libnl-helpers/Netlink80211Wiphy.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Wiphy.cxx
@@ -199,7 +199,7 @@ Nl80211Wiphy::ToString() const
 
     ss << " Cipher Suites:\n  ";
     for (const auto &cipherSuite : CipherSuites) {
-        ss << std::format("{:x} ", cipherSuite);
+        ss << std::format("{} ", Nl80211CipherSuiteToString(cipherSuite));
     }
 
     constexpr auto IfTypePrefixLength = std::size(std::string_view("NL80211_IFTYPE_"));

--- a/src/linux/libnl-helpers/Netlink80211WiphyBand.cxx
+++ b/src/linux/libnl-helpers/Netlink80211WiphyBand.cxx
@@ -1,0 +1,92 @@
+
+#include <array>
+#include <format>
+#include <sstream>
+
+#include <magic_enum.hpp>
+#include <microsoft/net/netlink/nl80211/Netlink80211WiphyBand.hxx>
+#include <netlink/attr.h>
+#include <netlink/genl/genl.h>
+#include <plog/Log.h>
+
+using namespace Microsoft::Net::Netlink::Nl80211;
+
+Nl80211WiphyBand::Nl80211WiphyBand(std::vector<WiphyBandFrequency> frequencies, std::vector<uint32_t> bitRates, uint16_t htCapabilities) noexcept :
+    Frequencies(std::move(frequencies)),
+    Bitrates(std::move(bitRates)),
+    HtCapabilities(htCapabilities)
+{
+}
+
+std::string
+Nl80211WiphyBand::ToString() const
+{
+    std::ostringstream ss;
+
+    ss << "   HT Capabilities: " << std::format("0x{:04x}\n", HtCapabilities);
+    ss << "   Frequencies:\n";
+    for (const auto &frequency : Frequencies) {
+        ss << std::format("    {}\n", frequency.ToString());
+    }
+    ss << "   Bitrates:\n";
+    for (const auto bitRate : Bitrates) {
+        ss << std::format("    {:2.1f} Mbps\n", 0.1 * bitRate);
+    }
+
+    return ss.str();
+}
+
+/* static */
+std::optional<Nl80211WiphyBand>
+Nl80211WiphyBand::Parse(struct nlattr *wiphyBand) noexcept
+{
+    // Parse the attribute message.
+    std::array<struct nlattr *, NL80211_BAND_ATTR_MAX + 1> wiphyBandAttributes{};
+    int ret = nla_parse(std::data(wiphyBandAttributes), std::size(wiphyBandAttributes), static_cast<struct nlattr *>(nla_data(wiphyBand)), nla_len(wiphyBand), nullptr);
+    if (ret < 0) {
+        LOGE << std::format("Failed to parse wiphy band attributes with error {} ({})", ret, nl_geterror(ret));
+        return std::nullopt;
+    }
+
+    uint16_t htCapabilities{ 0 };
+    if (wiphyBandAttributes[NL80211_BAND_ATTR_HT_CAPA] != nullptr) {
+        htCapabilities = nla_get_u16(wiphyBandAttributes[NL80211_BAND_ATTR_HT_CAPA]);
+    }
+
+    std::vector<WiphyBandFrequency> frequencies{};
+    if (wiphyBandAttributes[NL80211_BAND_ATTR_FREQS] != nullptr) {
+        LOGD << "Parsing frequencies ..";
+        struct nlattr *wiphyBandFrequency;
+        int remainingBandFrequencies;
+        nla_for_each_nested(wiphyBandFrequency, wiphyBandAttributes[NL80211_BAND_ATTR_FREQS], remainingBandFrequencies)
+        {
+            auto frequency = WiphyBandFrequency::Parse(wiphyBandFrequency);
+            if (frequency.has_value()) {
+                frequencies.emplace_back(std::move(frequency.value()));
+            }
+        }
+    } else {
+        LOGW << "No frequencies for band";
+    }
+
+    std::vector<uint32_t> bitRates{};
+    if (wiphyBandAttributes[NL80211_BAND_ATTR_RATES] != nullptr) {
+        int remainingBitRates;
+        struct nlattr *bitRate;
+        nla_for_each_nested(bitRate, wiphyBandAttributes[NL80211_BAND_ATTR_RATES], remainingBitRates) {
+            std::array<struct nlattr *, NL80211_BITRATE_ATTR_MAX + 1> bitRateAttributes{};
+            ret = nla_parse(std::data(bitRateAttributes), std::size(bitRateAttributes), static_cast<struct nlattr *>(nla_data(bitRate)), nla_len(bitRate), nullptr);
+            if (ret < 0) {
+                LOGW << std::format("Failed to parse wiphy band bit rate attributes with error {} ({})", ret, nl_geterror(ret));
+                return std::nullopt;
+            } else if (bitRateAttributes[NL80211_BITRATE_ATTR_RATE] == nullptr) {
+                continue;
+            }
+
+            auto bitRateValue = static_cast<uint32_t>(nla_get_u32(bitRateAttributes[NL80211_BITRATE_ATTR_RATE]));
+            bitRates.emplace_back(bitRateValue);
+        }
+    }
+
+    return Nl80211WiphyBand(std::move(frequencies), std::move(bitRates), htCapabilities);
+}

--- a/src/linux/libnl-helpers/Netlink80211WiphyBand.cxx
+++ b/src/linux/libnl-helpers/Netlink80211WiphyBand.cxx
@@ -46,8 +46,6 @@ Nl80211WiphyBand::Parse(struct nlattr *wiphyBand) noexcept
                 frequencies.emplace_back(std::move(frequency.value()));
             }
         }
-    } else {
-        LOGW << "No frequencies for band";
     }
 
     std::vector<uint32_t> bitRates{};

--- a/src/linux/libnl-helpers/Netlink80211WiphyBand.cxx
+++ b/src/linux/libnl-helpers/Netlink80211WiphyBand.cxx
@@ -37,7 +37,6 @@ Nl80211WiphyBand::Parse(struct nlattr *wiphyBand) noexcept
 
     std::vector<WiphyBandFrequency> frequencies{};
     if (wiphyBandAttributes[NL80211_BAND_ATTR_FREQS] != nullptr) {
-        LOGD << "Parsing frequencies ..";
         struct nlattr *wiphyBandFrequency;
         int remainingBandFrequencies;
         nla_for_each_nested(wiphyBandFrequency, wiphyBandAttributes[NL80211_BAND_ATTR_FREQS], remainingBandFrequencies)

--- a/src/linux/libnl-helpers/Netlink80211WiphyBand.cxx
+++ b/src/linux/libnl-helpers/Netlink80211WiphyBand.cxx
@@ -18,24 +18,6 @@ Nl80211WiphyBand::Nl80211WiphyBand(std::vector<WiphyBandFrequency> frequencies, 
 {
 }
 
-std::string
-Nl80211WiphyBand::ToString() const
-{
-    std::ostringstream ss;
-
-    ss << "   HT Capabilities: " << std::format("0x{:04x}\n", HtCapabilities);
-    ss << "   Frequencies:\n";
-    for (const auto &frequency : Frequencies) {
-        ss << std::format("    {}\n", frequency.ToString());
-    }
-    ss << "   Bitrates:\n";
-    for (const auto bitRate : Bitrates) {
-        ss << std::format("    {:2.1f} Mbps\n", 0.1 * bitRate);
-    }
-
-    return ss.str();
-}
-
 /* static */
 std::optional<Nl80211WiphyBand>
 Nl80211WiphyBand::Parse(struct nlattr *wiphyBand) noexcept
@@ -73,7 +55,8 @@ Nl80211WiphyBand::Parse(struct nlattr *wiphyBand) noexcept
     if (wiphyBandAttributes[NL80211_BAND_ATTR_RATES] != nullptr) {
         int remainingBitRates;
         struct nlattr *bitRate;
-        nla_for_each_nested(bitRate, wiphyBandAttributes[NL80211_BAND_ATTR_RATES], remainingBitRates) {
+        nla_for_each_nested(bitRate, wiphyBandAttributes[NL80211_BAND_ATTR_RATES], remainingBitRates)
+        {
             std::array<struct nlattr *, NL80211_BITRATE_ATTR_MAX + 1> bitRateAttributes{};
             ret = nla_parse(std::data(bitRateAttributes), std::size(bitRateAttributes), static_cast<struct nlattr *>(nla_data(bitRate)), nla_len(bitRate), nullptr);
             if (ret < 0) {
@@ -89,4 +72,22 @@ Nl80211WiphyBand::Parse(struct nlattr *wiphyBand) noexcept
     }
 
     return Nl80211WiphyBand(std::move(frequencies), std::move(bitRates), htCapabilities);
+}
+
+std::string
+Nl80211WiphyBand::ToString() const
+{
+    std::ostringstream ss;
+
+    ss << "   HT Capabilities: " << std::format("0x{:04x}\n", HtCapabilities);
+    ss << "   Frequencies:\n";
+    for (const auto &frequency : Frequencies) {
+        ss << std::format("    {}\n", frequency.ToString());
+    }
+    ss << "   Bitrates:\n";
+    for (const auto bitRate : Bitrates) {
+        ss << std::format("    {:2.1f} Mbps\n", BitRateUnitMbpsMultiplier * bitRate);
+    }
+
+    return ss.str();
 }

--- a/src/linux/libnl-helpers/Netlink80211WiphyBandFrequency.cxx
+++ b/src/linux/libnl-helpers/Netlink80211WiphyBandFrequency.cxx
@@ -1,0 +1,59 @@
+
+#include <array>
+#include <format>
+#include <sstream>
+
+#include <magic_enum.hpp>
+#include <microsoft/net/netlink/nl80211/Netlink80211WiphyBandFrequency.hxx>
+#include <netlink/attr.h>
+#include <netlink/genl/genl.h>
+#include <plog/Log.h>
+
+using namespace Microsoft::Net::Netlink::Nl80211;
+
+WiphyBandFrequency::WiphyBandFrequency(uint32_t frequency, std::optional<uint32_t> frequencyOffset, bool isDisabled) noexcept :
+    Frequency(frequency),
+    FrequencyOffset(frequencyOffset),
+    IsDisabled(isDisabled)
+{
+}
+
+std::string
+WiphyBandFrequency::ToString() const
+{
+    std::ostringstream ss;
+    ss << std::format("{}.{} MHz", Frequency, FrequencyOffset.value_or(0));
+    if (IsDisabled) {
+        ss << " (disabled)";
+    }
+
+    return ss.str();
+}
+
+/* static */
+std::optional<WiphyBandFrequency>
+WiphyBandFrequency::Parse(struct nlattr *wiphyBandFrequencyNlAttribute) noexcept
+{
+    // Parse the attribute message.
+    std::array<struct nlattr *, NL80211_FREQUENCY_ATTR_MAX + 1> wiphyBandFrequenciesAttributes{};
+    int ret = nla_parse(std::data(wiphyBandFrequenciesAttributes), std::size(wiphyBandFrequenciesAttributes), static_cast<struct nlattr *>(nla_data(wiphyBandFrequencyNlAttribute)), nla_len(wiphyBandFrequencyNlAttribute), nullptr);
+    if (ret < 0) {
+        LOGE << std::format("Failed to parse wiphy band frequency attributes with error {} ({})", ret, nl_geterror(ret));
+        return std::nullopt;
+    }
+
+    if (wiphyBandFrequenciesAttributes[NL80211_FREQUENCY_ATTR_FREQ] == nullptr) {
+        LOGW << "Received null wiphy band frequency";
+        return std::nullopt;
+    }
+
+    auto isDisabled = wiphyBandFrequenciesAttributes[NL80211_FREQUENCY_ATTR_DISABLED] != nullptr;
+    auto frequency = static_cast<uint32_t>(nla_get_u32(wiphyBandFrequenciesAttributes[NL80211_FREQUENCY_ATTR_FREQ]));
+    std::optional<uint32_t> frequencyOffset{};
+    if (wiphyBandFrequenciesAttributes[NL80211_FREQUENCY_ATTR_OFFSET] != nullptr) {
+        frequencyOffset = static_cast<uint32_t>(nla_get_u32(wiphyBandFrequenciesAttributes[NL80211_FREQUENCY_ATTR_OFFSET]));
+    }
+
+    WiphyBandFrequency wiphyBandFrequency{ frequency, frequencyOffset, isDisabled };
+    return wiphyBandFrequency;
+}

--- a/src/linux/libnl-helpers/Netlink80211WiphyBandFrequency.cxx
+++ b/src/linux/libnl-helpers/Netlink80211WiphyBandFrequency.cxx
@@ -18,18 +18,6 @@ WiphyBandFrequency::WiphyBandFrequency(uint32_t frequency, std::optional<uint32_
 {
 }
 
-std::string
-WiphyBandFrequency::ToString() const
-{
-    std::ostringstream ss;
-    ss << std::format("{}.{} MHz", Frequency, FrequencyOffset.value_or(0));
-    if (IsDisabled) {
-        ss << " (disabled)";
-    }
-
-    return ss.str();
-}
-
 /* static */
 std::optional<WiphyBandFrequency>
 WiphyBandFrequency::Parse(struct nlattr *wiphyBandFrequencyNlAttribute) noexcept
@@ -56,4 +44,16 @@ WiphyBandFrequency::Parse(struct nlattr *wiphyBandFrequencyNlAttribute) noexcept
 
     WiphyBandFrequency wiphyBandFrequency{ frequency, frequencyOffset, isDisabled };
     return wiphyBandFrequency;
+}
+
+std::string
+WiphyBandFrequency::ToString() const
+{
+    std::ostringstream ss;
+    ss << std::format("{}.{} MHz", Frequency, FrequencyOffset.value_or(0));
+    if (IsDisabled) {
+        ss << " (disabled)";
+    }
+
+    return ss.str();
 }

--- a/src/linux/libnl-helpers/Netlink80211WiphyBandFrequency.cxx
+++ b/src/linux/libnl-helpers/Netlink80211WiphyBandFrequency.cxx
@@ -31,12 +31,11 @@ WiphyBandFrequency::Parse(struct nlattr *wiphyBandFrequencyNlAttribute) noexcept
     }
 
     if (wiphyBandFrequenciesAttributes[NL80211_FREQUENCY_ATTR_FREQ] == nullptr) {
-        LOGW << "Received null wiphy band frequency";
         return std::nullopt;
     }
 
-    auto isDisabled = wiphyBandFrequenciesAttributes[NL80211_FREQUENCY_ATTR_DISABLED] != nullptr;
-    auto frequency = static_cast<uint32_t>(nla_get_u32(wiphyBandFrequenciesAttributes[NL80211_FREQUENCY_ATTR_FREQ]));
+    const auto isDisabled = wiphyBandFrequenciesAttributes[NL80211_FREQUENCY_ATTR_DISABLED] != nullptr;
+    const auto frequency = static_cast<uint32_t>(nla_get_u32(wiphyBandFrequenciesAttributes[NL80211_FREQUENCY_ATTR_FREQ]));
     std::optional<uint32_t> frequencyOffset{};
     if (wiphyBandFrequenciesAttributes[NL80211_FREQUENCY_ATTR_OFFSET] != nullptr) {
         frequencyOffset = static_cast<uint32_t>(nla_get_u32(wiphyBandFrequenciesAttributes[NL80211_FREQUENCY_ATTR_OFFSET]));

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211.hxx
@@ -49,6 +49,14 @@ std::string_view
 Nl80211InterfaceTypeToString(nl80211_iftype type) noexcept;
 
 /**
+ * @brief Convert a cipher suite value to a string.
+ *
+ * @return std::string_view
+ */
+std::string_view
+Nl80211CipherSuiteToString(uint32_t cipherType) noexcept;
+
+/**
  * @brief Create a netlink socket for use with Nl80211.
  *
  * This creates a netlink socket and connects it to the nl80211 generic netlink family.

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
@@ -20,13 +20,14 @@ namespace Microsoft::Net::Netlink::Nl80211
 struct Nl80211Interface
 {
     std::string Name;
-    nl80211_iftype Type{ nl80211_iftype::NL80211_IFTYPE_UNSPECIFIED};
+    nl80211_iftype Type{ nl80211_iftype::NL80211_IFTYPE_UNSPECIFIED };
     uint32_t Index;
+    uint32_t WiphyIndex;
 
     /**
      * @brief Parse a netlink message into an Nl80211Interface. The netlink message must contain a response to the
      * NL80211_CMD_GET_INTERFACE command, which is encoded as a NL80211_CMD_NEW_INTERFACE.
-     * 
+     *
      * @param nl80211Message The message to parse.
      * @return std::optional<Nl80211Interface> Will contain a valid Nl80211Interface if the message was parsed
      * successfully, otherwise has no value, indicating the message did not contain a valid NL80211_CMD_NEW_INTERFACE
@@ -37,7 +38,7 @@ struct Nl80211Interface
 
     /**
      * @brief Enumerate all netlink 802.11 interfaces on the system.
-     * 
+     *
      * @return std::vector<Nl80211Interface>
      */
     static std::vector<Nl80211Interface>
@@ -45,8 +46,8 @@ struct Nl80211Interface
 
     /**
      * @brief Convert the interface to a string representation.
-     * 
-     * @return std::string 
+     *
+     * @return std::string
      */
     std::string
     ToString() const;
@@ -54,12 +55,13 @@ struct Nl80211Interface
 private:
     /**
      * @brief Construct a new Nl80211Interface object with the specified attributes.
-     * 
+     *
      * @param name The name of the interface.
      * @param type The nl80211_iftype of the interface.
      * @param index The interface index in the kernel.
+     * @param wiphyIndex The phy interface index in the kernel.
      */
-    Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index) noexcept;
+    Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index, uint32_t wiphyIndex) noexcept;
 };
 
 } // namespace Microsoft::Net::Netlink::Nl80211

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
@@ -12,6 +12,8 @@
 #include <linux/nl80211.h>
 #include <netlink/msg.h>
 
+#include <microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx>
+
 namespace Microsoft::Net::Netlink::Nl80211
 {
 /**
@@ -43,6 +45,14 @@ struct Nl80211Interface
      */
     static std::vector<Nl80211Interface>
     Enumerate();
+
+    /**
+     * @brief Get the Wiphy (PHY) object associated with this interface.
+     * 
+     * @return std::optional<Nl80211Wiphy> 
+     */
+    std::optional<Nl80211Wiphy>
+    GetWiphy() const;
 
     /**
      * @brief Convert the interface to a string representation.

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
@@ -13,44 +13,10 @@
 #include <linux/nl80211.h>
 #include <netlink/msg.h>
 
+#include <microsoft/net/netlink/nl80211/Netlink80211WiphyBand.hxx>
+
 namespace Microsoft::Net::Netlink::Nl80211
 {
-struct WiphyBandFrequency
-{
-    uint32_t Frequency;
-    std::optional<uint32_t> FrequencyOffset;
-    bool IsDisabled;
-
-    static std::optional<WiphyBandFrequency>
-    Parse(struct nlattr* wiphyBandFrequency) noexcept;
-
-    std::string
-    ToString() const;
-
-private:
-    WiphyBandFrequency(uint32_t frequency, std::optional<uint32_t> frequencyOffset, bool isDisabled) noexcept;
-};
-
-/**
- * @brief Represents a netlink 802.11 wiphy radio band and its properties.
- * TODO: move to own file.
- */
-struct Nl80211WiphyBand
-{
-    std::vector<WiphyBandFrequency> Frequencies;
-    std::vector<uint32_t> Bitrates;
-    uint16_t HtCapabilities;
-
-    std::string
-    ToString() const;
-
-    static std::optional<Nl80211WiphyBand>
-    Parse(struct nlattr* wiphyBand) noexcept;
-
-private:
-    Nl80211WiphyBand(std::vector<WiphyBandFrequency> frequencies, std::vector<uint32_t> bitRates, uint16_t htCapabilities) noexcept;
-};
-
 /**
  * @brief Represents a netlink 802.11 wiphy.
  */

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
@@ -1,0 +1,64 @@
+
+#ifndef NETLINK_80211_WIPHY_HXX
+#define NETLINK_80211_WIPHY_HXX
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <linux/netlink.h>
+#include <linux/nl80211.h>
+#include <netlink/msg.h>
+
+namespace Microsoft::Net::Netlink::Nl80211
+{
+/**
+ * @brief Represents a netlink 802.11 wiphy.
+ */
+struct Nl80211Wiphy
+{
+    uint32_t Index;
+    std::string Name;
+
+    /**
+     * @brief Creates a new Nl80211Wiphy object from the specified wiphy index.
+     *
+     * @param wiphyIndex The wiphy index to create the object from.
+     * @return std::optional<Nl80211Wiphy>
+     */
+    static std::optional<Nl80211Wiphy>
+    FromIndex(uint32_t wiphyIndex);
+
+    /**
+     * @brief Parse a netlink message into an Nl80211Wiphy. The netlink message must contain a response to the
+     * NL80211_CMD_GET_WIPHY command.
+     *
+     * @param nl80211Message The message to parse.
+     * @return std::optional<Nl80211Wiphy> A valid Nl80211Wiphy if the message was parsed successfully, otherwise has no
+     * value.
+     */
+    static std::optional<Nl80211Wiphy>
+    Parse(struct nl_msg* nl80211Message) noexcept;
+
+    /**
+     * @brief Convert the wiphy to a string representation.
+     *
+     * @return std::string
+     */
+    std::string
+    ToString() const;
+
+private:
+    /**
+     * @brief Construct a new Nl80211Wiphy object.
+     *
+     * @param index The wiphy index.
+     * @param name The wiphy name.
+     */
+    Nl80211Wiphy(uint32_t index, std::string_view name) noexcept;
+};
+
+} // namespace Microsoft::Net::Netlink::Nl80211
+
+#endif // NETLINK_80211_WIPHY_HXX

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
@@ -6,6 +6,8 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
+#include <vector>
 
 #include <linux/netlink.h>
 #include <linux/nl80211.h>
@@ -14,12 +16,28 @@
 namespace Microsoft::Net::Netlink::Nl80211
 {
 /**
+ * @brief Represents a netlink 802.11 wiphy radio band and its properties.
+ * TODO: move to own file.
+ */
+struct Nl80211WiphyBand
+{
+    bool SupportsRoaming;
+
+    Nl80211WiphyBand(bool supportsRoaming) noexcept;
+
+    std::string
+    ToString() const;
+};
+
+/**
  * @brief Represents a netlink 802.11 wiphy.
  */
 struct Nl80211Wiphy
 {
     uint32_t Index;
     std::string Name;
+    std::vector<uint32_t> CipherSuites;
+    std::unordered_map<nl80211_band, Nl80211WiphyBand> Bands;
 
     /**
      * @brief Creates a new Nl80211Wiphy object from the specified wiphy index.
@@ -56,7 +74,7 @@ private:
      * @param index The wiphy index.
      * @param name The wiphy name.
      */
-    Nl80211Wiphy(uint32_t index, std::string_view name) noexcept;
+    Nl80211Wiphy(uint32_t index, std::string_view name, std::vector<uint32_t> cipherSuites, std::unordered_map<nl80211_band, Nl80211WiphyBand> bands) noexcept;
 };
 
 } // namespace Microsoft::Net::Netlink::Nl80211

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
@@ -27,6 +27,7 @@ struct Nl80211Wiphy
     std::string Name;
     std::vector<uint32_t> CipherSuites;
     std::unordered_map<nl80211_band, Nl80211WiphyBand> Bands;
+    std::vector<nl80211_iftype> SupportedInterfaceTypes;
     bool SupportsRoaming;
 
     /**
@@ -64,7 +65,7 @@ private:
      * @param index The wiphy index.
      * @param name The wiphy name.
      */
-    Nl80211Wiphy(uint32_t index, std::string_view name, std::vector<uint32_t> cipherSuites, std::unordered_map<nl80211_band, Nl80211WiphyBand> bands, bool supportsRoaming) noexcept;
+    Nl80211Wiphy(uint32_t index, std::string_view name, std::vector<uint32_t> cipherSuites, std::unordered_map<nl80211_band, Nl80211WiphyBand> bands, std::vector<nl80211_iftype> supportedInterfaceTypes, bool supportsRoaming) noexcept;
 };
 
 } // namespace Microsoft::Net::Netlink::Nl80211

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
@@ -15,18 +15,40 @@
 
 namespace Microsoft::Net::Netlink::Nl80211
 {
+struct WiphyBandFrequency
+{
+    uint32_t Frequency;
+    std::optional<uint32_t> FrequencyOffset;
+    bool IsDisabled;
+
+    static std::optional<WiphyBandFrequency>
+    Parse(struct nlattr* wiphyBandFrequency) noexcept;
+
+    std::string
+    ToString() const;
+
+private:
+    WiphyBandFrequency(uint32_t frequency, std::optional<uint32_t> frequencyOffset, bool isDisabled) noexcept;
+};
+
 /**
  * @brief Represents a netlink 802.11 wiphy radio band and its properties.
  * TODO: move to own file.
  */
 struct Nl80211WiphyBand
 {
-    bool SupportsRoaming;
-
-    Nl80211WiphyBand(bool supportsRoaming) noexcept;
+    std::vector<WiphyBandFrequency> Frequencies;
+    std::vector<uint32_t> Bitrates;
+    uint16_t HtCapabilities;
 
     std::string
     ToString() const;
+
+    static std::optional<Nl80211WiphyBand>
+    Parse(struct nlattr* wiphyBand) noexcept;
+
+private:
+    Nl80211WiphyBand(std::vector<WiphyBandFrequency> frequencies, std::vector<uint32_t> bitRates, uint16_t htCapabilities) noexcept;
 };
 
 /**
@@ -38,6 +60,7 @@ struct Nl80211Wiphy
     std::string Name;
     std::vector<uint32_t> CipherSuites;
     std::unordered_map<nl80211_band, Nl80211WiphyBand> Bands;
+    bool SupportsRoaming;
 
     /**
      * @brief Creates a new Nl80211Wiphy object from the specified wiphy index.
@@ -74,7 +97,7 @@ private:
      * @param index The wiphy index.
      * @param name The wiphy name.
      */
-    Nl80211Wiphy(uint32_t index, std::string_view name, std::vector<uint32_t> cipherSuites, std::unordered_map<nl80211_band, Nl80211WiphyBand> bands) noexcept;
+    Nl80211Wiphy(uint32_t index, std::string_view name, std::vector<uint32_t> cipherSuites, std::unordered_map<nl80211_band, Nl80211WiphyBand> bands, bool supportsRoaming) noexcept;
 };
 
 } // namespace Microsoft::Net::Netlink::Nl80211

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
@@ -18,7 +18,8 @@
 namespace Microsoft::Net::Netlink::Nl80211
 {
 /**
- * @brief Represents a netlink 802.11 wiphy.
+ * @brief Represents a netlink 802.11 wiphy. This is the interface to the physical radio and describes raw capabilities
+ * of the device, irrespective of how the device is being used (eg. in userspace via hostapd, etc.).
  */
 struct Nl80211Wiphy
 {

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211WiphyBand.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211WiphyBand.hxx
@@ -24,29 +24,35 @@ struct Nl80211WiphyBand
     uint16_t HtCapabilities;
 
     /**
-     * @brief 
-     * 
-     * @return std::string 
-     */
-    std::string
-    ToString() const;
-
-    /**
-     * @brief 
-     * 
-     * @param wiphyBand 
-     * @return std::optional<Nl80211WiphyBand> 
+     * @brief Parses a netlink attribute into a Nl80211WiphyBand.
+     *
+     * @param wiphyBand The netlink attribute to parse.
+     * @return std::optional<Nl80211WiphyBand>
      */
     static std::optional<Nl80211WiphyBand>
     Parse(struct nlattr* wiphyBand) noexcept;
 
+    /**
+     * @brief Convert the wiphy band to a string representation.
+     *
+     * @return std::string
+     */
+    std::string
+    ToString() const;
+
+private:
+    /**
+     * @brief The value to multiply the bitrate by to get the actual bitrate in Mbps.
+     */
+    static constexpr auto BitRateUnitMbpsMultiplier = 0.1;
+
 private:
     /**
      * @brief Construct a new Nl80211WiphyBand object.
-     * 
-     * @param frequencies 
-     * @param bitRates 
-     * @param htCapabilities 
+     *
+     * @param frequencies The frequencies supported by this band.
+     * @param bitRates The bitrates supported by this band.
+     * @param htCapabilities The high-throughput ('HT' aka 802.11n) capabilities of this band.
      */
     Nl80211WiphyBand(std::vector<WiphyBandFrequency> frequencies, std::vector<uint32_t> bitRates, uint16_t htCapabilities) noexcept;
 };

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211WiphyBand.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211WiphyBand.hxx
@@ -2,6 +2,7 @@
 #ifndef NETLINK_80211_WIPHY_BAND_HXX
 #define NETLINK_80211_WIPHY_BAND_HXX
 
+#include <array>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -22,6 +23,11 @@ struct Nl80211WiphyBand
     std::vector<WiphyBandFrequency> Frequencies;
     std::vector<uint32_t> Bitrates;
     uint16_t HtCapabilities;
+    uint32_t VhtCapabilities;
+
+    // From documentation in nl80211.h under nl80211_band_attr defintion.
+    static constexpr auto VhtMcsSetNumBytes{ 32 };
+    std::optional<std::array<uint8_t, VhtMcsSetNumBytes>> VhtMcsSet;
 
     /**
      * @brief Parses a netlink attribute into a Nl80211WiphyBand.
@@ -53,8 +59,9 @@ private:
      * @param frequencies The frequencies supported by this band.
      * @param bitRates The bitrates supported by this band.
      * @param htCapabilities The high-throughput ('HT' aka 802.11n) capabilities of this band.
+     * @param vhtCapabilities The very-high-throughput ('VHT' aka 802.11ac) capabilities of this band.
      */
-    Nl80211WiphyBand(std::vector<WiphyBandFrequency> frequencies, std::vector<uint32_t> bitRates, uint16_t htCapabilities) noexcept;
+    Nl80211WiphyBand(std::vector<WiphyBandFrequency> frequencies, std::vector<uint32_t> bitRates, uint16_t htCapabilities, uint32_t vhtCapabilities, std::optional<std::array<uint8_t, VhtMcsSetNumBytes>> vhtMcsSet) noexcept;
 };
 } // namespace Microsoft::Net::Netlink::Nl80211
 

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211WiphyBand.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211WiphyBand.hxx
@@ -1,0 +1,55 @@
+
+#ifndef NETLINK_80211_WIPHY_BAND_HXX
+#define NETLINK_80211_WIPHY_BAND_HXX
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include <linux/netlink.h>
+#include <linux/nl80211.h>
+#include <netlink/msg.h>
+
+#include <microsoft/net/netlink/nl80211/Netlink80211WiphyBandFrequency.hxx>
+
+namespace Microsoft::Net::Netlink::Nl80211
+{
+/**
+ * @brief Represents a netlink 802.11 wiphy radio band and its properties.
+ */
+struct Nl80211WiphyBand
+{
+    std::vector<WiphyBandFrequency> Frequencies;
+    std::vector<uint32_t> Bitrates;
+    uint16_t HtCapabilities;
+
+    /**
+     * @brief 
+     * 
+     * @return std::string 
+     */
+    std::string
+    ToString() const;
+
+    /**
+     * @brief 
+     * 
+     * @param wiphyBand 
+     * @return std::optional<Nl80211WiphyBand> 
+     */
+    static std::optional<Nl80211WiphyBand>
+    Parse(struct nlattr* wiphyBand) noexcept;
+
+private:
+    /**
+     * @brief Construct a new Nl80211WiphyBand object.
+     * 
+     * @param frequencies 
+     * @param bitRates 
+     * @param htCapabilities 
+     */
+    Nl80211WiphyBand(std::vector<WiphyBandFrequency> frequencies, std::vector<uint32_t> bitRates, uint16_t htCapabilities) noexcept;
+};
+} // namespace Microsoft::Net::Netlink::Nl80211
+
+#endif // NETLINK_80211_WIPHY_BAND_HXX

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211WiphyBandFrequency.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211WiphyBandFrequency.hxx
@@ -13,7 +13,7 @@
 namespace Microsoft::Net::Netlink::Nl80211
 {
 /**
- * @brief Represents data about a frequency in a netlink 802.11 wiphy radio band.
+ * @brief Represents information about a frequency in a netlink 802.11 wiphy radio band.
  */
 struct WiphyBandFrequency
 {
@@ -22,29 +22,29 @@ struct WiphyBandFrequency
     bool IsDisabled;
 
     /**
-     * @brief 
-     * 
-     * @param wiphyBandFrequency 
-     * @return std::optional<WiphyBandFrequency> 
+     * @brief Parses a netlink attribute into a WiphyBandFrequency.
+     *
+     * @param wiphyBandFrequency The netlink attribute to parse.
+     * @return std::optional<WiphyBandFrequency>
      */
     static std::optional<WiphyBandFrequency>
     Parse(struct nlattr* wiphyBandFrequency) noexcept;
 
     /**
-     * @brief 
-     * 
-     * @return std::string 
+     * @brief Convert the frequency to a string representation.
+     *
+     * @return std::string
      */
     std::string
     ToString() const;
 
 private:
     /**
-     * @brief Construct a new Wiphy Band Frequency object
-     * 
-     * @param frequency 
-     * @param frequencyOffset 
-     * @param isDisabled 
+     * @brief Construct a new Wiphy Band Frequency object.
+     *
+     * @param frequency The frequency in MHz.
+     * @param frequencyOffset The fractional portion of the frequency, if any.
+     * @param isDisabled Whether the frequency is disabled.
      */
     WiphyBandFrequency(uint32_t frequency, std::optional<uint32_t> frequencyOffset, bool isDisabled) noexcept;
 };

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211WiphyBandFrequency.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211WiphyBandFrequency.hxx
@@ -1,0 +1,53 @@
+
+#ifndef NETLINK_80211_WIPHY_BAND_FREQUENCY_HXX
+#define NETLINK_80211_WIPHY_BAND_FREQUENCY_HXX
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include <linux/netlink.h>
+#include <linux/nl80211.h>
+#include <netlink/msg.h>
+
+namespace Microsoft::Net::Netlink::Nl80211
+{
+/**
+ * @brief Represents data about a frequency in a netlink 802.11 wiphy radio band.
+ */
+struct WiphyBandFrequency
+{
+    uint32_t Frequency;
+    std::optional<uint32_t> FrequencyOffset;
+    bool IsDisabled;
+
+    /**
+     * @brief 
+     * 
+     * @param wiphyBandFrequency 
+     * @return std::optional<WiphyBandFrequency> 
+     */
+    static std::optional<WiphyBandFrequency>
+    Parse(struct nlattr* wiphyBandFrequency) noexcept;
+
+    /**
+     * @brief 
+     * 
+     * @return std::string 
+     */
+    std::string
+    ToString() const;
+
+private:
+    /**
+     * @brief Construct a new Wiphy Band Frequency object
+     * 
+     * @param frequency 
+     * @param frequencyOffset 
+     * @param isDisabled 
+     */
+    WiphyBandFrequency(uint32_t frequency, std::optional<uint32_t> frequencyOffset, bool isDisabled) noexcept;
+};
+} // namespace Microsoft::Net::Netlink::Nl80211
+
+#endif // NETLINK_80211_WIPHY_BAND_FREQUENCY_HXX


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure AP capability information can be used in the netremote API implementation.

### Technical Details

* Install the `hostapd_cli` command-line tool.
* Add wiphy index and accessor method to `Nl80211Interface`.
* Add `Nl80211<Wiphy|WiphyBand|WiphyBandFrequency>` classes to represent the corresponding nl80211 concepts of a Wi-Fi PHY, band, and frequency respectively, including code to parse nl80211 messages containing this information.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Use these to populate the AP capability information in `WifiEnumerateAccessPoints` via `Microsoft.Net.Wifi.AccessPointCapabilities`.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
