### PR TITLE
Partially implement WifiEnumerateAccessPoints to expose access point ids

### DIFF
--- a/src/common/server/NetRemoteServer.cxx
+++ b/src/common/server/NetRemoteServer.cxx
@@ -9,8 +9,9 @@
 
 using namespace Microsoft::Net::Remote;
 
-NetRemoteServer::NetRemoteServer(std::string_view serverAddress) :
-    m_serverAddress{ serverAddress }
+NetRemoteServer::NetRemoteServer(NetRemoteServerConfiguration configuration) :
+    m_serverAddress(configuration.ServerAddress),
+    m_service(configuration.AccessPointManager)
 {}
 
 NetRemoteServer::~NetRemoteServer()
@@ -42,7 +43,7 @@ NetRemoteServer::Run()
     builder.RegisterService(&m_service);
 
     m_server = builder.BuildAndStart();
-    LOG_INFO << std::format("netremote server started listening on {}", m_serverAddress);
+    LOG_INFO << std::format("Netremote server started listening on {}", m_serverAddress);
 }
 
 void

--- a/src/common/server/NetRemoteServer.cxx
+++ b/src/common/server/NetRemoteServer.cxx
@@ -24,6 +24,12 @@ NetRemoteServer::GetGrpcServer() noexcept
     return m_server;
 }
 
+Service::NetRemoteService&
+NetRemoteServer::GetService() noexcept
+{
+    return m_service;
+}
+
 void
 NetRemoteServer::Run()
 {

--- a/src/common/server/NetRemoteServerConfiguration.cxx
+++ b/src/common/server/NetRemoteServerConfiguration.cxx
@@ -19,12 +19,12 @@ ConfigureCliAppOptions(CLI::App& app, NetRemoteServerConfiguration& config)
     app.add_option(
         "-a,--address",
         config.ServerAddress,
-        "The address to listen on for incoming connections.");
+        "The address to listen on for incoming connections");
 
-    app.add_option(
+    app.add_flag(
         "-v,--verbosity",
         config.LogVerbosity,
-        "The log verbosity level. Supply multiple times to increase verbosity (0=warnings, errors, and fatal messages, 1=info messages, 2=debug messages, 3=verbose messages).");
+        "The log verbosity level. Supply multiple times to increase verbosity (0=warnings, errors, and fatal messages, 1=info messages, 2=debug messages, 3=verbose messages)");
 
     return app;
 }

--- a/src/common/server/include/microsoft/net/remote/NetRemoteServer.hxx
+++ b/src/common/server/include/microsoft/net/remote/NetRemoteServer.hxx
@@ -34,6 +34,14 @@ struct NetRemoteServer
     GetGrpcServer() noexcept;
 
     /**
+     * @brief Get the NetRemoteService object instance.
+     * 
+     * @return Service::NetRemoteService& 
+     */
+    Service::NetRemoteService&
+    GetService() noexcept;
+
+    /**
      * @brief Start the server if not already started.
      */
     void

--- a/src/common/server/include/microsoft/net/remote/NetRemoteServer.hxx
+++ b/src/common/server/include/microsoft/net/remote/NetRemoteServer.hxx
@@ -7,7 +7,9 @@
 #include <string_view>
 
 #include <grpcpp/server.h>
+#include <microsoft/net/remote/NetRemoteServerConfiguration.hxx>
 #include <microsoft/net/remote/NetRemoteService.hxx>
+#include <microsoft/net/wifi/AccessPointManager.hxx>
 
 namespace Microsoft::Net::Remote
 {
@@ -19,11 +21,11 @@ struct NetRemoteServer
     virtual ~NetRemoteServer();
 
     /**
-     * @brief Construct a new NetRemoteServer object.
+     * @brief Construct a new NetRemoteServer object with the specified configuration.
      *
-     * @param serverAddress
+     * @param configuration
      */
-    NetRemoteServer(std::string_view serverAddress);
+    NetRemoteServer(NetRemoteServerConfiguration configuration);
 
     /**
      * @brief Get the GrpcServer object.
@@ -35,8 +37,8 @@ struct NetRemoteServer
 
     /**
      * @brief Get the NetRemoteService object instance.
-     * 
-     * @return Service::NetRemoteService& 
+     *
+     * @return Service::NetRemoteService&
      */
     Service::NetRemoteService&
     GetService() noexcept;

--- a/src/common/server/include/microsoft/net/remote/NetRemoteServerConfiguration.hxx
+++ b/src/common/server/include/microsoft/net/remote/NetRemoteServerConfiguration.hxx
@@ -3,11 +3,20 @@
 #define NET_REMOTE_SERVER_CONFIGURATION_HXX
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
+namespace Microsoft::Net::Wifi
+{
+class AccessPointManager;
+} // namespace Microsoft::Net::Wifi
+
 namespace Microsoft::Net::Remote
 {
+/**
+ * @brief Collects configuration options for the NetRemoteServer class.
+ */
 struct NetRemoteServerConfiguration
 {
     /**
@@ -55,6 +64,11 @@ struct NetRemoteServerConfiguration
      * and a level of 3 or above will show all verbose messages.
      */
     uint32_t LogVerbosity{ 0 };
+
+    /**
+     * @brief Access point manager instance.
+     */
+    std::shared_ptr<Microsoft::Net::Wifi::AccessPointManager> AccessPointManager;
 };
 
 } // namespace Microsoft::Net::Remote

--- a/src/common/server/include/microsoft/net/remote/NetRemoteServerConfiguration.hxx
+++ b/src/common/server/include/microsoft/net/remote/NetRemoteServerConfiguration.hxx
@@ -54,7 +54,7 @@ struct NetRemoteServerConfiguration
      * show all info messages, and a level of 2 will show all debug messages,
      * and a level of 3 or above will show all verbose messages.
      */
-    uint8_t LogVerbosity{ 0 };
+    uint32_t LogVerbosity{ 0 };
 };
 
 } // namespace Microsoft::Net::Remote

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -16,6 +16,12 @@ NetRemoteService::NetRemoteService() :
     m_accessPointManager(AccessPointManager::Create())
 {}
 
