### PR TITLE
Fix xtra args positioning for hostapd systemd service unit file (again)

### DIFF
--- a/src/linux/external/hostap/systemd/hostapd@.service.in
+++ b/src/linux/external/hostap/systemd/hostapd@.service.in
@@ -6,7 +6,7 @@ After=sys-subsystem-net-devices-%i.device
 [Service]
 Type=simple
 Restart=on-failure
-ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/hostapd -i %i ${HOSTAPD_XTRA_ARGS} @CMAKE_INSTALL_FULL_SYSCONFDIR@/hostapd/hostapd-%i.conf
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/hostapd ${HOSTAPD_XTRA_ARGS} -i %i @CMAKE_INSTALL_FULL_SYSCONFDIR@/hostapd/hostapd-%i.conf
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure hostapd can be controlled via systemd whether extra arguments are provided or not.

### Technical Details

* `hostapd` is picky and expects the configuration file argument to come directly after the `-i` flag, so any extra arguments must be positioned prior to this flag. So, move `${HOSTAPD_XTRA_ARGS}` to be the first argument for `hostapd`.

### Test Results

* Ran `sudo systemctl start hostapd@wlx08beac0696fe` on a Linux machine and ensured the hostapd service came up:
```bash
shadowfax@mrstux:/etc/systemd/system$ sudo systemctl status hostapd@wlx08beac0696fe
● hostapd@wlx08beac0696fe.service - Hostapd Daemon
     Loaded: loaded (/etc/systemd/system/hostapd@.service; disabled; preset: enabled)
     Active: active (running) since Thu 2024-01-18 17:17:29 UTC; 5min ago
   Main PID: 24752 (hostapd)
      Tasks: 1 (limit: 18968)
     Memory: 1.0M
        CPU: 1.371s
     CGroup: /system.slice/system-hostapd.slice/hostapd@wlx08beac0696fe.service
             └─24752 /home/shadowfax/src/microsoft/netremote-cmake/out/install/dev-linux/sbin/hostapd -i wlx08beac0696fe /etc/hostapd/hostapd-wlx08beac0696fe.conf

Jan 18 17:17:29 mrstux systemd[1]: Started hostapd@wlx08beac0696fe.service - Hostapd Daemon.
Jan 18 17:17:30 mrstux hostapd[24752]: wlx08beac0696fe: interface state UNINITIALIZED->ENABLED
Jan 18 17:17:30 mrstux hostapd[24752]: wlx08beac0696fe: AP-ENABLED
```

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
