### PR TITLE
systemd service unit fixes

### DIFF
--- a/src/linux/external/hostap/CMakeLists.txt
+++ b/src/linux/external/hostap/CMakeLists.txt
@@ -102,4 +102,8 @@ install(
         ${CMAKE_INSTALL_SBINDIR}
 )
 
+install(
+    DIRECTORY DESTINATION ${CMAKE_INSTALL_FULL_RUNSTATEDIR}
+)
+
 add_subdirectory(systemd)

--- a/src/linux/external/hostap/systemd/hostapd@.service.in
+++ b/src/linux/external/hostap/systemd/hostapd@.service.in
@@ -6,7 +6,7 @@ After=sys-subsystem-net-devices-%i.device
 [Service]
 Type=simple
 Restart=on-failure
-ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/hostapd -i %i @CMAKE_INSTALL_FULL_SYSCONFDIR@/hostapd/hostapd-%i.conf
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/hostapd -i %i ${HOSTAPD_XTRA_ARGS} @CMAKE_INSTALL_FULL_SYSCONFDIR@/hostapd/hostapd-%i.conf
 
 [Install]
 WantedBy=default.target

--- a/src/linux/external/hostap/systemd/hostapd@.service.in
+++ b/src/linux/external/hostap/systemd/hostapd@.service.in
@@ -6,7 +6,7 @@ After=sys-subsystem-net-devices-%i.device
 [Service]
 Type=forking
 Restart=on-failure
-ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/hostapd -B -P @CMAKE_INSTALL_FULL_RUNSTATEDIR@/hostapd/hostapd-%i.pid -i %i @CMAKE_INSTALL_FULL_SYSCONFDIR@/hostapd/hostapd-%i.conf ${HOSTAPD_XTRA_ARGS}
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/hostapd -B -P @CMAKE_INSTALL_FULL_RUNSTATEDIR@/hostapd/hostapd-%i.pid -i %i ${HOSTAPD_XTRA_ARGS} @CMAKE_INSTALL_FULL_SYSCONFDIR@/hostapd/hostapd-%i.conf
 PIDFile=@CMAKE_INSTALL_FULL_RUNSTATEDIR@/hostapd/hostapd-%i.pid
 
 [Install]

--- a/src/linux/external/hostap/systemd/hostapd@.service.in
+++ b/src/linux/external/hostap/systemd/hostapd@.service.in
@@ -4,10 +4,9 @@ Requires=sys-subsystem-net-devices-%i.device
 After=sys-subsystem-net-devices-%i.device
 
 [Service]
-Type=forking
+Type=simple
 Restart=on-failure
-ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/hostapd -B -P @CMAKE_INSTALL_FULL_RUNSTATEDIR@/hostapd/hostapd-%i.pid -i %i ${HOSTAPD_XTRA_ARGS} @CMAKE_INSTALL_FULL_SYSCONFDIR@/hostapd/hostapd-%i.conf
-PIDFile=@CMAKE_INSTALL_FULL_RUNSTATEDIR@/hostapd/hostapd-%i.pid
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/hostapd -i %i @CMAKE_INSTALL_FULL_SYSCONFDIR@/hostapd/hostapd-%i.conf
 
 [Install]
 WantedBy=default.target

--- a/src/linux/server/systemd/netremote-server.service.in
+++ b/src/linux/server/systemd/netremote-server.service.in
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 Type=simple
 Restart=on-failure
-ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/netremote-server ${NETREMOTE_SERVER_XTRA_ARGS} 
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/netremote-server
 
 [Install]
 WantedBy=default.target

--- a/src/linux/server/systemd/netremote-server.service.in
+++ b/src/linux/server/systemd/netremote-server.service.in
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 Type=simple
 Restart=on-failure
-ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/netremote-server
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/netremote-server ${NETREMOTE_SERVER_XTRA_ARGS}
 
 [Install]
 WantedBy=default.target

--- a/src/linux/server/systemd/netremote-server.service.in
+++ b/src/linux/server/systemd/netremote-server.service.in
@@ -4,9 +4,9 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-Type=forking
+Type=simple
 Restart=on-failure
-ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/netremote-server ${NETREMOTE_SERVER_XTRA_ARGS} -d 
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/netremote-server ${NETREMOTE_SERVER_XTRA_ARGS} 
 
 [Install]
 WantedBy=default.target