+std::shared_ptr<AccessPointManager>
+NetRemoteService::GetAccessPointManager() noexcept
+{
+    return m_accessPointManager;
+}
+
 ::grpc::Status
 NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerContext* context, [[maybe_unused]] const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response)
 {

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -1,6 +1,5 @@
 
 #include <format>
-#include <iostream>
 #include <iterator>
 #include <string>
 #include <vector>
@@ -13,7 +12,11 @@ using namespace Microsoft::Net::Remote::Service;
 using Microsoft::Net::Wifi::AccessPointManager;
 
 NetRemoteService::NetRemoteService() :
-    m_accessPointManager(AccessPointManager::Create())
+    NetRemoteService(AccessPointManager::Create())
+{}
+
+NetRemoteService::NetRemoteService(std::shared_ptr<AccessPointManager> accessPointManager) :
+    m_accessPointManager(std::move(accessPointManager))
 {}
 
 std::shared_ptr<AccessPointManager>
@@ -27,7 +30,7 @@ NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerConte
 {
     using Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResultItem;
 
-    LOG_VERBOSE << std::format("Received WifiEnumerateAccessPoints request\n");
+    LOGD << std::format("Received WifiEnumerateAccessPoints request");
 
     auto accessPoints = m_accessPointManager->GetAllAccessPoints();
     std::vector<WifiEnumerateAccessPointsResultItem> accessPointResultItems(std::size(accessPoints));
@@ -59,7 +62,7 @@ using Microsoft::Net::Wifi::Dot11PhyType;
 ::grpc::Status
 NetRemoteService::WifiAccessPointEnable([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableResult* response)
 {
-    LOG_VERBOSE << std::format("Received WifiAccessPointEnable request for access point id {}\n", request->accesspointid());
+    LOGD << std::format("Received WifiAccessPointEnable request for access point id {}", request->accesspointid());
 
     WifiAccessPointOperationStatus status{};
 
@@ -78,7 +81,7 @@ NetRemoteService::WifiAccessPointEnable([[maybe_unused]] ::grpc::ServerContext* 
 ::grpc::Status
 NetRemoteService::WifiAccessPointDisable([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointDisableResult* response)
 {
-    LOG_VERBOSE << std::format("Received WifiAccessPointDisable request for access point id {}\n", request->accesspointid());
+    LOGD << std::format("Received WifiAccessPointDisable request for access point id {}", request->accesspointid());
 
     WifiAccessPointOperationStatus status{};
     // TODO: Disable the access point.

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -15,6 +15,14 @@ class NetRemoteService :
 public:
     NetRemoteService();
 
+    /**
+     * @brief Get the AccessPointManager object for this service.
+     * 
+     * @return std::shared_ptr<Microsoft::Net::Wifi::AccessPointManager> 
+     */
+    std::shared_ptr<Microsoft::Net::Wifi::AccessPointManager>
+    GetAccessPointManager() noexcept;
+
 private:
     virtual ::grpc::Status
     WifiEnumerateAccessPoints(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response) override;

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -9,16 +9,29 @@
 
 namespace Microsoft::Net::Remote::Service
 {
+/**
+ * @brief Implementation of the NetRemote::Service gRPC service.
+ */
 class NetRemoteService :
     public NetRemote::Service
 {
 public:
+    /**
+     * @brief Construct a new NetRemoteService object.
+     */
     NetRemoteService();
 
     /**
+     * @brief Construct a new NetRemoteService object with the specified access point manager.
+     *
+     * @param accessPointManager The access point manager to use.
+     */
+    NetRemoteService(std::shared_ptr<Microsoft::Net::Wifi::AccessPointManager> accessPointManager);
+
+    /**
      * @brief Get the AccessPointManager object for this service.
-     * 
-     * @return std::shared_ptr<Microsoft::Net::Wifi::AccessPointManager> 
+     *
+     * @return std::shared_ptr<Microsoft::Net::Wifi::AccessPointManager>
      */
     std::shared_ptr<Microsoft::Net::Wifi::AccessPointManager>
     GetAccessPointManager() noexcept;

--- a/src/common/shared/logging/LogUtils.cxx
+++ b/src/common/shared/logging/LogUtils.cxx
@@ -22,7 +22,7 @@ logging::GetLogName(std::string_view componentName)
 }
 
 plog::Severity
-logging::LogVerbosityToPlogSeverity(uint8_t verbosity) noexcept
+logging::LogVerbosityToPlogSeverity(uint32_t verbosity) noexcept
 {
     switch (verbosity) {
     case 0:

--- a/src/common/shared/logging/include/logging/LogUtils.hxx
+++ b/src/common/shared/logging/include/logging/LogUtils.hxx
@@ -29,7 +29,7 @@ GetLogName(std::string_view componentName);
  * @return plog::Severity
  */
 plog::Severity
-LogVerbosityToPlogSeverity(uint8_t verbosity) noexcept;
+LogVerbosityToPlogSeverity(uint32_t verbosity) noexcept;
 
 } // namespace logging
 

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -29,6 +29,12 @@ NetRemoteCliHandlerOperations::WifiEnumerateAccessPoints()
         LOGE << std::format("Failed to enumerate WiFi access points, error={} details={} message={}", magic_enum::enum_name(status.error_code()), status.error_details(), status.error_message());
         return;
     }
+
+    LOGI << std::format("{} access points discovered", result.accesspoints_size());
+
+    for (const auto& accessPoint : result.accesspoints()) {
+        LOGI << std::format(" - [{}]", accessPoint.accesspointid());
+    }
 }
 
 std::unique_ptr<INetRemoteCliHandlerOperations>

--- a/src/common/wifi/apmanager/AccessPointDiscoveryAgent.cxx
+++ b/src/common/wifi/apmanager/AccessPointDiscoveryAgent.cxx
@@ -2,6 +2,7 @@
 #include <microsoft/net/wifi/AccessPointDiscoveryAgent.hxx>
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <notstd/Memory.hxx>
+#include <plog/Log.h>
 
 using namespace Microsoft::Net::Wifi;
 
@@ -39,6 +40,7 @@ AccessPointDiscoveryAgent::DevicePresenceChanged(AccessPointPresenceEvent presen
 {
     std::shared_lock<std::shared_mutex> onDevicePresenceChangedLock{ m_onDevicePresenceChangedGate };
     if (m_onDevicePresenceChanged) {
+        LOGD << "Access point discovery agent detected a device presence change";
         m_onDevicePresenceChanged(presence, std::move(interfaceName));
     }
 }
@@ -54,6 +56,7 @@ AccessPointDiscoveryAgent::Start()
 {
     bool expected = false;
     if (m_started.compare_exchange_weak(expected, true)) {
+        LOGD << "Access point discovery agent starting";
         m_operations->Start([weakThis = std::weak_ptr<AccessPointDiscoveryAgent>(GetInstance())](auto&& presence, auto&& interfaceName) {
             // Attempt to promote the weak pointer to a shared pointer to ensure this instance is still valid.
             if (auto strongThis = weakThis.lock(); strongThis) {
@@ -68,6 +71,7 @@ AccessPointDiscoveryAgent::Stop()
 {
     bool expected = true;
     if (m_started.compare_exchange_weak(expected, false)) {
+        LOGD << "Access point discovery agent stopping";
         m_operations->Stop();
     }
 }
@@ -75,5 +79,6 @@ AccessPointDiscoveryAgent::Stop()
 std::future<std::vector<std::string>>
 AccessPointDiscoveryAgent::ProbeAsync()
 {
+    LOGD << "Access point discovery agent probing for devices";
     return m_operations->ProbeAsync();
 }

--- a/src/common/wifi/apmanager/CMakeLists.txt
+++ b/src/common/wifi/apmanager/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(wifi-apmanager
 target_link_libraries(wifi-apmanager
     PRIVATE
         notstd
+        plog::plog
     PUBLIC
         ${PROJECT_NAME}-protocol
         wifi-core

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -3,6 +3,7 @@
 #define IEEE_80211_HXX
 
 #include <cmath>
+#include <cstdint>
 
 namespace Microsoft::Net::Wifi
 {
@@ -100,26 +101,86 @@ enum class IeeeAuthenticationAlgorithm {
 constexpr auto Wpa3Enterprise192 = IeeeAuthenticationAlgorithm::Wpa3;
 constexpr auto Wpa3Personal = IeeeAuthenticationAlgorithm::Sae;
 
-enum class IeeeCipherAlgorithm {
-    Unknown,
-    None,
-    Wep,
-    Wep40,
-    Wep104,
-    Tkip,
-    BipCmac128,
-    BipGmac128,
-    BipGmac256,
-    BipCmac256,
-    Gcmp128,
-    Gcmp256,
-    Ccmp256,
-    WpaUseGroup,
-};
+/**
+ * @brief OUI for IEEE 802.11 organization.
+ */
+static constexpr uint32_t OuiIeee80211 = 0x00000FAC;
 
-constexpr auto Bip = IeeeCipherAlgorithm::BipCmac128;
-constexpr auto Gcmp = IeeeCipherAlgorithm::Gcmp128;
-constexpr auto RsnUseGroup = IeeeCipherAlgorithm::WpaUseGroup;
+/**
+ * @brief OUI placeholder for signaling invalid values.
+ */
+static constexpr uint32_t OuiInvalid = 0x00FFFFFF;
+
+/**
+ * @brief Cipher suite identifiers or "selectors".
+ *
+ * Defined in IEEE 802.11-2020, Section 9.4.2.24.2, Table 9-149.
+ */
+static constexpr uint8_t Ieee80211CipherSuiteIdUseGroup = 0;
+static constexpr uint8_t Ieee80211CipherSuiteIdWep40 = 1;
+static constexpr uint8_t Ieee80211CipherSuiteIdTkip = 2;
+static constexpr uint8_t Ieee80211CipherSuiteIdReserved = 3;
+static constexpr uint8_t Ieee80211CipherSuiteCcmp128 = 4;
+static constexpr uint8_t Ieee80211CipherSuiteIdWep104 = 5;
+static constexpr uint8_t Ieee80211CipherSuiteIdBipCmac128 = 6;
+static constexpr uint8_t Ieee80211CipherSuiteIdGroupAddressTrafficNotAllowed = 7;
+static constexpr uint8_t Ieee80211CipherSuiteIdGcmp128 = 8;
+static constexpr uint8_t Ieee80211CipherSuiteIdGcmp256 = 9;
+static constexpr uint8_t Ieee80211CipherSuiteIdCcmp256 = 10;
+static constexpr uint8_t Ieee80211CipherSuiteIdBipGmac128 = 11;
+static constexpr uint8_t Ieee80211CipherSuiteIdBipGmac256 = 12;
+static constexpr uint8_t Ieee80211CipherSuiteIdBipCmac256 = 13;
+
+/**
+ * @brief Helper function to construct an IEEE cipher suite value.
+ *
+ * The OUT is 3 octets and the suite ID is 1 octet.
+ *
+ * @param oui The OUI value.
+ * @param suiteId The suite ID value.
+ * @return constexpr uint32_t
+ */
+constexpr uint32_t
+MakeIeeeCipherSuite(uint32_t oui, uint8_t suiteId)
+{
+    constexpr uint32_t OuiShiftAmount = 8;
+    constexpr uint32_t OuiMask = 0x00FFFFFF;
+    return ((oui & OuiMask) << OuiShiftAmount) | suiteId;
+}
+
+/**
+ * @brief Helper function to construct an IEEE 802.11 cipher suite value. This uses the IEEE 802.11 OUI.
+ *
+ * @param suiteId The suite ID value.
+ * @return constexpr uint32_t
+ */
+constexpr uint32_t
+MakeIeee80211CipherSuite(uint8_t suiteId)
+{
+    return MakeIeeeCipherSuite(OuiIeee80211, suiteId);
+}
+
+/**
+ * @brief IEEE 802.11 Cipher Suites.
+ *
+ * Defined in IEEE 802.11-2020, Section 9.4.2.24.2, Table 9-149.
+ */
+enum class IeeeCipherSuite : uint32_t {
+    Unknown = MakeIeeeCipherSuite(OuiInvalid, 0),
+    BipCmac128 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdBipCmac128),
+    BipCmac256 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdBipCmac256),
+    BipGmac128 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdBipGmac128),
+    BipGmac256 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdBipGmac256),
+    Ccmp128 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteCcmp128),
+    Ccmp256 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdCcmp256),
+    Gcmp128 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdGcmp128),
+    Gcmp256 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdGcmp256),
+    GroupAddressesTrafficNotAllowed = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdGroupAddressTrafficNotAllowed),
+    Tkip = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdTkip),
+    UseGroup = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdUseGroup),
+    Wep104 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdWep104),
+    Wep40 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdWep40),
+};
 
 } // namespace Microsoft::Net::Wifi
 

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -82,25 +82,6 @@ enum class IeeeProtocol {
     BE,
 };
 
-enum class IeeeAuthenticationAlgorithm {
-    Unknown,
-    Open,
-    SharedKey,
-    Wpa,
-    WpaPsk,
-    WpaNone,
-    Rsna,
-    RsnaPsk,
-    Wpa3,
-    Wpa3Enterprise192,
-    Wpa3Enterprise,
-    Sae,
-    Owe,
-};
-
-constexpr auto Wpa3Enterprise192 = IeeeAuthenticationAlgorithm::Wpa3;
-constexpr auto Wpa3Personal = IeeeAuthenticationAlgorithm::Sae;
-
 /**
  * @brief OUI for IEEE 802.11 organization.
  */
@@ -110,6 +91,108 @@ static constexpr uint32_t OuiIeee80211 = 0x00000FAC;
  * @brief OUI placeholder for signaling invalid values.
  */
 static constexpr uint32_t OuiInvalid = 0x00FFFFFF;
+
+/**
+ * @brief Helper function to construct an IEEE cipher or AKM suite value.
+ *
+ * The OUI is 3 octets and the suite ID is 1 octet.
+ *
+ * @param oui The OUI value.
+ * @param suiteId The suite ID value.
+ * @return constexpr uint32_t
+ */
+constexpr uint32_t
+MakeIeeeSuite(uint32_t oui, uint8_t suiteId)
+{
+    constexpr uint32_t OuiShiftAmount = 8;
+    constexpr uint32_t OuiMask = 0x00FFFFFF;
+
+    return ((oui & OuiMask) << OuiShiftAmount) | suiteId;
+}
+
+/**
+ * @brief Helper function to construct an IEEE 802.11 cipher suite value. This uses the IEEE 802.11 OUI.
+ *
+ * @param suiteId The suite ID value.
+ * @return constexpr uint32_t
+ */
+constexpr uint32_t
+MakeIeee80211Suite(uint8_t suiteId)
+{
+    return MakeIeeeSuite(OuiIeee80211, suiteId);
+}
+
+/**
+ * @brief Authentication algorithms. Each entry denotes a single algorithm, not a suite.
+ *
+ * Defined in IEEE 802.11-2020, Section 9.4.1.1, Figure 9-82.
+ */
+enum class IeeeAuthenticationAlgorithm : uint16_t {
+    OpenSystem = 0x0001,
+    SharedKey = 0x0002,
+    FastBssTransition = 0x0003,
+    Sae = 0x0004,
+    Fils = 0x0005,
+    FilsPfs = 0x0006,
+    FilsPublicKey = 0x0007,
+    VendorSpecific = 0xFFFF,
+};
+
+/**
+ * @brief AKM suite identifiers or "selectors".
+ *
+ * Defined in IEEE 802.11-2020, Section 9.4.2.24.3, Table 9-151.
+ */
+static constexpr uint8_t IeeeAkmSuiteIdReserved0 = 0;
+static constexpr uint8_t IeeeAkmSuiteId8021x = 1;
+static constexpr uint8_t IeeeAkmSuiteIdPsk = 2;
+static constexpr uint8_t IeeeAkmSuiteIdFt8021x = 3;
+static constexpr uint8_t IeeeAkmSuiteIdFtPsk = 4;
+static constexpr uint8_t IeeeAkmSuiteId8021xSha256 = 5;
+static constexpr uint8_t IeeeAkmSuiteIdPskSha256 = 6;
+static constexpr uint8_t IeeeAkmSuiteIdTdls = 7;
+static constexpr uint8_t IeeeAkmSuiteIdSae = 8;
+static constexpr uint8_t IeeeAkmSuiteIdFtSae = 9;
+static constexpr uint8_t IeeeAkmSuiteIdApPeerKey = 10;
+static constexpr uint8_t IeeeAkmSuiteId8021xSuiteB = 11;
+static constexpr uint8_t IeeeAkmSuiteId8021xSuiteB192 = 12;
+static constexpr uint8_t IeeeAkmSuiteIdFt8021xSha384 = 13;
+static constexpr uint8_t IeeeAkmSuiteIdFilsSha256 = 14;
+static constexpr uint8_t IeeeAkmSuiteIdFilsSha384 = 15;
+static constexpr uint8_t IeeeAkmSuiteIdFtFilsSha256 = 16;
+static constexpr uint8_t IeeeAkmSuiteIdFtFilsSha384 = 17;
+static constexpr uint8_t IeeeAkmSuiteIdOwe = 18;
+static constexpr uint8_t IeeeAkmSuiteIdFtPskSha384 = 19;
+static constexpr uint8_t IeeeAkmSuiteIdPskSha384 = 20;
+
+/**
+ * @brief IEEE 802.11 Authentication and Key Management (AKM) Suites.
+ *
+ * Defined in IEEE 802.11-2020, Section 9.4.2.24.3, Table 9-151.
+ */
+enum class IeeeAkmSuite : uint32_t {
+    Reserved0 = MakeIeee80211Suite(IeeeAkmSuiteIdReserved0),
+    Ieee8021x = MakeIeee80211Suite(IeeeAkmSuiteId8021x),
+    Psk = MakeIeee80211Suite(IeeeAkmSuiteIdPsk),
+    Ft8021x = MakeIeee80211Suite(IeeeAkmSuiteIdFt8021x),
+    FtPsk = MakeIeee80211Suite(IeeeAkmSuiteIdFtPsk),
+    Ieee8021xSha256 = MakeIeee80211Suite(IeeeAkmSuiteId8021xSha256),
+    PskSha256 = MakeIeee80211Suite(IeeeAkmSuiteIdPskSha256),
+    Tdls = MakeIeee80211Suite(IeeeAkmSuiteIdTdls),
+    Sae = MakeIeee80211Suite(IeeeAkmSuiteIdSae),
+    FtSae = MakeIeee80211Suite(IeeeAkmSuiteIdFtSae),
+    ApPeerKey = MakeIeee80211Suite(IeeeAkmSuiteIdApPeerKey),
+    Ieee8021xSuiteB = MakeIeee80211Suite(IeeeAkmSuiteId8021xSuiteB),
+    Ieee8011xSuiteB192 = MakeIeee80211Suite(IeeeAkmSuiteId8021xSuiteB192),
+    Ft8021xSha384 = MakeIeee80211Suite(IeeeAkmSuiteIdFt8021xSha384),
+    FilsSha256 = MakeIeee80211Suite(IeeeAkmSuiteIdFilsSha256),
+    FilsSha284 = MakeIeee80211Suite(IeeeAkmSuiteIdFilsSha384),
+    FtFilsSha256 = MakeIeee80211Suite(IeeeAkmSuiteIdFtFilsSha256),
+    FtFilsSha384 = MakeIeee80211Suite(IeeeAkmSuiteIdFtFilsSha384),
+    Owe = MakeIeee80211Suite(IeeeAkmSuiteIdOwe),
+    FtPskSha384 = MakeIeee80211Suite(IeeeAkmSuiteIdFtPskSha384),
+    PskSha384 = MakeIeee80211Suite(IeeeAkmSuiteIdPskSha384),
+};
 
 /**
  * @brief Cipher suite identifiers or "selectors".
@@ -132,54 +215,25 @@ static constexpr uint8_t Ieee80211CipherSuiteIdBipGmac256 = 12;
 static constexpr uint8_t Ieee80211CipherSuiteIdBipCmac256 = 13;
 
 /**
- * @brief Helper function to construct an IEEE cipher suite value.
- *
- * The OUT is 3 octets and the suite ID is 1 octet.
- *
- * @param oui The OUI value.
- * @param suiteId The suite ID value.
- * @return constexpr uint32_t
- */
-constexpr uint32_t
-MakeIeeeCipherSuite(uint32_t oui, uint8_t suiteId)
-{
-    constexpr uint32_t OuiShiftAmount = 8;
-    constexpr uint32_t OuiMask = 0x00FFFFFF;
-    return ((oui & OuiMask) << OuiShiftAmount) | suiteId;
-}
-
-/**
- * @brief Helper function to construct an IEEE 802.11 cipher suite value. This uses the IEEE 802.11 OUI.
- *
- * @param suiteId The suite ID value.
- * @return constexpr uint32_t
- */
-constexpr uint32_t
-MakeIeee80211CipherSuite(uint8_t suiteId)
-{
-    return MakeIeeeCipherSuite(OuiIeee80211, suiteId);
-}
-
-/**
  * @brief IEEE 802.11 Cipher Suites.
  *
  * Defined in IEEE 802.11-2020, Section 9.4.2.24.2, Table 9-149.
  */
 enum class IeeeCipherSuite : uint32_t {
-    Unknown = MakeIeeeCipherSuite(OuiInvalid, 0),
-    BipCmac128 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdBipCmac128),
-    BipCmac256 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdBipCmac256),
-    BipGmac128 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdBipGmac128),
-    BipGmac256 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdBipGmac256),
-    Ccmp128 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteCcmp128),
-    Ccmp256 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdCcmp256),
-    Gcmp128 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdGcmp128),
-    Gcmp256 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdGcmp256),
-    GroupAddressesTrafficNotAllowed = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdGroupAddressTrafficNotAllowed),
-    Tkip = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdTkip),
-    UseGroup = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdUseGroup),
-    Wep104 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdWep104),
-    Wep40 = MakeIeee80211CipherSuite(Ieee80211CipherSuiteIdWep40),
+    Unknown = MakeIeeeSuite(OuiInvalid, 0),
+    BipCmac128 = MakeIeee80211Suite(Ieee80211CipherSuiteIdBipCmac128),
+    BipCmac256 = MakeIeee80211Suite(Ieee80211CipherSuiteIdBipCmac256),
+    BipGmac128 = MakeIeee80211Suite(Ieee80211CipherSuiteIdBipGmac128),
+    BipGmac256 = MakeIeee80211Suite(Ieee80211CipherSuiteIdBipGmac256),
+    Ccmp128 = MakeIeee80211Suite(Ieee80211CipherSuiteCcmp128),
+    Ccmp256 = MakeIeee80211Suite(Ieee80211CipherSuiteIdCcmp256),
+    Gcmp128 = MakeIeee80211Suite(Ieee80211CipherSuiteIdGcmp128),
+    Gcmp256 = MakeIeee80211Suite(Ieee80211CipherSuiteIdGcmp256),
+    GroupAddressesTrafficNotAllowed = MakeIeee80211Suite(Ieee80211CipherSuiteIdGroupAddressTrafficNotAllowed),
+    Tkip = MakeIeee80211Suite(Ieee80211CipherSuiteIdTkip),
+    UseGroup = MakeIeee80211Suite(Ieee80211CipherSuiteIdUseGroup),
+    Wep104 = MakeIeee80211Suite(Ieee80211CipherSuiteIdWep104),
+    Wep40 = MakeIeee80211Suite(Ieee80211CipherSuiteIdWep40),
 };
 
 } // namespace Microsoft::Net::Wifi

