### PR TITLE
Separate access point creation and management

### DIFF
--- a/src/common/server/NetRemoteServer.cxx
+++ b/src/common/server/NetRemoteServer.cxx
@@ -43,7 +43,7 @@ NetRemoteServer::Run()
     builder.RegisterService(&m_service);
 
     m_server = builder.BuildAndStart();
-    LOG_INFO << std::format("Netremote server started listening on {}", m_serverAddress);
+    LOGI << std::format("Netremote server started listening on {}", m_serverAddress);
 }
 
 void

--- a/src/common/wifi/apmanager/AccessPointManager.cxx
+++ b/src/common/wifi/apmanager/AccessPointManager.cxx
@@ -11,12 +11,22 @@
 
 using namespace Microsoft::Net::Wifi;
 
-AccessPointManager::AccessPointManager() = default;
+AccessPointManager::AccessPointManager(std::unique_ptr<IAccessPointFactory> accessPointFactory) :
+    m_accessPointFactory(std::move(accessPointFactory))
+{}
 
+/* static */
+std::shared_ptr<AccessPointManager>
+AccessPointManager::Create(std::unique_ptr<IAccessPointFactory> accessPointFactory)
+{
+    return std::make_shared<notstd::enable_make_protected<AccessPointManager>>(std::move(accessPointFactory));
+}
+
+/* static */
 std::shared_ptr<AccessPointManager>
 AccessPointManager::Create()
 {
-    return std::make_shared<notstd::enable_make_protected<AccessPointManager>>();
+    return Create(std::make_unique<AccessPointFactory>());
 }
 
 std::shared_ptr<AccessPointManager>

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
@@ -10,6 +10,7 @@
 namespace Microsoft::Net::Wifi
 {
 struct IAccessPoint;
+struct IAccessPointFactory;
 struct AccessPointDiscoveryAgent;
 enum class AccessPointPresenceEvent;
 
@@ -26,12 +27,22 @@ class AccessPointManager :
 {
 public:
     /**
-     * @brief Safely create an instance of the access point manager.
+     * @brief Safely create an instance of the access point manager with a default access point factory that creates
+     * AccessPoint instances.
      *
      * @return std::shared_ptr<AccessPointManager>
      */
     [[nodiscard]] static std::shared_ptr<AccessPointManager>
     Create();
+
+    /**
+     * @brief Safely create an instance of the access point manager.
+     *
+     * @param accessPointFactory
+     * @return std::shared_ptr<AccessPointManager>
+     */
+    [[nodiscard]] static std::shared_ptr<AccessPointManager>
+    Create(std::unique_ptr<IAccessPointFactory> accessPointFactory);
 
     /**
      * @brief Get an instance of this access point manager.
@@ -95,7 +106,7 @@ protected:
      * Consequently, the = default implementation is done in the source file
      * instead.
      */
-    AccessPointManager();
+    AccessPointManager(std::unique_ptr<IAccessPointFactory> accessPointFactory);
 
 private:
     /**
@@ -125,6 +136,8 @@ private:
     RemoveAccessPoint(std::shared_ptr<IAccessPoint> accessPoint);
 
 private:
+    std::unique_ptr<IAccessPointFactory> m_accessPointFactory;
+
     mutable std::mutex m_accessPointGate;
     std::vector<std::shared_ptr<IAccessPoint>> m_accessPoints{};
 

--- a/src/common/wifi/core/AccessPoint.cxx
+++ b/src/common/wifi/core/AccessPoint.cxx
@@ -20,3 +20,9 @@ AccessPoint::CreateController()
 {
     throw std::runtime_error("this function must be overridden by a derived class");
 }
+
+std::shared_ptr<IAccessPoint>
+AccessPointFactory::Create(std::string_view interface)
+{
+    return std::make_shared<AccessPoint>(interface);
+}

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
@@ -3,6 +3,7 @@
 #define ACCESS_POINT_HXX
 
 #include <microsoft/net/wifi/IAccessPoint.hxx>
+#include <microsoft/net/wifi/IAccessPointFactory.hxx>
 
 #include <string>
 #include <string_view>
@@ -34,14 +35,30 @@ struct AccessPoint :
 
     /**
      * @brief Create a controller object.
-     * 
-     * @return std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController> 
+     *
+     * @return std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController>
      */
     virtual std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController>
     CreateController() override;
 
 private:
     const std::string m_interface;
+};
+
+/**
+ * @brief Creates instances of the AccessPoint class.
+ */
+struct AccessPointFactory :
+    public IAccessPointFactory
+{
+    /**
+     * @brief Create a new access point object for the given network interface.
+     *
+     * @param interface
+     * @return std::shared_ptr<AccessPoint>
+     */
+    virtual std::shared_ptr<IAccessPoint>
+    Create(std::string_view interface) override;
 };
 } // namespace Microsoft::Net::Wifi
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Separate creation and management of access points.

### Technical Details

* Modify `AccessPointManager` to accept an `AccessPointFactory` on creation.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Update `netremote-server` on Linux to provide a factory which creates Linux-specific access points instead of the default/base `AccessPoint`.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