--- a/src/linux/server/systemd/netremote-server.service.in
+++ b/src/linux/server/systemd/netremote-server.service.in
@@ -4,9 +4,9 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-Type=simple
+Type=forking
 Restart=on-failure
-ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/netremote-server -d ${NETREMOTE_SERVER_XTRA_ARGS}
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/netremote-server ${NETREMOTE_SERVER_XTRA_ARGS} -d 
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure installed systemd unit files work properly.

### Technical Details

* During install step, create the empty directory structure for the hostapd control file specific in the example configuration file (eg. the "run state" directory).
* Change hostapd service type from `forking` to `simple` and remove extra corresponding service lines (`PIDFile`) and daemon arguments (`-B`, `-P`).
* Change `netremote-server` unit ExecStart` from `sbin` to `bin` where it's actually installed.

### Test Results

* Performed the following commands:
    - `cmake --build /home/shadowfax/src/microsoft/netremote-cmake/out/build/dev-linux --parallel 14 --target install`
    - `cd /etc/systemd/system`
    - `sudo ln -s /home/shadowfax/src/microsoft/netremote-cmake/out/build/dev-linux/install/etc/systemd/system/hostapd@.service`
    - `sudo ln -s /home/shadowfax/src/microsoft/netremote-cmake/out/build/dev-linux/install/etc/systemd/system/netremote-server.service`
    - `sudo systemctl daemon-reload`
    - `sudo systemctl enable hostapd@wlan0`
    - `sudo systemctl start hostapd@wlan0`
    - `sudo systemctl status hostapd@wlan0.service netremote-server.service`
    

Verfidied below output showed both services as active/running:

```bash
● hostapd@wlan0.service - Hostapd Daemon
     Loaded: loaded (/etc/systemd/system/hostapd@wlan0.service; enabled; preset: enabled)
     Active: active (running) since Tue 2024-01-16 20:58:43 MST; 12min ago
   Main PID: 18192 (hostapd)
      Tasks: 1 (limit: 38513)
     Memory: 1.0M
     CGroup: /system.slice/system-hostapd.slice/hostapd@wlan0.service
             └─18192 /home/shadowfax/src/microsoft/netremote-cmake/out/install/dev-linux/sbin/hostapd -i wlan0 /home/shadowfax/src/microsoft/netremote-cmake/out/install/dev-linux/etc/hostapd/hostapd-wlan0.conf

Jan 16 20:58:43 foxmulder systemd[1]: hostapd@wlan0.service: Changed failed -> running
Jan 16 20:58:43 foxmulder systemd[1]: hostapd@wlan0.service: Job 1452 hostapd@wlan0.service/start finished, result=done
Jan 16 20:58:43 foxmulder systemd[1]: Started hostapd@wlan0.service - Hostapd Daemon.
Jan 16 20:58:43 foxmulder (hostapd)[18192]: hostapd@wlan0.service: Executing: /home/shadowfax/src/microsoft/netremote-cmake/out/install/dev-linux/sbin/hostapd -i wlan0 /home/shadowfax/src/microsoft/netremote-cmake/out/install/dev-linux/etc/hostapd/hostapd-wla>
Jan 16 20:58:43 foxmulder hostapd[18192]: wlan0: interface state UNINITIALIZED->ENABLED
Jan 16 20:58:43 foxmulder hostapd[18192]: wlan0: AP-ENABLED
Jan 16 21:02:28 foxmulder systemd[1]: hostapd@wlan0.service: Current command vanished from the unit file.
...

● netremote-server.service - Netremote Daemon
     Loaded: loaded (/etc/systemd/system/netremote-server.service; enabled; preset: enabled)
     Active: active (running) since Tue 2024-01-16 20:36:17 MST; 34min ago
   Main PID: 6373 (netremote-serve)
      Tasks: 18 (limit: 38513)
     Memory: 5.3M
     CGroup: /system.slice/netremote-server.service
             └─6373 /home/shadowfax/src/microsoft/netremote-cmake/out/install/dev-linux/bin/netremote-server

Jan 16 20:36:17 foxmulder systemd[1]: Started netremote-server.service - Netremote Daemon.
...
```
### Reviewer Focus

* Consider whether this would work for other development use cases.

### Future Work

* Create a cmake configure preset that sets `installDir` like a typical installation (eg. `/`).

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