--- a/src/linux/server/CMakeLists.txt
+++ b/src/linux/server/CMakeLists.txt
@@ -8,10 +8,11 @@ target_sources(${PROJECT_NAME}-server-linux
 
 target_link_libraries(${PROJECT_NAME}-server-linux
     PRIVATE
-        logging-utils
         ${PROJECT_NAME}-server
+        logging-utils
         notstd
         plog::plog
+        wifi-apmanager-linux
 )
 
 set_target_properties(${PROJECT_NAME}-server-linux

--- a/src/linux/server/Main.cxx
+++ b/src/linux/server/Main.cxx
@@ -57,6 +57,7 @@ main(int argc, char *argv[])
     }
 
     // Start the server.
+    LOGI << "Starting netremote server";
     server.Run();
 
     // If running in the background, daemonize the process.
@@ -66,7 +67,7 @@ main(int argc, char *argv[])
 
         if (daemon(nochdir, noclose) != 0) {
             const int error = errno;
-            const auto what = std::format("failed to daemonize (error={})", error);
+            const auto what = std::format("Failed to daemonize (error={})", error);
             LOG_ERROR << what;
             throw std::runtime_error(what);
         }
@@ -76,7 +77,7 @@ main(int argc, char *argv[])
         server.GetGrpcServer()->Wait();
     }
 
