### PR TITLE
Allow supplying address without port.

### DIFF
--- a/protocol/include/microsoft/net/remote/protocol/NetRemoteProtocol.hxx
+++ b/protocol/include/microsoft/net/remote/protocol/NetRemoteProtocol.hxx
@@ -16,17 +16,20 @@ static constexpr std::string_view NetRemoteAddressHttpDefault = "localhost:5047"
  */
 struct NetRemoteProtocol
 {
-#define IP_DEFAULT   "localhost"
-#define PORT_DEFAULT 5047
-#define xstr(s)      str(s)
-#define str(s)       #s
+#define IP_DEFAULT     "localhost"
+#define PORT_DEFAULT   5047
+#define PORT_SEPARATOR ""
+#define xstr(s)        str(s)
+#define str(s)         #s
 
     static constexpr uint32_t PortDefault{ 5047 };
+    static constexpr std::string_view PortSeparator{ ":" };
     static constexpr std::string_view IpDefault{ "localhost" };
-    static constexpr std::string_view AddressDefault{ IP_DEFAULT ":" xstr(PORT_DEFAULT) };
+    static constexpr std::string_view AddressDefault{ IP_DEFAULT PORT_SEPARATOR xstr(PORT_DEFAULT) };
 
 #undef IP_DEFAULT
 #undef PORT_DEFAULT
+#undef PORT_SEPARATOR
 #undef xstr
 #undef str
 };


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow specifying the server address with `netremote-cli` without a port, eg. `netremote-cli -s 1.2.3.4` instead of `netremote-cli -s 1.2.3.4:5047`.

### Technical Details

* Detect when no port is specified, and append the default port (5047).
* Define port separator in static protocol info.

### Test Results

```bash
shadowfax@mrstux:~/src/microsoft/netremote-cmake/out/install/dev-linux/bin$ ./netremote-cli -s localhost wifi enumaps
Executing command WifiEnumerateAccessPoints
```

### Reviewer Focus

* None

### Future Work

* Possibly auto-detect if the service is running locally, and allow no address to be specified in this case.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
