### PR TITLE
Populate capabilities in WifiEnumerateAccessPoints API

### DIFF
--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -6,10 +6,14 @@
 
 #include <microsoft/net/remote/NetRemoteService.hxx>
 #include <microsoft/net/wifi/IAccessPoint.hxx>
+#include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <plog/Log.h>
 
 using namespace Microsoft::Net::Remote::Service;
+
 using Microsoft::Net::Wifi::AccessPointManager;
+using Microsoft::Net::Wifi::IAccessPoint;
+using Microsoft::Net::Wifi::AccessPointControllerException;
 
 NetRemoteService::NetRemoteService(std::shared_ptr<AccessPointManager> accessPointManager) :
     m_accessPointManager(std::move(accessPointManager))
@@ -21,6 +25,89 @@ NetRemoteService::GetAccessPointManager() noexcept
     return m_accessPointManager;
 }
 
+namespace detail
+{
+Microsoft::Net::Wifi::AccessPointCapabilities
+IeeeAccessPointCapabilitiesToNetRemoteAccessPointCapabilities([[maybe_unused]] const Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities& ieeeCapabilities)
+{
+    using Microsoft::Net::Wifi::AccessPointCapabilities;
+    using Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities;
+
+    AccessPointCapabilities capabilities{};
+
+    // capabilities.set_protocols(ieeeCapabilities.Protocols);
+    // capabilities.set_frequencybands(ieeeCapabilities.FrequencyBands);
+    // capabilities.set_authenticationalgorithms(ieeeCapabilities.AuthenticationAlgorithms);
+    // capabilities.set_encryptionalgorithms(ieeeCapabilities.EncryptionAlgorithms);
+
+    return capabilities;
+}
+
+using Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResultItem;
+using Microsoft::Net::Wifi::AccessPointCapabilities;
+
+static constexpr auto AccessPointIdInvalid{ "invalid" };
+
+Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResultItem
+MakeInvalidAccessPointResultItem()
+{
+    WifiEnumerateAccessPointsResultItem item{};
+    item.set_accesspointid(AccessPointIdInvalid);
+    return item;
+}
+
+Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResultItem
+IAccessPointToNetRemoteAccessPointResultItem(IAccessPoint& accessPoint)
+{
+    WifiEnumerateAccessPointsResultItem item{};
+
+    bool isEnabled{ false };
+    std::string id{};
+    Microsoft::Net::Wifi::AccessPointCapabilities capabilities{};
+
+    auto interfaceName = accessPoint.GetInterfaceName();
+    id.assign(std::cbegin(interfaceName), std::cend(interfaceName));
+
+    auto accessPointController = accessPoint.CreateController();
+    if (accessPointController != nullptr) {
+        LOGE << std::format("Failed to create controller for access point {}", interfaceName);
+        return MakeInvalidAccessPointResultItem();
+    }
+
+    try {
+        auto capabilitiesIeee80211 = accessPointController->GetCapabilities();
+        capabilities = IeeeAccessPointCapabilitiesToNetRemoteAccessPointCapabilities(capabilitiesIeee80211);
+    } catch (const AccessPointControllerException& apce) {
+        LOGE << std::format("Failed to get capabilities for access point {} ({})", interfaceName, apce.what());
+        return MakeInvalidAccessPointResultItem();
+    }
+
+    // Populate the result item.
+    item.set_accesspointid(std::move(id));
+    item.set_isenabled(isEnabled);
+    *item.mutable_capabilities() = std::move(capabilities);
+
+    return item;
+}
+
+Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResultItem
+IAccessPointWeakToNetRemoteAccessPointResultItem(std::weak_ptr<Microsoft::Net::Wifi::IAccessPoint>& accessPointWeak)
+{
+    using Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResultItem;
+
+    WifiEnumerateAccessPointsResultItem item{};
+
+    auto accessPoint = accessPointWeak.lock();
+    if (accessPoint != nullptr) {
+        item = IAccessPointToNetRemoteAccessPointResultItem(*accessPoint.get());
+    } else {
+        item.set_accesspointid(AccessPointIdInvalid);
+    }
+
+    return item;
+}
+} // namespace detail
+
 ::grpc::Status
 NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerContext* context, [[maybe_unused]] const ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResult* response)
 {
@@ -30,15 +117,8 @@ NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerConte
 
     auto accessPoints = m_accessPointManager->GetAllAccessPoints();
     std::vector<WifiEnumerateAccessPointsResultItem> accessPointResultItems(std::size(accessPoints));
-    std::ranges::transform(accessPoints, std::begin(accessPointResultItems), [](const auto& accessPointWeak) {
-        WifiEnumerateAccessPointsResultItem item{};
-        auto accessPoint = accessPointWeak.lock();
-        if (accessPoint != nullptr) {
-            auto interfaceName = accessPoint->GetInterfaceName();
-            std::string accessPointId{ std::cbegin(interfaceName), std::cend(interfaceName) };
-            item.set_accesspointid(std::move(accessPointId));
-        }
-        return std::move(item);
+    std::ranges::transform(accessPoints, std::begin(accessPointResultItems), [](auto& accessPointWeak) {
+        return detail::IAccessPointWeakToNetRemoteAccessPointResultItem(accessPointWeak);
     });
 
     *response->mutable_accesspoints() = {

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -285,7 +285,7 @@ IAccessPointWeakToNetRemoteAccessPointResultItem(std::weak_ptr<Microsoft::Net::W
     if (accessPoint != nullptr) {
         item = IAccessPointToNetRemoteAccessPointResultItem(*accessPoint.get());
     } else {
-        item.set_accesspointid(AccessPointIdInvalid);
+        item = detail::MakeInvalidAccessPointResultItem();
     }
 
     return item;

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -28,6 +28,155 @@ NetRemoteService::GetAccessPointManager() noexcept
 
 namespace detail
 {
+Microsoft::Net::Wifi::Dot11PhyType
+IeeeProtocolToNetRemotePhyType(const Microsoft::Net::Wifi::IeeeProtocol& ieeeProtocol)
+{
+    using Microsoft::Net::Wifi::Dot11PhyType;
+    using Microsoft::Net::Wifi::IeeeProtocol;
+
+    Dot11PhyType phyType{ Dot11PhyType::Dot11PhyTypeUnknown };
+
+    switch (ieeeProtocol) {
+    case IeeeProtocol::B:
+        phyType = Dot11PhyType::Dot11PhyTypeB;
+        break;
+    case IeeeProtocol::G:
+        phyType = Dot11PhyType::Dot11PhyTypeG;
+        break;
+    case IeeeProtocol::N:
+        phyType = Dot11PhyType::Dot11PhyTypeN;
+        break;
+    case IeeeProtocol::A:
+        phyType = Dot11PhyType::Dot11PhyTypeA;
+        break;
+    case IeeeProtocol::AC:
+        phyType = Dot11PhyType::Dot11PhyTypeAC;
+        break;
+    case IeeeProtocol::AD:
+        phyType = Dot11PhyType::Dot11PhyTypeAD;
+        break;
+    case IeeeProtocol::AX:
+        phyType = Dot11PhyType::Dot11PhyTypeAX;
+        break;
+    case IeeeProtocol::BE:
+        phyType = Dot11PhyType::Dot11PhyTypeBE;
+        break;
+    default:
+        break;
+    }
+
+    return phyType;
+}
+
+Microsoft::Net::Wifi::RadioBand
+IeeeFrequencyBandToNetRemoteRadioBand(const Microsoft::Net::Wifi::IeeeFrequencyBand& ieeeFrequencyBand)
+{
+    using Microsoft::Net::Wifi::IeeeFrequencyBand;
+    using Microsoft::Net::Wifi::RadioBand;
+
+    RadioBand band{ RadioBand::RadioBandUnknown };
+
+    switch (ieeeFrequencyBand) {
+    case IeeeFrequencyBand::TwoPointFourGHz:
+        band = RadioBand::RadioBandTwoPoint4GHz;
+        break;
+    case IeeeFrequencyBand::FiveGHz:
+        band = RadioBand::RadioBandFiveGHz;
+        break;
+    case IeeeFrequencyBand::SixGHz:
+        band = RadioBand::RadioBandSixGHz;
+        break;
+    default:
+        break;
+    }
+
+    return band;
+}
+
+Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm
+IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm(const Microsoft::Net::Wifi::IeeeAuthenticationAlgorithm& ieeeAuthenticationAlgorithm)
+{
+    using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
+    using Microsoft::Net::Wifi::IeeeAuthenticationAlgorithm;
+
+    Dot11AuthenticationAlgorithm authenticationAlgorithm{ Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmUnknown };
+
+    switch (ieeeAuthenticationAlgorithm) {
+    case IeeeAuthenticationAlgorithm::OpenSystem:
+        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmOpen;
+        break;
+    case IeeeAuthenticationAlgorithm::SharedKey:
+        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey;
+        break;
+    case IeeeAuthenticationAlgorithm::Sae:
+        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSae;
+        break;
+    // The following cases do not map to Dot11AuthenticationAlgorithm types. This appears to be because the Microsoft
+    // authentication algorithm definitions do not map 1-1 with the 802.11 definitions. Instead, they more resemble an
+    // 802.11 AKM. Fixing this requires a breaking API change, so will be deferred.
+    //
+    // case IeeeAuthenticationAlgorithm::FastBssTransition:
+    // case IeeeAuthenticationAlgorithm::Fils:
+    // case IeeeAuthenticationAlgorithm::FilsPfs:
+    // case IeeeAuthenticationAlgorithm::FilsPublicKey:
+    //
+    default:
+        break;
+    }
+
+    return authenticationAlgorithm;
+}
+
+Microsoft::Net::Wifi::Dot11CipherAlgorithm
+IeeeCipherAlgorithmToNetRemoteCipherAlgorithm(const Microsoft::Net::Wifi::IeeeCipherSuite& ieeeCipherSuite)
+{
+    using Microsoft::Net::Wifi::Dot11CipherAlgorithm;
+    using Microsoft::Net::Wifi::IeeeCipherSuite;
+
+    Dot11CipherAlgorithm cipherAlgorithm{ Dot11CipherAlgorithm::Dot11CipherAlgorithmUnknown };
+
+    switch (ieeeCipherSuite) {
+    case IeeeCipherSuite::Unknown:
+        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmNone;
+        break;
+    case IeeeCipherSuite::Wep40:
+        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmWep40;
+        break;
+    case IeeeCipherSuite::Tkip:
+        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmTkip;
+        break;
+    // case IeeeCipherSuite::Ccmp128: // FIXME
+    case IeeeCipherSuite::Wep104:
+        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmWep104;
+        break;
+    case IeeeCipherSuite::BipCmac128:
+        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmBipCmac128;
+        break;
+    case IeeeCipherSuite::Gcmp128:
+        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmGcmp128;
+        break;
+    case IeeeCipherSuite::Gcmp256:
+        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmGcmp256;
+        break;
+    case IeeeCipherSuite::Ccmp256:
+        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmCcmp256;
+        break;
+    case IeeeCipherSuite::BipGmac128:
+        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmBipGmac128;
+        break;
+    case IeeeCipherSuite::BipGmac256:
+        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmBipGmac256;
+        break;
+    case IeeeCipherSuite::BipCmac256:
+        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmBipCmac256;
+        break;
+    default:
+        break;
+    }
+
+    return cipherAlgorithm;
+}
+
 Microsoft::Net::Wifi::AccessPointCapabilities
 IeeeAccessPointCapabilitiesToNetRemoteAccessPointCapabilities([[maybe_unused]] const Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities& ieeeCapabilities)
 {
@@ -36,10 +185,37 @@ IeeeAccessPointCapabilitiesToNetRemoteAccessPointCapabilities([[maybe_unused]] c
 
     AccessPointCapabilities capabilities{};
 
-    // capabilities.set_protocols(ieeeCapabilities.Protocols);
-    // capabilities.set_frequencybands(ieeeCapabilities.FrequencyBands);
-    // capabilities.set_authenticationalgorithms(ieeeCapabilities.AuthenticationAlgorithms);
-    // capabilities.set_encryptionalgorithms(ieeeCapabilities.EncryptionAlgorithms);
+    std::vector<Microsoft::Net::Wifi::Dot11PhyType> phyTypes(std::size(ieeeCapabilities.Protocols));
+    std::ranges::transform(ieeeCapabilities.Protocols, std::begin(phyTypes), IeeeProtocolToNetRemotePhyType);
+
+    *capabilities.mutable_phytypes() = {
+        std::make_move_iterator(std::begin(phyTypes)),
+        std::make_move_iterator(std::end(phyTypes))
+    };
+
+    std::vector<Microsoft::Net::Wifi::RadioBand> bands(std::size(ieeeCapabilities.FrequencyBands));
+    std::ranges::transform(ieeeCapabilities.FrequencyBands, std::begin(bands), IeeeFrequencyBandToNetRemoteRadioBand);
+
+    *capabilities.mutable_bands() = {
+        std::make_move_iterator(std::begin(bands)),
+        std::make_move_iterator(std::end(bands))
+    };
+
+    std::vector<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm> authenticationAlgorithms(std::size(ieeeCapabilities.AuthenticationAlgorithms));
+    std::ranges::transform(ieeeCapabilities.AuthenticationAlgorithms, std::begin(authenticationAlgorithms), IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm);
+
+    *capabilities.mutable_authenticationalgorithms() = {
+        std::make_move_iterator(std::begin(authenticationAlgorithms)),
+        std::make_move_iterator(std::end(authenticationAlgorithms))
+    };
+
+    std::vector<Microsoft::Net::Wifi::Dot11CipherAlgorithm> encryptionAlgorithms(std::size(ieeeCapabilities.EncryptionAlgorithms));
+    std::ranges::transform(ieeeCapabilities.EncryptionAlgorithms, std::begin(encryptionAlgorithms), IeeeCipherAlgorithmToNetRemoteCipherAlgorithm);
+
+    *capabilities.mutable_encryptionalgorithms() = {
+        std::make_move_iterator(std::begin(encryptionAlgorithms)),
+        std::make_move_iterator(std::end(encryptionAlgorithms))
+    };
 
     return capabilities;
 }

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -29,7 +29,7 @@ NetRemoteService::GetAccessPointManager() noexcept
 namespace detail
 {
 Microsoft::Net::Wifi::Dot11PhyType
-IeeeProtocolToNetRemotePhyType(const Microsoft::Net::Wifi::IeeeProtocol& ieeeProtocol)
+IeeeProtocolToNetRemotePhyType(Microsoft::Net::Wifi::IeeeProtocol ieeeProtocol)
 {
     using Microsoft::Net::Wifi::Dot11PhyType;
     using Microsoft::Net::Wifi::IeeeProtocol;
@@ -69,7 +69,7 @@ IeeeProtocolToNetRemotePhyType(const Microsoft::Net::Wifi::IeeeProtocol& ieeePro
 }
 
 Microsoft::Net::Wifi::RadioBand
-IeeeFrequencyBandToNetRemoteRadioBand(const Microsoft::Net::Wifi::IeeeFrequencyBand& ieeeFrequencyBand)
+IeeeFrequencyBandToNetRemoteRadioBand(Microsoft::Net::Wifi::IeeeFrequencyBand ieeeFrequencyBand)
 {
     using Microsoft::Net::Wifi::IeeeFrequencyBand;
     using Microsoft::Net::Wifi::RadioBand;
@@ -94,7 +94,7 @@ IeeeFrequencyBandToNetRemoteRadioBand(const Microsoft::Net::Wifi::IeeeFrequencyB
 }
 
 Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm
-IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm(const Microsoft::Net::Wifi::IeeeAuthenticationAlgorithm& ieeeAuthenticationAlgorithm)
+IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm(Microsoft::Net::Wifi::IeeeAuthenticationAlgorithm ieeeAuthenticationAlgorithm)
 {
     using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
     using Microsoft::Net::Wifi::IeeeAuthenticationAlgorithm;
@@ -128,7 +128,7 @@ IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm(const Microsoft::N
 }
 
 Microsoft::Net::Wifi::Dot11CipherAlgorithm
-IeeeCipherAlgorithmToNetRemoteCipherAlgorithm(const Microsoft::Net::Wifi::IeeeCipherSuite& ieeeCipherSuite)
+IeeeCipherAlgorithmToNetRemoteCipherAlgorithm(Microsoft::Net::Wifi::IeeeCipherSuite ieeeCipherSuite)
 {
     using Microsoft::Net::Wifi::Dot11CipherAlgorithm;
     using Microsoft::Net::Wifi::IeeeCipherSuite;
@@ -178,7 +178,7 @@ IeeeCipherAlgorithmToNetRemoteCipherAlgorithm(const Microsoft::Net::Wifi::IeeeCi
 }
 
 Microsoft::Net::Wifi::AccessPointCapabilities
-IeeeAccessPointCapabilitiesToNetRemoteAccessPointCapabilities([[maybe_unused]] const Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities& ieeeCapabilities)
+IeeeAccessPointCapabilitiesToNetRemoteAccessPointCapabilities(const Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities& ieeeCapabilities)
 {
     using Microsoft::Net::Wifi::AccessPointCapabilities;
     using Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities;

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -34,6 +34,7 @@ NetRemoteCliHandlerOperations::WifiEnumerateAccessPoints()
 
     for (const auto& accessPoint : result.accesspoints()) {
         LOGI << std::format(" - [{}]", accessPoint.accesspointid());
+        LOGI << std::format("   - {}", accessPoint.isenabled() ? "enabled" : "disabled");
     }
 }
 

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -155,7 +155,10 @@ AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync()
     // Enumerate all nl80211 interfaces and filter out those that are not APs.
     auto nl80211Interfaces{ Nl80211Interface::Enumerate() };
     auto nl80211ApInterfaceNames = nl80211Interfaces | std::views::filter(detail::IsNl80211InterfaceTypeAp) | std::views::transform(detail::Nl80211InterfaceName);
-    std::vector<std::string> accessPoints(std::begin(nl80211ApInterfaceNames), std::end(nl80211ApInterfaceNames));
+    std::vector<std::string> accessPoints(std::make_move_iterator(std::begin(nl80211ApInterfaceNames)), std::make_move_iterator(std::end(nl80211ApInterfaceNames)));
+
+    // Clear the vector since most of the items were moved out.
+    nl80211Interfaces.clear();
 
     probePromise.set_value(std::move(accessPoints));
 

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -3,6 +3,7 @@
 #include <array>
 #include <cerrno>
 #include <format>
+#include <ranges>
 #include <stdexcept>
 #include <string_view>
 
@@ -117,17 +118,44 @@ AccessPointDiscoveryAgentOperationsNetlink::Stop()
     }
 }
 
+namespace detail
+{
+/**
+ * @brief Helper function to determine if an nl80211 interface is an AP. To be used in range expressions.
+ *
+ * @param nl80211Interface
+ * @return true
+ * @return false
+ */
+bool
+IsNl80211InterfaceTypeAp(const Nl80211Interface &nl80211Interface)
+{
+    return (nl80211Interface.Type == nl80211_iftype::NL80211_IFTYPE_AP);
+}
+
+/**
+ * @brief Helper function returning the name of an nl80211 interface. To be used in range expressions.
+ *
+ * @param nl80211Interface
+ * @return std::string
+ */
+std::string
+Nl80211InterfaceName(const Nl80211Interface &nl80211Interface)
+{
+    return nl80211Interface.Name;
+}
+} // namespace detail
+
 std::future<std::vector<std::string>>
 AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync()
 {
     std::promise<std::vector<std::string>> probePromise{};
     auto probeFuture = probePromise.get_future();
 
+    // Enumerate all nl80211 interfaces and filter out those that are not APs.
     auto nl80211Interfaces{ Nl80211Interface::Enumerate() };
-    std::vector<std::string> accessPoints(std::size(nl80211Interfaces));
-    std::ranges::transform(nl80211Interfaces, std::begin(accessPoints), [](const auto &nl80211Interface) {
-        return nl80211Interface.Name;
-    });
+    auto nl80211ApInterfaceNames = nl80211Interfaces | std::views::filter(detail::IsNl80211InterfaceTypeAp) | std::views::transform(detail::Nl80211InterfaceName);
+    std::vector<std::string> accessPoints(std::begin(nl80211ApInterfaceNames), std::end(nl80211ApInterfaceNames));
 
     probePromise.set_value(std::move(accessPoints));
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure access point capabilities can be obtained by clients.

### Technical Details

* Implement conversion functions from the `Ieee80211*` spec types to the `Dot11*` API types.
* Filter out non-AP interfaces when probing using netlink-based ap discovery mechanism.

### Test Results

* Unit tests still need to be authored and carried out.
* Ran `netremote-cli` and ensured no crashes occurred. Also attached a debugger to the server side and inspected the fully built protobuf object which appeared to be correct, excepting the known issues (see Future Work section below).

### Reviewer Focus

* Consider whether the mapping from `Ieee80211*` to `Dot11*` API types makes sense and/or whether there are cases where the mapping is not 1-1.

### Future Work

* The `Dot11AuthenticationAlgorithm` protobuf enumeration currently reflects Windows view of 802.11 authentication algorithms, however, it appears more like an 802.11 AKM instead. As such, there is no direct mapping(s) from the `Ieee80211AuthenticationAlgorithm` enumeration. _An API breaking change will be needed to fix this_, @corbin-phipps FYI.
* The `netremote-cli` tool needs to be updated to display the capabilities information.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