-    LOG_INFO << "Server exiting.";
+    LOGI << "Server exiting";
 
     return 0;
 }

--- a/src/linux/server/Main.cxx
+++ b/src/linux/server/Main.cxx
@@ -7,6 +7,7 @@
 #include <microsoft/net/remote/NetRemoteServerConfiguration.hxx>
 #include <microsoft/net/wifi/AccessPointDiscoveryAgent.hxx>
 #include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
+#include <microsoft/net/wifi/AccessPointManager.hxx>
 #include <notstd/Utility.hxx>
 #include <plog/Appenders/ColorConsoleAppender.h>
 #include <plog/Appenders/RollingFileAppender.h>
@@ -20,6 +21,7 @@ using namespace Microsoft::Net::Remote;
 
 using Microsoft::Net::Wifi::AccessPointDiscoveryAgent;
 using Microsoft::Net::Wifi::AccessPointDiscoveryAgentOperationsNetlink;
+using Microsoft::Net::Wifi::AccessPointManager;
 
 enum class LogInstanceId : int {
     // Default logger is 0 and is omitted from this enumeration.
@@ -35,7 +37,7 @@ main(int argc, char *argv[])
     static plog::RollingFileAppender<plog::TxtFormatter> rollingFileAppender(logging::GetLogName("server").c_str());
 
     // Parse command line arguments.
-    const auto configuration = NetRemoteServerConfiguration::FromCommandLineArguments(argc, argv);
+    auto configuration = NetRemoteServerConfiguration::FromCommandLineArguments(argc, argv);
     const auto logSeverity = logging::LogVerbosityToPlogSeverity(configuration.LogVerbosity);
 
     // Configure logging, appending all loggers to the default instance.
@@ -45,19 +47,21 @@ main(int argc, char *argv[])
         .addAppender(plog::get<notstd::to_underlying(LogInstanceId::Console)>())
         .addAppender(plog::get<notstd::to_underlying(LogInstanceId::File)>());
 
-    // Create the server.
-    NetRemoteServer server{ configuration.ServerAddress };
-
-    // Create an access point discovery agent, and register it with the server's access point manager.
+    // Create an access point manager and discovery agent.
     {
+        configuration.AccessPointManager = AccessPointManager::Create();
+
+        auto &accessPointManager = configuration.AccessPointManager;
         auto accessPointDiscoveryAgentOperationsNetlink = std::make_unique<AccessPointDiscoveryAgentOperationsNetlink>();
         auto accessPointDiscoveryAgent = AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperationsNetlink));
