### PR TITLE
Print access point capabilities in netremote-cli

### DIFF
--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -1,4 +1,6 @@
+
 #include <format>
+#include <sstream>
 
 #include <grpcpp/client_context.h>
 #include <magic_enum.hpp>
@@ -17,6 +19,63 @@ NetRemoteCliHandlerOperations::NetRemoteCliHandlerOperations(std::shared_ptr<Net
 {
 }
 
+namespace detail
+{
+/**
+ * @brief Generate a string representation of a AccessPointCapabilities object.
+ * 
+ * @param accessPointCapabilities The object to generate a string representation of.
+ * @param indentationLevel The indentation level to use.
+ * @param indentation The number of spaces in each indentation level.
+ * @return std::string 
+ */
+std::string
+NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::AccessPointCapabilities& accessPointCapabilities, std::size_t indentationLevel = 1, std::size_t indentation = 2)
+{
+    const auto indent0 = std::string((indentationLevel + 0) * indentation, ' ');
+    const auto indent1 = std::string((indentationLevel + 1) * indentation, ' ');
+
+    std::stringstream ss;
+
+    ss << indent0
+       <<  "Phy Types:";
+    for (const auto& phyType : accessPointCapabilities.phytypes()) {
+        ss << '\n'
+           << indent1
+           << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11PhyType>(phyType));
+    }
+
+    ss << '\n'
+       << indent0
+       << "Bands:";
+    for (const auto& band : accessPointCapabilities.bands()) {
+        ss << '\n'
+           << indent1
+           << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::RadioBand>(band));
+    }
+
+    ss << '\n'
+       << indent0
+       << "Authentication Algorithms:";
+    for (const auto& authenticationAlgorithm : accessPointCapabilities.authenticationalgorithms()) {
+        ss << '\n'
+           << indent1
+           << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm>(authenticationAlgorithm));
+    }
+
+    ss << '\n'
+       << indent0
+       << "Cipher Algorithms:";
+    for (const auto& ciperAlgorithm : accessPointCapabilities.encryptionalgorithms()) {
+        ss << '\n'
+           << indent1
+           << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11CipherAlgorithm>(ciperAlgorithm));
+    }
+
+    return ss.str();
+}
+} // namespace detail
+
 void
 NetRemoteCliHandlerOperations::WifiEnumerateAccessPoints()
 {
@@ -30,11 +89,22 @@ NetRemoteCliHandlerOperations::WifiEnumerateAccessPoints()
         return;
     }
 
-    LOGI << std::format("{} access points discovered", result.accesspoints_size());
+    if (result.accesspoints().empty()) {
+        LOGI << "No access points found";
+        return;
+    }
 
+    std::size_t numAccessPoint = 1;
     for (const auto& accessPoint : result.accesspoints()) {
-        LOGI << std::format(" - [{}]", accessPoint.accesspointid());
-        LOGI << std::format("   - {}", accessPoint.isenabled() ? "enabled" : "disabled");
+        std::stringstream ss;
+        ss << '[' << numAccessPoint++ << "] " << accessPoint.accesspointid();
+        if (!accessPoint.isenabled()) {
+            ss << " (disabled)";
+        }
+        ss << '\n'
+           << detail::NetRemoteAccessPointCapabilitiesToString(accessPoint.capabilities())
+           << '\n';
+        LOGI << ss.str();
     }
 }
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure access point capabilities are displayed in the `wifi enumaps` cli command.

### Technical Details

* Add function to convert a `AccessPointCapabilities` to a string.
* Use the conversion function to print out the capabilities in response to the `wifi enumapsa cli command.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