-        auto accessPointManager = server.GetService().GetAccessPointManager();
         accessPointManager->AddDiscoveryAgent(std::move(accessPointDiscoveryAgent));
     }
 
+    // Create the server.
+    NetRemoteServer server{ std::move(configuration) };
+
     // Start the server.
-    LOGI << "Starting netremote server";
+    LOGI << "Netremote server starting";
     server.Run();
 
     // If running in the background, daemonize the process.
@@ -68,7 +72,7 @@ main(int argc, char *argv[])
         if (daemon(nochdir, noclose) != 0) {
             const int error = errno;
             const auto what = std::format("Failed to daemonize (error={})", error);
-            LOG_ERROR << what;
+            LOGE << what;
             throw std::runtime_error(what);
         }
     }
@@ -77,7 +81,7 @@ main(int argc, char *argv[])
         server.GetGrpcServer()->Wait();
     }
 
-    LOGI << "Server exiting";
+    LOGI << "Netremote server stopping";
 
     return 0;
 }

--- a/tests/unit/TestNetRemoteServer.cxx
+++ b/tests/unit/TestNetRemoteServer.cxx
@@ -12,10 +12,16 @@
 TEST_CASE("Create a NetRemoteServer instance", "[basic][rpc][remote]")
 {
     using namespace Microsoft::Net::Remote;
+    using namespace Microsoft::Net::Wifi;
+
+    NetRemoteServerConfiguration Configuration{
+        .ServerAddress = Test::RemoteServiceAddressHttp,
+        .AccessPointManager = AccessPointManager::Create(),
+    };
 
     SECTION("Create doesn't cause a crash")
     {
-        REQUIRE_NOTHROW(NetRemoteServer{ Test::RemoteServiceAddressHttp });
+        REQUIRE_NOTHROW(NetRemoteServer{ Configuration });
     }
 }
 
@@ -23,8 +29,14 @@ TEST_CASE("Destroy a NetRemoteServer instance", "[basic][rpc][remote]")
 {
     using namespace Microsoft::Net::Remote;
     using namespace Microsoft::Net::Remote::Service;
+    using namespace Microsoft::Net::Wifi;
 
-    std::optional<NetRemoteServer> server{ Test::RemoteServiceAddressHttp };
+    NetRemoteServerConfiguration Configuration{
+        .ServerAddress = Test::RemoteServiceAddressHttp,
+        .AccessPointManager = AccessPointManager::Create(),
+    };
+
+    std::optional<NetRemoteServer> server{ Configuration };
     server->Run();
 
     SECTION("Destroy doesn't cause a crash")
@@ -48,8 +60,14 @@ TEST_CASE("NetRemoteServer can be reached", "[basic][rpc][remote]")
 {
     using namespace Microsoft::Net::Remote;
     using namespace Microsoft::Net::Remote::Service;
+    using namespace Microsoft::Net::Wifi;
 
-    NetRemoteServer server{ Test::RemoteServiceAddressHttp };
+    NetRemoteServerConfiguration Configuration{
+        .ServerAddress = Test::RemoteServiceAddressHttp,
+        .AccessPointManager = AccessPointManager::Create(),
+    };
+
+    NetRemoteServer server{ Configuration };
     server.Run();
 
     SECTION("Can be reached using insecure channel")
@@ -65,8 +83,14 @@ TEST_CASE("NetRemoteServer shuts down correctly", "[basic][rpc][remote]")
 {
     using namespace Microsoft::Net::Remote;
     using namespace Microsoft::Net::Remote::Service;
+    using namespace Microsoft::Net::Wifi;
 
-    NetRemoteServer server{ Test::RemoteServiceAddressHttp };
+    NetRemoteServerConfiguration Configuration{
+        .ServerAddress = Test::RemoteServiceAddressHttp,
+        .AccessPointManager = AccessPointManager::Create(),
+    };
+
+    NetRemoteServer server{ Configuration };
     server.Run();
 
     SECTION("Stop() doesn't cause a crash with no connected clients")
@@ -114,8 +138,14 @@ TEST_CASE("NetRemoteServer can be cycled through run/stop states", "[basic][rpc]
 {
     using namespace Microsoft::Net::Remote;
     using namespace Microsoft::Net::Remote::Service;
+    using namespace Microsoft::Net::Wifi;
 
-    NetRemoteServer server{ Test::RemoteServiceAddressHttp };
+    NetRemoteServerConfiguration Configuration{
+        .ServerAddress = Test::RemoteServiceAddressHttp,
+        .AccessPointManager = AccessPointManager::Create(),
+    };
+
+    NetRemoteServer server{ Configuration };
     REQUIRE_NOTHROW(server.Run());
 
     SECTION("Can be cycled multiple times")

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -9,6 +9,7 @@
 #include <magic_enum.hpp>
 #include <microsoft/net/remote/NetRemoteServer.hxx>
 #include <microsoft/net/remote/protocol/NetRemoteService.grpc.pb.h>
+#include <microsoft/net/wifi/AccessPointManager.hxx>
 
 #include "TestNetRemoteCommon.hxx"
 
@@ -17,8 +18,14 @@ TEST_CASE("WifiEnumerateAccessPoints API", "[basic][rpc][client][remote]")
     using namespace Microsoft::Net::Remote;
     using namespace Microsoft::Net::Remote::Service;
     using namespace Microsoft::Net::Remote::Wifi;
+    using namespace Microsoft::Net::Wifi;
 
-    NetRemoteServer server{ Test::RemoteServiceAddressHttp };
+    NetRemoteServerConfiguration Configuration{
+        .ServerAddress = Test::RemoteServiceAddressHttp,
+        .AccessPointManager = AccessPointManager::Create(),
+    };
+
+    NetRemoteServer server{ Configuration };
     server.Run();
 
     auto channel = grpc::CreateChannel(Test::RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());
@@ -63,7 +70,12 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
 
     constexpr auto SsidName{ "TestWifiAccessPointEnable" };
 
-    NetRemoteServer server{ Test::RemoteServiceAddressHttp };
+    NetRemoteServerConfiguration Configuration{
+        .ServerAddress = Test::RemoteServiceAddressHttp,
+        .AccessPointManager = AccessPointManager::Create(),
+    };
+
+    NetRemoteServer server{ Configuration };
     server.Run();
 
     auto channel = grpc::CreateChannel(Test::RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Implement `WifiEnumerateAccessPoints` API.

### Technical Details

Partially implement `WifiEnumerateAccessPoints` to surface discovered APs, populating their id (interface name) only.

* Fix `-v` flag for `netremote-server`.
* Add some logging for AP discovery.
* Probe for access points when a discovery agent is added to ensure pre-existing devices are discovered.
* Update `netremote-cli` to display discovered access points.
* Update IEEE 802.11 cipher and akm suites with values from the spec instead of a combination of Windows and Linux types.
* Use short macros `LOG<E|W|I>` instead of those with full names like `LOG_<ERROR|WARNING|INFO>`.

### Test Results

* All unit tests pass.
* Ran `netremote-cli` on a Linux machine with 2 AP-capable wi-fi devices with the following results:
```bash
shadowfax@mrstux:~/src/microsoft/netremote-cmake/out/install/dev-linux/bin$ ./netremote-cli -s localhost wifi enumaps
Executing command WifiEnumerateAccessPoints
2 access points discovered
 - [wlx08beac0696fe]
 - [wls1]
```

### Reviewer Focus

* None

### Future Work

* Populate `WifiEnumerateAccessPoints` results with access point capabilities. That portion is too large for this already sizable PR.
* Update `AccessPointManager` to accept an `IAccessPointFactory` to create access point instances instead of creating the base class type `AccessPoint`.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
