### PR TITLE
Change access point discovery output from interface name to IAccessPoint

### DIFF
--- a/src/common/wifi/apmanager/AccessPointDiscoveryAgent.cxx
+++ b/src/common/wifi/apmanager/AccessPointDiscoveryAgent.cxx
@@ -57,7 +57,7 @@ AccessPointDiscoveryAgent::Start()
     bool expected = false;
     if (m_started.compare_exchange_weak(expected, true)) {
         LOGD << "Access point discovery agent starting";
-         m_operations->Start([weakThis = std::weak_ptr<AccessPointDiscoveryAgent>(GetInstance())](auto&& presence, auto&& accessPoint) {
+        m_operations->Start([weakThis = std::weak_ptr<AccessPointDiscoveryAgent>(GetInstance())](auto&& presence, auto&& accessPoint) {
             // Attempt to promote the weak pointer to a shared pointer to ensure this instance is still valid.
             if (auto strongThis = weakThis.lock(); strongThis) {
                 strongThis->DevicePresenceChanged(presence, std::move(accessPoint));

--- a/src/common/wifi/apmanager/AccessPointDiscoveryAgent.cxx
+++ b/src/common/wifi/apmanager/AccessPointDiscoveryAgent.cxx
@@ -82,3 +82,9 @@ AccessPointDiscoveryAgent::ProbeAsync()
     LOGD << "Access point discovery agent probing for devices";
     return m_operations->ProbeAsync();
 }
+
+std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+AccessPointDiscoveryAgent::ProbeAsync2()
+{
+    return m_operations->ProbeAsync2();
+}

--- a/src/common/wifi/apmanager/AccessPointDiscoveryAgent.cxx
+++ b/src/common/wifi/apmanager/AccessPointDiscoveryAgent.cxx
@@ -76,15 +76,8 @@ AccessPointDiscoveryAgent::Stop()
     }
 }
 
-std::future<std::vector<std::string>>
+std::future<std::vector<std::shared_ptr<IAccessPoint>>>
 AccessPointDiscoveryAgent::ProbeAsync()
 {
-    LOGD << "Access point discovery agent probing for devices";
     return m_operations->ProbeAsync();
-}
-
-std::future<std::vector<std::shared_ptr<IAccessPoint>>>
-AccessPointDiscoveryAgent::ProbeAsync2()
-{
-    return m_operations->ProbeAsync2();
 }

--- a/src/common/wifi/apmanager/AccessPointManager.cxx
+++ b/src/common/wifi/apmanager/AccessPointManager.cxx
@@ -3,23 +3,21 @@
 #include <chrono>
 #include <iterator>
 
+#include <magic_enum.hpp>
 #include <microsoft/net/wifi/AccessPoint.hxx>
 #include <microsoft/net/wifi/AccessPointDiscoveryAgent.hxx>
 #include <microsoft/net/wifi/AccessPointManager.hxx>
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <notstd/Memory.hxx>
+#include <plog/Log.h>
 
 using namespace Microsoft::Net::Wifi;
 
-AccessPointManager::AccessPointManager(std::shared_ptr<IAccessPointFactory> accessPointFactory) :
-    m_accessPointFactory(std::move(accessPointFactory))
-{}
-
 /* static */
 std::shared_ptr<AccessPointManager>
-AccessPointManager::Create(std::shared_ptr<IAccessPointFactory> accessPointFactory)
+AccessPointManager::Create()
 {
-    return std::make_shared<notstd::enable_make_protected<AccessPointManager>>(std::move(accessPointFactory));
+    return std::make_shared<notstd::enable_make_protected<AccessPointManager>>();
 }
 
 std::shared_ptr<AccessPointManager>
@@ -110,7 +108,7 @@ AccessPointManager::AddDiscoveryAgent(std::shared_ptr<AccessPointDiscoveryAgent>
     }
 
     // Kick off a probe to ensure any access points already present will be added to this manager.
-    auto existingAccessPointInterfaceNamesProbe = discoveryAgent->ProbeAsync();
+    auto existingAccessPointsProbe = discoveryAgent->ProbeAsync();
 
     // Add the agent.
     {
@@ -118,21 +116,20 @@ AccessPointManager::AddDiscoveryAgent(std::shared_ptr<AccessPointDiscoveryAgent>
         m_discoveryAgents.push_back(std::move(discoveryAgent));
     }
 
-    if (existingAccessPointInterfaceNamesProbe.valid()) {
+    if (existingAccessPointsProbe.valid()) {
         static constexpr auto ProbeTimeout = 3s;
 
         // Wait for the operation to complete.
-        const auto waitResult = existingAccessPointInterfaceNamesProbe.wait_for(ProbeTimeout);
+        const auto waitResult = existingAccessPointsProbe.wait_for(ProbeTimeout);
 
         // If the operation completed, get the results and add those access points.
         if (waitResult == std::future_status::ready) {
-            auto existingAccessPointInterfaceNames = existingAccessPointInterfaceNamesProbe.get();
-            for (const auto& existingAccessPointInterfaceName : existingAccessPointInterfaceNames) {
-                auto existingAccessPoint = m_accessPointFactory->Create(existingAccessPointInterfaceName);
+            auto existingAccessPoints = existingAccessPointsProbe.get();
+            for (const auto& existingAccessPoint : existingAccessPoints) {
                 AddAccessPoint(std::move(existingAccessPoint));
             }
         } else {
-            // TODO: log error
+            LOGE << std::format("Access point discovery agent probe failed ({})", magic_enum::enum_name(waitResult));
         }
     }
 }

--- a/src/common/wifi/apmanager/AccessPointManager.cxx
+++ b/src/common/wifi/apmanager/AccessPointManager.cxx
@@ -11,13 +11,13 @@
 
 using namespace Microsoft::Net::Wifi;
 
-AccessPointManager::AccessPointManager(std::unique_ptr<IAccessPointFactory> accessPointFactory) :
+AccessPointManager::AccessPointManager(std::shared_ptr<IAccessPointFactory> accessPointFactory) :
     m_accessPointFactory(std::move(accessPointFactory))
 {}
 
 /* static */
 std::shared_ptr<AccessPointManager>
-AccessPointManager::Create(std::unique_ptr<IAccessPointFactory> accessPointFactory)
+AccessPointManager::Create(std::shared_ptr<IAccessPointFactory> accessPointFactory)
 {
     return std::make_shared<notstd::enable_make_protected<AccessPointManager>>(std::move(accessPointFactory));
 }

--- a/src/common/wifi/apmanager/AccessPointManager.cxx
+++ b/src/common/wifi/apmanager/AccessPointManager.cxx
@@ -98,9 +98,8 @@ AccessPointManager::AddDiscoveryAgent(std::shared_ptr<AccessPointDiscoveryAgent>
     // be safely destroyed prior to the discovery agent. This allows the
     // callback to be registered indefinitely, safely checking whether this
     // instance is still valid upon each callback invocation.
-    discoveryAgent->RegisterDiscoveryEventCallback([discoveryAgentPtr = discoveryAgent.get(), weakThis = std::weak_ptr<AccessPointManager>(GetInstance())](auto&& presence, auto&& interfaceName) {
+    discoveryAgent->RegisterDiscoveryEventCallback([discoveryAgentPtr = discoveryAgent.get(), weakThis = std::weak_ptr<AccessPointManager>(GetInstance())](auto&& presence, auto&& accessPointChanged) {
         if (auto strongThis = weakThis.lock()) {
-            auto accessPointChanged = strongThis->m_accessPointFactory->Create(interfaceName);
             strongThis->OnAccessPointPresenceChanged(discoveryAgentPtr, presence, std::move(accessPointChanged));
         }
     });

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgent.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgent.hxx
@@ -82,6 +82,14 @@ struct AccessPointDiscoveryAgent :
     std::future<std::vector<std::string>>
     ProbeAsync();
 
+    /**
+     * @brief Perform an asynchronous discovery probe.
+     *
+     * @return std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+     */
+    std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+    ProbeAsync2();
+
 protected:
     /**
      * @brief Construct a new AccessPointDiscoveryAgent object with the specified operations.

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgent.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgent.hxx
@@ -54,6 +54,16 @@ struct AccessPointDiscoveryAgent :
     RegisterDiscoveryEventCallback(AccessPointPresenceEventCallback onDevicePresenceChanged);
 
     /**
+     * @brief Register a callback for device presence change events.
+     *
+     * The caller must ensure the validity of this callback during the lifetime of this object instance.
+     *
+     * @param onDevicePresenceChanged The callback to register.
+     */
+    void
+    RegisterDiscoveryEventCallback2(AccessPointPresenceEventCallback2 onDevicePresenceChanged);
+
+    /**
      * @brief indicates the started/running state.
      *
      * @return true
@@ -107,12 +117,22 @@ protected:
     void
     DevicePresenceChanged(AccessPointPresenceEvent presence, std::string interfaceName) const noexcept;
 
+    /**
+     * @brief Wrapper for safely invoking any device presence changed registered callback.
+     *
+     * @param presence The presence change that occurred.
+     * @param accessPoint The access point instance that changed.
+     */
+    void
+    DevicePresenceChanged2(AccessPointPresenceEvent presence, std::shared_ptr<IAccessPoint> accessPoint) const noexcept;
+
 private:
     std::unique_ptr<IAccessPointDiscoveryAgentOperations> m_operations;
     std::atomic<bool> m_started{ false };
 
     mutable std::shared_mutex m_onDevicePresenceChangedGate;
     AccessPointPresenceEventCallback m_onDevicePresenceChanged;
+    AccessPointPresenceEventCallback2 m_onDevicePresenceChanged2;
 };
 
 } // namespace Microsoft::Net::Wifi

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgent.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgent.hxx
@@ -7,7 +7,6 @@
 #include <future>
 #include <memory>
 #include <shared_mutex>
-#include <string>
 
 #include <microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx>
 
@@ -75,20 +74,12 @@ struct AccessPointDiscoveryAgent :
     Stop();
 
     /**
-     * @brief Probe for all existing devices.
-     *
-     * @return std::future<std::vector<std::string>>
-     */
-    std::future<std::vector<std::string>>
-    ProbeAsync();
-
-    /**
      * @brief Perform an asynchronous discovery probe.
      *
      * @return std::future<std::vector<std::shared_ptr<IAccessPoint>>>
      */
     std::future<std::vector<std::shared_ptr<IAccessPoint>>>
-    ProbeAsync2();
+    ProbeAsync();
 
 protected:
     /**

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgent.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgent.hxx
@@ -54,16 +54,6 @@ struct AccessPointDiscoveryAgent :
     RegisterDiscoveryEventCallback(AccessPointPresenceEventCallback onDevicePresenceChanged);
 
     /**
-     * @brief Register a callback for device presence change events.
-     *
-     * The caller must ensure the validity of this callback during the lifetime of this object instance.
-     *
-     * @param onDevicePresenceChanged The callback to register.
-     */
-    void
-    RegisterDiscoveryEventCallback2(AccessPointPresenceEventCallback2 onDevicePresenceChanged);
-
-    /**
      * @brief indicates the started/running state.
      *
      * @return true
@@ -112,19 +102,10 @@ protected:
      * @brief Wrapper for safely invoking any device presence changed registered callback.
      *
      * @param presence The presence change that occurred.
-     * @param interfaceName The name of the network interface of the access point that changed.
-     */
-    void
-    DevicePresenceChanged(AccessPointPresenceEvent presence, std::string interfaceName) const noexcept;
-
-    /**
-     * @brief Wrapper for safely invoking any device presence changed registered callback.
-     *
-     * @param presence The presence change that occurred.
      * @param accessPoint The access point instance that changed.
      */
     void
-    DevicePresenceChanged2(AccessPointPresenceEvent presence, std::shared_ptr<IAccessPoint> accessPoint) const noexcept;
+    DevicePresenceChanged(AccessPointPresenceEvent presence, std::shared_ptr<IAccessPoint> accessPoint) const noexcept;
 
 private:
     std::unique_ptr<IAccessPointDiscoveryAgentOperations> m_operations;
@@ -132,7 +113,6 @@ private:
 
     mutable std::shared_mutex m_onDevicePresenceChangedGate;
     AccessPointPresenceEventCallback m_onDevicePresenceChanged;
-    AccessPointPresenceEventCallback2 m_onDevicePresenceChanged2;
 };
 
 } // namespace Microsoft::Net::Wifi

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
@@ -33,7 +33,7 @@ public:
      * @return std::shared_ptr<AccessPointManager>
      */
     [[nodiscard]] static std::shared_ptr<AccessPointManager>
-    Create(std::shared_ptr<IAccessPointFactory> accessPointFactory);
+    Create();
 
     /**
      * @brief Get an instance of this access point manager.
@@ -84,11 +84,11 @@ public:
 
 protected:
     /**
-     * @brief Construct a new AccessPointManager object with the specified access point factory.
+     * @brief Construct a new AccessPointManager object.
      * 
      * @param accessPointFactory 
      */
-    AccessPointManager(std::shared_ptr<IAccessPointFactory> accessPointFactory);
+    AccessPointManager() = default;
 
 private:
     /**

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
@@ -33,7 +33,7 @@ public:
      * @return std::shared_ptr<AccessPointManager>
      */
     [[nodiscard]] static std::shared_ptr<AccessPointManager>
-    Create(std::unique_ptr<IAccessPointFactory> accessPointFactory);
+    Create(std::shared_ptr<IAccessPointFactory> accessPointFactory);
 
     /**
      * @brief Get an instance of this access point manager.
@@ -84,20 +84,11 @@ public:
 
 protected:
     /**
-     * @brief Default constructor.
-     *
-     * It's intentional that this is *declared* here and default-implemented
-     * in the source file. This is required because IAccessPoint
-     * and AccessPointDiscoveryAgent are used as incomplete
-     * types with std::unique_ptr and std::shared_ptr. In case an exception is
-     * thrown in the constructor, their destructors may be called, and the
-     * wrapped type must be complete at that time. As such, defining the
-     * constructor implementation as default here would require the type to be
-     * complete, which is impossible due to the forward declaration.
-     * Consequently, the = default implementation is done in the source file
-     * instead.
+     * @brief Construct a new AccessPointManager object with the specified access point factory.
+     * 
+     * @param accessPointFactory 
      */
-    AccessPointManager(std::unique_ptr<IAccessPointFactory> accessPointFactory);
+    AccessPointManager(std::shared_ptr<IAccessPointFactory> accessPointFactory);
 
 private:
     /**
@@ -127,7 +118,7 @@ private:
     RemoveAccessPoint(std::shared_ptr<IAccessPoint> accessPoint);
 
 private:
-    std::unique_ptr<IAccessPointFactory> m_accessPointFactory;
+    std::shared_ptr<IAccessPointFactory> m_accessPointFactory;
 
     mutable std::mutex m_accessPointGate;
     std::vector<std::shared_ptr<IAccessPoint>> m_accessPoints{};

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
@@ -85,8 +85,8 @@ public:
 protected:
     /**
      * @brief Construct a new AccessPointManager object.
-     * 
-     * @param accessPointFactory 
+     *
+     * @param accessPointFactory
      */
     AccessPointManager() = default;
 

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx
@@ -51,6 +51,14 @@ struct IAccessPointDiscoveryAgentOperations
      */
     virtual std::future<std::vector<std::string>>
     ProbeAsync() = 0;
+
+    /**
+     * @brief Perform an asynchronous discovery probe.
+     *
+     * @return std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+     */
+    virtual std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+    ProbeAsync2() = 0;
 };
 
 } // namespace Microsoft::Net::Wifi

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx
@@ -22,6 +22,8 @@ struct IAccessPoint;
  */
 using AccessPointPresenceEventCallback = std::function<void(AccessPointPresenceEvent, std::string interfaceName)>;
 
+using AccessPointPresenceEventCallback2 = std::function<void(AccessPointPresenceEvent, std::shared_ptr<IAccessPoint> accessPoint)>;
+
 /**
  * @brief Operations used to perform discovery of access points, used by
  * AccessPointDiscoveryAgent as part of the strategy design pattern.
@@ -37,6 +39,14 @@ struct IAccessPointDiscoveryAgentOperations
      */
     virtual void
     Start(AccessPointPresenceEventCallback callback) = 0;
+
+    /**
+     * @brief Start the discovery process.
+     *
+     * @param callback The callback to invoke when an access point is discovered or removed.
+     */
+    virtual void
+    Start2(AccessPointPresenceEventCallback2 callback) = 0;
 
     /**
      * @brief Stop the discovery process.

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx
@@ -20,9 +20,7 @@ struct IAccessPoint;
 /**
  * @brief Prototype for the callback invoked when an access point is discovered or removed.
  */
-using AccessPointPresenceEventCallback = std::function<void(AccessPointPresenceEvent, std::string interfaceName)>;
-
-using AccessPointPresenceEventCallback2 = std::function<void(AccessPointPresenceEvent, std::shared_ptr<IAccessPoint> accessPoint)>;
+using AccessPointPresenceEventCallback = std::function<void(AccessPointPresenceEvent, std::shared_ptr<IAccessPoint> accessPoint)>;
 
 /**
  * @brief Operations used to perform discovery of access points, used by
@@ -39,14 +37,6 @@ struct IAccessPointDiscoveryAgentOperations
      */
     virtual void
     Start(AccessPointPresenceEventCallback callback) = 0;
-
-    /**
-     * @brief Start the discovery process.
-     *
-     * @param callback The callback to invoke when an access point is discovered or removed.
-     */
-    virtual void
-    Start2(AccessPointPresenceEventCallback2 callback) = 0;
 
     /**
      * @brief Stop the discovery process.

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx
@@ -5,7 +5,6 @@
 #include <functional>
 #include <future>
 #include <memory>
-#include <string>
 #include <vector>
 
 namespace Microsoft::Net::Wifi
@@ -47,18 +46,10 @@ struct IAccessPointDiscoveryAgentOperations
     /**
      * @brief Perform an asynchronous discovery probe.
      *
-     * @return std::future<std::vector<std::string>>
-     */
-    virtual std::future<std::vector<std::string>>
-    ProbeAsync() = 0;
-
-    /**
-     * @brief Perform an asynchronous discovery probe.
-     *
      * @return std::future<std::vector<std::shared_ptr<IAccessPoint>>>
      */
     virtual std::future<std::vector<std::shared_ptr<IAccessPoint>>>
-    ProbeAsync2() = 0;
+    ProbeAsync() = 0;
 };
 
 } // namespace Microsoft::Net::Wifi

--- a/src/linux/server/Main.cxx
+++ b/src/linux/server/Main.cxx
@@ -49,11 +49,11 @@ main(int argc, char *argv[])
     // Create an access point manager and discovery agent.
     {
         auto accessPointControllerFactory = std::make_unique<AccessPointControllerHostapdFactory>();
-        auto accessPointFactory = std::make_unique<AccessPointFactoryLinux>(std::move(accessPointControllerFactory));
+        auto accessPointFactory = std::make_shared<AccessPointFactoryLinux>(std::move(accessPointControllerFactory));
         configuration.AccessPointManager = AccessPointManager::Create(std::move(accessPointFactory));
 
         auto &accessPointManager = configuration.AccessPointManager;
-        auto accessPointDiscoveryAgentOperationsNetlink = std::make_unique<AccessPointDiscoveryAgentOperationsNetlink>();
+        auto accessPointDiscoveryAgentOperationsNetlink = std::make_unique<AccessPointDiscoveryAgentOperationsNetlink>(accessPointFactory);
         auto accessPointDiscoveryAgent = AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperationsNetlink));
         accessPointManager->AddDiscoveryAgent(std::move(accessPointDiscoveryAgent));
     }

--- a/src/linux/server/Main.cxx
+++ b/src/linux/server/Main.cxx
@@ -50,7 +50,7 @@ main(int argc, char *argv[])
     {
         auto accessPointControllerFactory = std::make_unique<AccessPointControllerHostapdFactory>();
         auto accessPointFactory = std::make_shared<AccessPointFactoryLinux>(std::move(accessPointControllerFactory));
-        configuration.AccessPointManager = AccessPointManager::Create(std::move(accessPointFactory));
+        configuration.AccessPointManager = AccessPointManager::Create();
 
         auto &accessPointManager = configuration.AccessPointManager;
         auto accessPointDiscoveryAgentOperationsNetlink = std::make_unique<AccessPointDiscoveryAgentOperationsNetlink>(accessPointFactory);

--- a/src/linux/server/Main.cxx
+++ b/src/linux/server/Main.cxx
@@ -48,13 +48,14 @@ main(int argc, char *argv[])
 
     // Create an access point manager and discovery agent.
     {
-        auto accessPointControllerFactory = std::make_unique<AccessPointControllerHostapdFactory>();
-        auto accessPointFactory = std::make_shared<AccessPointFactoryLinux>(std::move(accessPointControllerFactory));
         configuration.AccessPointManager = AccessPointManager::Create();
 
-        auto &accessPointManager = configuration.AccessPointManager;
+        auto accessPointControllerFactory = std::make_unique<AccessPointControllerHostapdFactory>();
+        auto accessPointFactory = std::make_shared<AccessPointFactoryLinux>(std::move(accessPointControllerFactory));
         auto accessPointDiscoveryAgentOperationsNetlink = std::make_unique<AccessPointDiscoveryAgentOperationsNetlink>(accessPointFactory);
         auto accessPointDiscoveryAgent = AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperationsNetlink));
+        auto &accessPointManager = configuration.AccessPointManager;
+
         accessPointManager->AddDiscoveryAgent(std::move(accessPointDiscoveryAgent));
     }
 

--- a/src/linux/tools/apmonitor/CMakeLists.txt
+++ b/src/linux/tools/apmonitor/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(apmonitor-cli-linux
     PRIVATE
         plog::plog
         wifi-apmanager-linux
+        wifi-core-linux
 )
 
 set_target_properties(apmonitor-cli-linux

--- a/src/linux/tools/apmonitor/Main.cxx
+++ b/src/linux/tools/apmonitor/Main.cxx
@@ -2,8 +2,10 @@
 #include <format>
 
 #include <magic_enum.hpp>
+#include <microsoft/net/wifi/AccessPointControllerHostapd.hxx>
 #include <microsoft/net/wifi/AccessPointDiscoveryAgent.hxx>
 #include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
+#include <microsoft/net/wifi/AccessPointLinux.hxx>
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <plog/Appenders/ColorConsoleAppender.h>
 #include <plog/Formatters/MessageOnlyFormatter.h>
@@ -11,9 +13,7 @@
 #include <plog/Log.h>
 #include <signal.h>
 
-using Microsoft::Net::Wifi::AccessPointDiscoveryAgent;
-using Microsoft::Net::Wifi::AccessPointDiscoveryAgentOperationsNetlink;
-using Microsoft::Net::Wifi::IAccessPointDiscoveryAgentOperations;
+using namespace Microsoft::Net::Wifi;
 
 int
 main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
@@ -23,10 +23,15 @@ main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     plog::init(plog::verbose, &colorConsoleAppender);
 
     // Configure monitoring with the netlink protocol.
-    auto accessPointDiscoveryAgentOperationsNetlink{ std::make_unique<AccessPointDiscoveryAgentOperationsNetlink>() };
+    auto accessPointControllerFactory = std::make_unique<AccessPointControllerHostapdFactory>();
+    auto accessPointFactory = std::make_shared<AccessPointFactoryLinux>(std::move(accessPointControllerFactory));
+    auto accessPointDiscoveryAgentOperationsNetlink{ std::make_unique<AccessPointDiscoveryAgentOperationsNetlink>(accessPointFactory) };
     auto accessPointDiscoveryAgent{ AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperationsNetlink)) };
     accessPointDiscoveryAgent->RegisterDiscoveryEventCallback([](auto&& presence, auto&& interfaceName) {
         PLOG_INFO << std::format("{} -> {}", interfaceName, magic_enum::enum_name(presence));
+    });
+    accessPointDiscoveryAgent->RegisterDiscoveryEventCallback2([](auto&& presence, auto&& accessPoint) {
+        LOGI <<  std::format("{} -> {}", accessPoint->GetInterfaceName(), magic_enum::enum_name(presence));
     });
 
     LOG_INFO << "starting access point discovery agent";

--- a/src/linux/tools/apmonitor/Main.cxx
+++ b/src/linux/tools/apmonitor/Main.cxx
@@ -28,7 +28,7 @@ main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     auto accessPointDiscoveryAgentOperationsNetlink{ std::make_unique<AccessPointDiscoveryAgentOperationsNetlink>(accessPointFactory) };
     auto accessPointDiscoveryAgent{ AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperationsNetlink)) };
     accessPointDiscoveryAgent->RegisterDiscoveryEventCallback([](auto&& presence, auto&& accessPointChanged) {
-        LOGI <<  std::format("{} -> {}", accessPointChanged->GetInterfaceName(), magic_enum::enum_name(presence));
+        LOGI << std::format("{} -> {}", accessPointChanged->GetInterfaceName(), magic_enum::enum_name(presence));
     });
 
     LOG_INFO << "starting access point discovery agent";

--- a/src/linux/tools/apmonitor/Main.cxx
+++ b/src/linux/tools/apmonitor/Main.cxx
@@ -27,11 +27,8 @@ main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     auto accessPointFactory = std::make_shared<AccessPointFactoryLinux>(std::move(accessPointControllerFactory));
     auto accessPointDiscoveryAgentOperationsNetlink{ std::make_unique<AccessPointDiscoveryAgentOperationsNetlink>(accessPointFactory) };
     auto accessPointDiscoveryAgent{ AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperationsNetlink)) };
-    accessPointDiscoveryAgent->RegisterDiscoveryEventCallback([](auto&& presence, auto&& interfaceName) {
-        PLOG_INFO << std::format("{} -> {}", interfaceName, magic_enum::enum_name(presence));
-    });
-    accessPointDiscoveryAgent->RegisterDiscoveryEventCallback2([](auto&& presence, auto&& accessPoint) {
-        LOGI <<  std::format("{} -> {}", accessPoint->GetInterfaceName(), magic_enum::enum_name(presence));
+    accessPointDiscoveryAgent->RegisterDiscoveryEventCallback([](auto&& presence, auto&& accessPointChanged) {
+        LOGI <<  std::format("{} -> {}", accessPointChanged->GetInterfaceName(), magic_enum::enum_name(presence));
     });
 
     LOG_INFO << "starting access point discovery agent";

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -30,10 +30,6 @@ using Microsoft::Net::Netlink::NetlinkMessage;
 using Microsoft::Net::Netlink::NetlinkSocket;
 using Microsoft::Net::Netlink::Nl80211::Nl80211ProtocolState;
 
-AccessPointDiscoveryAgentOperationsNetlink::AccessPointDiscoveryAgentOperationsNetlink() :
-    AccessPointDiscoveryAgentOperationsNetlink(nullptr) // FIXME: this c'tor should probably be removed
-{}
-
 AccessPointDiscoveryAgentOperationsNetlink::AccessPointDiscoveryAgentOperationsNetlink(std::shared_ptr<IAccessPointFactory> accessPointFactory) :
     m_accessPointFactory(std::move(accessPointFactory)),
     m_cookie(CookieValid),

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -165,6 +165,15 @@ AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync()
     return probeFuture;
 }
 
+std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync2()
+{
+    std::promise<std::vector<std::shared_ptr<IAccessPoint>>> probePromise{};
+    auto probeFuture = probePromise.get_future();
+
+    return probeFuture;
+}
+
 int
 AccessPointDiscoveryAgentOperationsNetlink::ProcessNetlinkMessage(struct nl_msg *netlinkMessage, AccessPointPresenceEventCallback &accessPointPresenceEventCallback)
 {

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -32,6 +32,11 @@ using Microsoft::Net::Netlink::NetlinkSocket;
 using Microsoft::Net::Netlink::Nl80211::Nl80211ProtocolState;
 
 AccessPointDiscoveryAgentOperationsNetlink::AccessPointDiscoveryAgentOperationsNetlink() :
+    AccessPointDiscoveryAgentOperationsNetlink(nullptr) // FIXME: this c'tor should probably be removed
+{}
+
+AccessPointDiscoveryAgentOperationsNetlink::AccessPointDiscoveryAgentOperationsNetlink(std::shared_ptr<IAccessPointFactory> accessPointFactory) :
+    m_accessPointFactory(std::move(accessPointFactory)),
     m_cookie(CookieValid),
     m_netlink80211ProtocolState(Nl80211ProtocolState::Instance())
 {}
@@ -102,6 +107,42 @@ AccessPointDiscoveryAgentOperationsNetlink::Start(AccessPointPresenceEventCallba
     // Update the access point presence callback for the netlink message handler to use.
     // Note: This is not thread-safe.
     m_accessPointPresenceCallback = std::move(accessPointPresenceEventCallback);
+    m_netlinkMessageProcessingThread = std::jthread([this, netlinkSocket = std::move(nl80211Socket)](std::stop_token stopToken) mutable {
+        ProcessNetlinkMessagesThread(std::move(netlinkSocket), std::move(stopToken));
+    });
+}
+
+void
+AccessPointDiscoveryAgentOperationsNetlink::Start2(AccessPointPresenceEventCallback2 accessPointPresenceEventCallback)
+{
+    if (m_netlinkMessageProcessingThread.joinable()) {
+        LOG_WARNING << "Netlink message processing thread is already running";
+        Stop();
+    }
+
+    // TODO: This function needs to signal errors either through its return type, or an exception.
+
+    // Allocate a new netlink socket for use with nl80211.
+    auto nl80211SocketOpt{ CreateNl80211Socket() };
+    if (nl80211SocketOpt == nullptr) {
+        LOG_ERROR << "Failed to allocate new netlink socket for nl control";
+        return;
+    }
+
+    auto nl80211Socket{ std::move(nl80211SocketOpt.value()) };
+
+    // Subscribe to configuration messages.
+    int nl80211MulticastGroupIdConfig = m_netlink80211ProtocolState.MulticastGroupId[Nl80211MulticastGroup::Configuration];
+    int ret = nl_socket_add_membership(nl80211Socket, nl80211MulticastGroupIdConfig);
+    if (ret < 0) {
+        const auto err = errno;
+        LOG_ERROR << std::format("Failed to add netlink socket membership for '" NL80211_MULTICAST_GROUP_CONFIG "' group with error {} ({})", err, strerror(err));
+        return;
+    }
+
+    // Update the access point presence callback for the netlink message handler to use.
+    // Note: This is not thread-safe.
+    m_accessPointPresenceCallback2 = std::move(accessPointPresenceEventCallback);
     m_netlinkMessageProcessingThread = std::jthread([this, netlinkSocket = std::move(nl80211Socket)](std::stop_token stopToken) mutable {
         ProcessNetlinkMessagesThread(std::move(netlinkSocket), std::move(stopToken));
     });
@@ -252,6 +293,85 @@ AccessPointDiscoveryAgentOperationsNetlink::ProcessNetlinkMessage(struct nl_msg 
     return NL_OK;
 }
 
+int
+AccessPointDiscoveryAgentOperationsNetlink::ProcessNetlinkMessage2(struct nl_msg *netlinkMessage, AccessPointPresenceEventCallback2 &accessPointPresenceEventCallback)
+{
+    // Ensure the message has a genl header.
+    auto *netlinkMessageHeader{ static_cast<struct nlmsghdr *>(nlmsg_hdr(netlinkMessage)) };
+    if (genlmsg_valid_hdr(netlinkMessageHeader, 1) == 0) {
+        LOG_ERROR << "Netlink genl message header is invalid, ignoring message";
+        return NL_SKIP;
+    }
+
+    // Extract the nl80211 (genl) message header.
+    const auto *genlMessageHeader{ static_cast<struct genlmsghdr *>(nlmsg_data(netlinkMessageHeader)) };
+    const auto nl80211CommandName{ Nl80211CommandToString(static_cast<nl80211_commands>(genlMessageHeader->cmd)) };
+
+    // Parse the message attributes.
+    std::array<struct nlattr *, NL80211_ATTR_MAX + 1> netlinkMessageAttributes{};
+    int ret = nla_parse(std::data(netlinkMessageAttributes), std::size(netlinkMessageAttributes), genlmsg_attrdata(genlMessageHeader, 0), genlmsg_attrlen(genlMessageHeader, 0), nullptr);
+    if (ret < 0) {
+        LOG_ERROR << std::format("Failed to parse netlink message attributes with error {} ({})", ret, strerror(-ret));
+        return NL_SKIP;
+    }
+
+    int interfaceIndex{ -1 };
+    const char *interfaceName{ nullptr };
+    nl80211_iftype interfaceType{ NL80211_IFTYPE_UNSPECIFIED };
+    AccessPointPresenceEvent accessPointPresenceEvent;
+
+    LOG_VERBOSE << std::format("Received {} nl80211 command message", nl80211CommandName);
+
+    switch (genlMessageHeader->cmd) {
+    case NL80211_CMD_NEW_INTERFACE:
+    case NL80211_CMD_DEL_INTERFACE: {
+        interfaceIndex = static_cast<int32_t>(nla_get_u32(netlinkMessageAttributes[NL80211_ATTR_IFINDEX]));
+        interfaceName = static_cast<const char *>(nla_data(netlinkMessageAttributes[NL80211_ATTR_IFNAME]));
+        interfaceType = static_cast<nl80211_iftype>(nla_get_u32(netlinkMessageAttributes[NL80211_ATTR_IFTYPE]));
+        if (interfaceType != NL80211_IFTYPE_AP) {
+            LOG_VERBOSE << std::format("Ignoring interface presence change nl80211 message for non-ap wi-fi interface (type={})", Nl80211InterfaceTypeToString(interfaceType));
+            return NL_SKIP;
+        }
+        accessPointPresenceEvent = (genlMessageHeader->cmd == NL80211_CMD_NEW_INTERFACE) ? AccessPointPresenceEvent::Arrived : AccessPointPresenceEvent::Departed;
+        break;
+    }
+    case NL80211_CMD_SET_INTERFACE: {
+        interfaceIndex = static_cast<int32_t>(nla_get_u32(netlinkMessageAttributes[NL80211_ATTR_IFINDEX]));
+        interfaceName = static_cast<const char *>(nla_data(netlinkMessageAttributes[NL80211_ATTR_IFNAME]));
+        interfaceType = static_cast<nl80211_iftype>(nla_get_u32(netlinkMessageAttributes[NL80211_ATTR_IFTYPE]));
+        accessPointPresenceEvent = (interfaceType == NL80211_IFTYPE_AP) ? AccessPointPresenceEvent::Arrived : AccessPointPresenceEvent::Departed;
+        break;
+    }
+    default: {
+        PLOG_VERBOSE << std::format("Ignoring {} nl80211 command message", nl80211CommandName);
+        return NL_SKIP;
+    }
+    }
+
+    // Update map tracking interface information. Handle the case where the
+    // interface is already present. This happens for NL80211_CMD_SET_INTERFACE
+    // when the interface type did not change.
+    auto interfaceInfo = m_interfaceInfo.find(interfaceIndex);
+    if (interfaceInfo == std::cend(m_interfaceInfo)) {
+        if (accessPointPresenceEvent == AccessPointPresenceEvent::Arrived) {
+            m_interfaceInfo[interfaceIndex] = { interfaceName, interfaceType };
+        }
+    } else {
+        if (accessPointPresenceEvent == AccessPointPresenceEvent::Departed) {
+            m_interfaceInfo.erase(interfaceInfo);
+        }
+    }
+
+    // Invoke presence event callback if present.
+    if (accessPointPresenceEventCallback != nullptr) {
+        LOGV << std::format("Invoking access point presence event callback with event args 'interface={}, presence={}'", interfaceName, magic_enum::enum_name(accessPointPresenceEvent));
+        auto accessPoint = m_accessPointFactory->Create(interfaceName);
+        accessPointPresenceEventCallback(accessPointPresenceEvent, accessPoint);
+    }
+
+    return NL_OK;
+}
+
 /* static */
 int
 AccessPointDiscoveryAgentOperationsNetlink::ProcessNetlinkMessagesCallback(struct nl_msg *netlinkMessage, void *contextArgument)
@@ -270,6 +390,7 @@ AccessPointDiscoveryAgentOperationsNetlink::ProcessNetlinkMessagesCallback(struc
     }
 
     auto ret = instance->ProcessNetlinkMessage(netlinkMessage, instance->m_accessPointPresenceCallback);
+    ret = instance->ProcessNetlinkMessage2(netlinkMessage, instance->m_accessPointPresenceCallback2);
     LOG_VERBOSE << std::format("Processed netlink message with result {}", ret);
 
     return ret;

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -29,18 +29,29 @@ namespace Microsoft::Net::Wifi
 struct AccessPointDiscoveryAgentOperationsNetlink :
     public IAccessPointDiscoveryAgentOperations
 {
-
-    AccessPointDiscoveryAgentOperationsNetlink();
     AccessPointDiscoveryAgentOperationsNetlink(std::shared_ptr<IAccessPointFactory> accessPointFactory);
 
     virtual ~AccessPointDiscoveryAgentOperationsNetlink();
 
+    /**
+     * @brief Start the discovery process.
+     *
+     * @param callback The callback to invoke when an access point is discovered or removed.
+     */
     void
     Start(AccessPointPresenceEventCallback accessPointPresenceEventCallback) override;
 
+    /**
+     * @brief Stop the discovery process.
+     */
     void
     Stop() override;
 
+    /**
+     * @brief Perform an asynchronous discovery probe.
+     *
+     * @return std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+     */
     std::future<std::vector<std::shared_ptr<IAccessPoint>>>
     ProbeAsync() override;
 
@@ -88,8 +99,6 @@ private:
      */
     int
     ProcessNetlinkMessage(struct nl_msg *netlinkMessage, AccessPointPresenceEventCallback &accessPointPresenceEventCallback);
-
-
 
 private:
     std::shared_ptr<IAccessPointFactory> m_accessPointFactory;

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -38,9 +38,6 @@ struct AccessPointDiscoveryAgentOperationsNetlink :
     Start(AccessPointPresenceEventCallback accessPointPresenceEventCallback) override;
 
     void
-    Start2(AccessPointPresenceEventCallback2 accessPointPresenceEventCallback) override;
-
-    void
     Stop() override;
 
     std::future<std::vector<std::string>>
@@ -94,15 +91,6 @@ private:
     int
     ProcessNetlinkMessage(struct nl_msg *netlinkMessage, AccessPointPresenceEventCallback &accessPointPresenceEventCallback);
 
-    /**
-     * @brief Process a single netlink message.
-     *
-     * @param netlinkMessage The netlink message to process.
-     * @param accessPointPresenceEventCallback The callback to invoke when an access point presence event occurs.
-     */
-    int
-    ProcessNetlinkMessage2(struct nl_msg *netlinkMessage, AccessPointPresenceEventCallback2 &accessPointPresenceEventCallback);
-
 private:
     std::shared_ptr<IAccessPointFactory> m_accessPointFactory;
 
@@ -113,7 +101,6 @@ private:
 
     uint32_t m_cookie{ CookieInvalid };
     AccessPointPresenceEventCallback m_accessPointPresenceCallback{ nullptr };
-    AccessPointPresenceEventCallback2 m_accessPointPresenceCallback2{ nullptr };
 
     int m_eventLoopStopFd{ -1 };
     std::jthread m_netlinkMessageProcessingThread;

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -12,6 +12,7 @@
 #include <linux/nl80211.h>
 #include <microsoft/net/netlink/NetlinkMessage.hxx>
 #include <microsoft/net/netlink/NetlinkSocket.hxx>
+#include <microsoft/net/netlink/nl80211/Netlink80211Interface.hxx>
 #include <microsoft/net/netlink/nl80211/Netlink80211ProtocolState.hxx>
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx>
@@ -40,11 +41,8 @@ struct AccessPointDiscoveryAgentOperationsNetlink :
     void
     Stop() override;
 
-    std::future<std::vector<std::string>>
-    ProbeAsync() override;
-
     std::future<std::vector<std::shared_ptr<IAccessPoint>>>
-    ProbeAsync2() override;
+    ProbeAsync() override;
 
 private:
     /**
@@ -90,6 +88,8 @@ private:
      */
     int
     ProcessNetlinkMessage(struct nl_msg *netlinkMessage, AccessPointPresenceEventCallback &accessPointPresenceEventCallback);
+
+
 
 private:
     std::shared_ptr<IAccessPointFactory> m_accessPointFactory;

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -3,6 +3,7 @@
 #define ACCESS_POINT_DISCOVERY_AGENT_OPERATIONS_NETLINK_HXX
 
 #include <cstdint>
+#include <memory>
 #include <stop_token>
 #include <string>
 #include <thread>
@@ -12,6 +13,7 @@
 #include <microsoft/net/netlink/NetlinkMessage.hxx>
 #include <microsoft/net/netlink/NetlinkSocket.hxx>
 #include <microsoft/net/netlink/nl80211/Netlink80211ProtocolState.hxx>
+#include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx>
 #include <netlink/netlink.h>
 
@@ -26,12 +28,17 @@ namespace Microsoft::Net::Wifi
 struct AccessPointDiscoveryAgentOperationsNetlink :
     public IAccessPointDiscoveryAgentOperations
 {
+
     AccessPointDiscoveryAgentOperationsNetlink();
+    AccessPointDiscoveryAgentOperationsNetlink(std::shared_ptr<IAccessPointFactory> accessPointFactory);
 
     virtual ~AccessPointDiscoveryAgentOperationsNetlink();
 
     void
     Start(AccessPointPresenceEventCallback accessPointPresenceEventCallback) override;
+
+    void
+    Start2(AccessPointPresenceEventCallback2 accessPointPresenceEventCallback) override;
 
     void
     Stop() override;
@@ -87,7 +94,18 @@ private:
     int
     ProcessNetlinkMessage(struct nl_msg *netlinkMessage, AccessPointPresenceEventCallback &accessPointPresenceEventCallback);
 
+    /**
+     * @brief Process a single netlink message.
+     *
+     * @param netlinkMessage The netlink message to process.
+     * @param accessPointPresenceEventCallback The callback to invoke when an access point presence event occurs.
+     */
+    int
+    ProcessNetlinkMessage2(struct nl_msg *netlinkMessage, AccessPointPresenceEventCallback2 &accessPointPresenceEventCallback);
+
 private:
+    std::shared_ptr<IAccessPointFactory> m_accessPointFactory;
+
     // Cookie used to validate that the callback context is valid.
     static constexpr uint32_t CookieValid{ 0x8BADF00Du };
     // Cookie used to invalidate the callback context.
@@ -95,6 +113,7 @@ private:
 
     uint32_t m_cookie{ CookieInvalid };
     AccessPointPresenceEventCallback m_accessPointPresenceCallback{ nullptr };
+    AccessPointPresenceEventCallback2 m_accessPointPresenceCallback2{ nullptr };
 
     int m_eventLoopStopFd{ -1 };
     std::jthread m_netlinkMessageProcessingThread;

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -39,6 +39,9 @@ struct AccessPointDiscoveryAgentOperationsNetlink :
     std::future<std::vector<std::string>>
     ProbeAsync() override;
 
+    std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+    ProbeAsync2() override;
+
 private:
     /**
      * @brief Request that the netlink processing loop stop.

--- a/src/windows/server/Main.cxx
+++ b/src/windows/server/Main.cxx
@@ -16,8 +16,7 @@ main(int argc, char* argv[])
 {
     auto configuration = NetRemoteServerConfiguration::FromCommandLineArguments(argc, argv);
     {
-        auto accessPointFactory = std::make_unique<AccessPointFactory>(nullptr);
-        auto accessPointManager = AccessPointManager::Create(std::move(accessPointFactory));
+        auto accessPointManager = AccessPointManager::Create();
         configuration.AccessPointManager = accessPointManager;
     }
 

--- a/tests/unit/TestNetRemoteServer.cxx
+++ b/tests/unit/TestNetRemoteServer.cxx
@@ -23,7 +23,7 @@ TEST_CASE("Create a NetRemoteServer instance", "[basic][rpc][remote]")
 
     NetRemoteServerConfiguration Configuration{
         .ServerAddress = RemoteServiceAddressHttp,
-        .AccessPointManager = AccessPointManager::Create(std::make_unique<AccessPointFactoryTest>()),
+        .AccessPointManager = AccessPointManager::Create(),
     };
 
     SECTION("Create doesn't cause a crash")
@@ -40,7 +40,7 @@ TEST_CASE("Destroy a NetRemoteServer instance", "[basic][rpc][remote]")
 
     NetRemoteServerConfiguration Configuration{
         .ServerAddress = RemoteServiceAddressHttp,
-        .AccessPointManager = AccessPointManager::Create(std::make_unique<AccessPointFactoryTest>()),
+        .AccessPointManager = AccessPointManager::Create(),
     };
 
     std::optional<NetRemoteServer> server{ Configuration };
@@ -71,7 +71,7 @@ TEST_CASE("NetRemoteServer can be reached", "[basic][rpc][remote]")
 
     NetRemoteServerConfiguration Configuration{
         .ServerAddress = RemoteServiceAddressHttp,
-        .AccessPointManager = AccessPointManager::Create(std::make_unique<AccessPointFactoryTest>()),
+        .AccessPointManager = AccessPointManager::Create(),
     };
 
     NetRemoteServer server{ Configuration };
@@ -94,7 +94,7 @@ TEST_CASE("NetRemoteServer shuts down correctly", "[basic][rpc][remote]")
 
     NetRemoteServerConfiguration Configuration{
         .ServerAddress = RemoteServiceAddressHttp,
-        .AccessPointManager = AccessPointManager::Create(std::make_unique<AccessPointFactoryTest>()),
+        .AccessPointManager = AccessPointManager::Create(),
     };
 
     NetRemoteServer server{ Configuration };
@@ -149,7 +149,7 @@ TEST_CASE("NetRemoteServer can be cycled through run/stop states", "[basic][rpc]
 
     NetRemoteServerConfiguration Configuration{
         .ServerAddress = RemoteServiceAddressHttp,
-        .AccessPointManager = AccessPointManager::Create(std::make_unique<AccessPointFactoryTest>()),
+        .AccessPointManager = AccessPointManager::Create(),
     };
 
     NetRemoteServer server{ Configuration };

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -29,7 +29,7 @@ TEST_CASE("WifiEnumerateAccessPoints API", "[basic][rpc][client][remote]")
 
     NetRemoteServerConfiguration Configuration{
         .ServerAddress = RemoteServiceAddressHttp,
-        .AccessPointManager = AccessPointManager::Create(std::make_unique<AccessPointFactoryTest>()),
+        .AccessPointManager = AccessPointManager::Create(),
     };
 
     NetRemoteServer server{ Configuration };
@@ -79,7 +79,7 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
 
     NetRemoteServerConfiguration Configuration{
         .ServerAddress = RemoteServiceAddressHttp,
-        .AccessPointManager = AccessPointManager::Create(std::make_unique<AccessPointFactoryTest>()),
+        .AccessPointManager = AccessPointManager::Create(),
     };
 
     NetRemoteServer server{ Configuration };

--- a/tests/unit/linux/wifi/apmanager/CMakeLists.txt
+++ b/tests/unit/linux/wifi/apmanager/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(wifi-apmanager-linux-test-unit
         plog::plog
         strings
         wifi-apmanager-linux
+        wifi-test-helpers
 )
 
 catch_discover_tests(wifi-apmanager-linux-test-unit)

--- a/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -5,24 +5,27 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
+#include <microsoft/net/wifi/test/AccessPointTest.hxx>
 
 TEST_CASE("Create AccessPointDiscoveryAgentOperationsNetlink", "[wifi][core][apmanager]")
 {
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
     SECTION("Create doesn't cause a crash")
     {
-        using namespace Microsoft::Net::Wifi;
-
-        REQUIRE_NOTHROW(AccessPointDiscoveryAgentOperationsNetlink{});
+        REQUIRE_NOTHROW(AccessPointDiscoveryAgentOperationsNetlink{ std::make_shared<AccessPointFactoryTest>() });
     }
 }
 
 TEST_CASE("Destroy AccessPointDiscoveryAgentOperationsNetlink", "[wifi][core][apmanager]")
 {
     using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
 
     SECTION("Destroy doesn't cause a crash")
     {
-        std::optional<AccessPointDiscoveryAgentOperationsNetlink> accessPointDiscoveryAgent(std::in_place);
+        std::optional<AccessPointDiscoveryAgentOperationsNetlink> accessPointDiscoveryAgent(std::make_shared<AccessPointFactoryTest>());
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.reset());
     }
 }
@@ -30,23 +33,24 @@ TEST_CASE("Destroy AccessPointDiscoveryAgentOperationsNetlink", "[wifi][core][ap
 TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::Start", "[wifi][core][apmanager]")
 {
     using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
 
     SECTION("Start doesn't cause a crash")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent;
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Start([](auto &&, auto &&) {}));
     }
 
     SECTION("Start doesn't cause a crash when called twice")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent;
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Start([](auto &&, auto &&) {}));
     }
 
     SECTION("Start doesn't cause a crash when called with a null callback")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent;
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Start(nullptr));
     }
 }
@@ -54,23 +58,24 @@ TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::Start", "[wifi][core][apm
 TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::Stop", "[wifi][core][apmanager]")
 {
     using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
 
     SECTION("Stop doesn't cause a crash when Start hasn't been called")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Stop());
     }
 
     SECTION("Stop doesn't cause a crash when Start has been called")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Stop());
     }
 
     SECTION("Stop doesn't cause a crash when called twice")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
         accessPointDiscoveryAgent.Stop();
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Stop());
@@ -78,7 +83,7 @@ TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::Stop", "[wifi][core][apma
 
     SECTION("Stop doesn't cause a crash when called with a null callback")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         accessPointDiscoveryAgent.Start(nullptr);
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Stop());
     }
@@ -87,30 +92,31 @@ TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::Stop", "[wifi][core][apma
 TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync", "[wifi][core][apmanager]")
 {
     using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
 
     SECTION("ProbeAsync doesn't cause a crash when Start hasn't been called")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
     }
 
     SECTION("ProbeAsync doesn't cause a crash when Start has been called")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
     }
 
     SECTION("ProbeAsync doesn't cause a crash when Stop has been called")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         accessPointDiscoveryAgent.Stop();
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
     }
 
     SECTION("ProbeAsync doesn't cause a crash when called twice")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
         accessPointDiscoveryAgent.ProbeAsync();
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
@@ -118,7 +124,7 @@ TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync", "[wifi][core
 
     SECTION("ProbeAsync doesn't cause a crash when called after a Start/Stop sequence")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         accessPointDiscoveryAgent.Start(nullptr);
         accessPointDiscoveryAgent.Stop();
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
@@ -126,20 +132,20 @@ TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync", "[wifi][core
 
     SECTION("ProbeAsync returns a valid future")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         accessPointDiscoveryAgent.Start(nullptr);
         REQUIRE(accessPointDiscoveryAgent.ProbeAsync().valid());
     }
 
     SECTION("ProbeAsync result can be obtained without causing a crash")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync().get());
     }
 
     SECTION("ProbeAsync result is valid")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{};
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync().get().clear());
     }
 }

--- a/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.cxx
+++ b/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.cxx
@@ -14,6 +14,12 @@ AccessPointDiscoveryAgentOperationsTest::Start(AccessPointPresenceEventCallback 
 }
 
 void
+AccessPointDiscoveryAgentOperationsTest::Start2(AccessPointPresenceEventCallback2 callback2)
+{
+    m_callback2 = callback2;
+}
+
+void
 AccessPointDiscoveryAgentOperationsTest::Stop()
 {
     m_callback = nullptr;

--- a/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.cxx
+++ b/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.cxx
@@ -23,17 +23,8 @@ AccessPointDiscoveryAgentOperationsTest::Stop()
     m_callback = nullptr;
 }
 
-std::future<std::vector<std::string>>
-AccessPointDiscoveryAgentOperationsTest::ProbeAsync()
-{
-    return std::async(std::launch::async, [&]() {
-        // return m_accessPointInterfaceNames;
-        return std::vector<std::string>();
-    });
-}
-
 std::future<std::vector<std::shared_ptr<IAccessPoint>>>
-AccessPointDiscoveryAgentOperationsTest::ProbeAsync2()
+AccessPointDiscoveryAgentOperationsTest::ProbeAsync()
 {
     return std::async(std::launch::async, [&]() {
         return m_accessPoints;

--- a/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.cxx
+++ b/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.cxx
@@ -27,6 +27,14 @@ AccessPointDiscoveryAgentOperationsTest::ProbeAsync()
     });
 }
 
+std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+AccessPointDiscoveryAgentOperationsTest::ProbeAsync2()
+{
+    return std::async(std::launch::async, [&]() {
+        return m_accessPoints;
+    });
+}
+
 void
 AccessPointDiscoveryAgentOperationsTest::AddAccessPoint(std::string_view interfaceNameToAdd)
 {

--- a/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.hxx
+++ b/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.hxx
@@ -23,6 +23,9 @@ struct AccessPointDiscoveryAgentOperationsTest :
     Start(AccessPointPresenceEventCallback callback) override;
 
     void
+    Start2(AccessPointPresenceEventCallback2 callback) override;
+
+    void
     Stop() override;
 
     std::future<std::vector<std::string>>
@@ -39,6 +42,7 @@ struct AccessPointDiscoveryAgentOperationsTest :
 
 private:
     AccessPointPresenceEventCallback m_callback;
+    AccessPointPresenceEventCallback2 m_callback2;
     std::vector<std::string> m_accessPointInterfaceNames;
     std::vector<std::shared_ptr<IAccessPoint>> m_accessPoints;
 };

--- a/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.hxx
+++ b/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.hxx
@@ -10,6 +10,7 @@
 
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx>
+#include <microsoft/net/wifi/test/AccessPointTest.hxx>
 
 namespace Microsoft::Net::Wifi::Test
 {
@@ -19,11 +20,10 @@ namespace Microsoft::Net::Wifi::Test
 struct AccessPointDiscoveryAgentOperationsTest :
     public Microsoft::Net::Wifi::IAccessPointDiscoveryAgentOperations
 {
-    void
-    Start(AccessPointPresenceEventCallback callback) override;
+    AccessPointDiscoveryAgentOperationsTest();
 
     void
-    Start2(AccessPointPresenceEventCallback2 callback) override;
+    Start(AccessPointPresenceEventCallback callback) override;
 
     void
     Stop() override;
@@ -42,9 +42,8 @@ struct AccessPointDiscoveryAgentOperationsTest :
 
 private:
     AccessPointPresenceEventCallback m_callback;
-    AccessPointPresenceEventCallback2 m_callback2;
-    std::vector<std::string> m_accessPointInterfaceNames;
     std::vector<std::shared_ptr<IAccessPoint>> m_accessPoints;
+    std::unique_ptr<IAccessPointFactory> m_accessPointFactory;
 };
 
 } // namespace Microsoft::Net::Wifi::Test

--- a/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.hxx
+++ b/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.hxx
@@ -28,11 +28,8 @@ struct AccessPointDiscoveryAgentOperationsTest :
     void
     Stop() override;
 
-    std::future<std::vector<std::string>>
-    ProbeAsync() override;
-
     std::future<std::vector<std::shared_ptr<IAccessPoint>>>
-    ProbeAsync2() override;
+    ProbeAsync() override;
 
     void
     AddAccessPoint(std::string_view accessPointInterfaceNameToAdd);

--- a/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.hxx
+++ b/tests/unit/wifi/apmanager/AccessPointDiscoveryAgentOperationsTest.hxx
@@ -28,6 +28,9 @@ struct AccessPointDiscoveryAgentOperationsTest :
     std::future<std::vector<std::string>>
     ProbeAsync() override;
 
+    std::future<std::vector<std::shared_ptr<IAccessPoint>>>
+    ProbeAsync2() override;
+
     void
     AddAccessPoint(std::string_view accessPointInterfaceNameToAdd);
 
@@ -37,6 +40,7 @@ struct AccessPointDiscoveryAgentOperationsTest :
 private:
     AccessPointPresenceEventCallback m_callback;
     std::vector<std::string> m_accessPointInterfaceNames;
+    std::vector<std::shared_ptr<IAccessPoint>> m_accessPoints;
 };
 
 } // namespace Microsoft::Net::Wifi::Test

--- a/tests/unit/wifi/apmanager/TestAccessPointDiscoveryAgent.cxx
+++ b/tests/unit/wifi/apmanager/TestAccessPointDiscoveryAgent.cxx
@@ -131,7 +131,7 @@ TEST_CASE("Presence events are raised", "[wifi][core][apdiscoveryagent]")
     auto accessPointDiscoveryAgent{ AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperations)) };
 
     // Create a promise to capture the presence event callback invocation data.
-    std::promise<std::pair<AccessPointPresenceEvent, std::string>> presenceEventRaised;
+    std::promise<std::pair<AccessPointPresenceEvent, std::shared_ptr<IAccessPoint>>> presenceEventRaised;
     auto presenceEventRaisedFuture{ presenceEventRaised.get_future() };
 
     SECTION("Arrival event is raised")
@@ -148,9 +148,9 @@ TEST_CASE("Presence events are raised", "[wifi][core][apdiscoveryagent]")
         REQUIRE(presenceEventRaisedFuture.wait_for(PresenceEventCallbackWaitTime) == std::future_status::ready);
 
         // Verify the callback fired with the expected event and access point.
-        const auto [presenceEvent, accessPointInterfaceNameChanged]{ presenceEventRaisedFuture.get() };
+        const auto [presenceEvent, accessPointChanged]{ presenceEventRaisedFuture.get() };
         REQUIRE(presenceEvent == AccessPointPresenceEvent::Arrived);
-        REQUIRE(accessPointInterfaceNameChanged == accessPointInterfaceName);
+        REQUIRE(accessPointChanged->GetInterfaceName() == accessPointInterfaceName);
     }
 
     SECTION("Arrival event is raised after toggling start/stop")
@@ -170,9 +170,9 @@ TEST_CASE("Presence events are raised", "[wifi][core][apdiscoveryagent]")
         REQUIRE(presenceEventRaisedFuture.wait_for(PresenceEventCallbackWaitTime) == std::future_status::ready);
 
         // Verify the callback fired with the expected event and access point.
-        const auto [presenceEvent, accessPointInterfaceNameChanged]{ presenceEventRaisedFuture.get() };
+        const auto [presenceEvent, accessPointChanged]{ presenceEventRaisedFuture.get() };
         REQUIRE(presenceEvent == AccessPointPresenceEvent::Arrived);
-        REQUIRE(accessPointInterfaceNameChanged == accessPointInterfaceName);
+        REQUIRE(accessPointChanged->GetInterfaceName() == accessPointInterfaceName);
     }
 
     SECTION("Departed event is raised")
@@ -191,9 +191,9 @@ TEST_CASE("Presence events are raised", "[wifi][core][apdiscoveryagent]")
         REQUIRE(presenceEventRaisedFuture.wait_for(PresenceEventCallbackWaitTime) == std::future_status::ready);
 
         // Verify the callback fired with the expected event and access point.
-        const auto [presenceEvent, accessPointInterfaceNameChanged]{ presenceEventRaisedFuture.get() };
+        const auto [presenceEvent, accessPointChanged]{ presenceEventRaisedFuture.get() };
         REQUIRE(presenceEvent == AccessPointPresenceEvent::Departed);
-        REQUIRE(accessPointInterfaceNameChanged == accessPointInterfaceName);
+        REQUIRE(accessPointChanged->GetInterfaceName() == accessPointInterfaceName);
     }
 
     SECTION("Departed event is raised after start/stop")
@@ -216,9 +216,9 @@ TEST_CASE("Presence events are raised", "[wifi][core][apdiscoveryagent]")
         REQUIRE(presenceEventRaisedFuture.wait_for(PresenceEventCallbackWaitTime) == std::future_status::ready);
 
         // Verify the callback fired with the expected event and access point.
-        const auto [presenceEvent, accessPointInterfaceNameChanged]{ presenceEventRaisedFuture.get() };
+        const auto [presenceEvent, accessPointChanged]{ presenceEventRaisedFuture.get() };
         REQUIRE(presenceEvent == AccessPointPresenceEvent::Departed);
-        REQUIRE(accessPointInterfaceNameChanged == accessPointInterfaceName);
+        REQUIRE(accessPointChanged->GetInterfaceName() == accessPointInterfaceName);
     }
 
     SECTION("Arrival event is not raised when stoppped")

--- a/tests/unit/wifi/apmanager/TestAccessPointManager.cxx
+++ b/tests/unit/wifi/apmanager/TestAccessPointManager.cxx
@@ -15,7 +15,7 @@ TEST_CASE("Create an AccessPointManager instance", "[wifi][core][apmanager]")
 
     SECTION("Create doesn't cause a crash")
     {
-        REQUIRE_NOTHROW(AccessPointManager::Create(std::make_unique<Test::AccessPointFactoryTest>()));
+        REQUIRE_NOTHROW(AccessPointManager::Create());
     }
 }
 
@@ -27,7 +27,7 @@ TEST_CASE("Destroy an AccessPointManager instance", "[wifi][core][apmanager]")
 
     SECTION("Destroy doesn't cause a crash")
     {
-        auto accessPointManager{ AccessPointManager::Create(std::make_unique<Test::AccessPointFactoryTest>()) };
+        auto accessPointManager{ AccessPointManager::Create() };
         REQUIRE_NOTHROW(accessPointManager.reset());
     }
 
@@ -36,7 +36,7 @@ TEST_CASE("Destroy an AccessPointManager instance", "[wifi][core][apmanager]")
         auto accessPointDiscoveryAgent1{ AccessPointDiscoveryAgent::Create(std::make_unique<AccessPointDiscoveryAgentOperationsTest>()) };
         auto accessPointDiscoveryAgent2{ AccessPointDiscoveryAgent::Create(std::make_unique<AccessPointDiscoveryAgentOperationsTest>()) };
 
-        auto accessPointManager{ AccessPointManager::Create(std::make_unique<Test::AccessPointFactoryTest>()) };
+        auto accessPointManager{ AccessPointManager::Create() };
         accessPointManager->AddDiscoveryAgent(std::move(accessPointDiscoveryAgent1));
         accessPointManager->AddDiscoveryAgent(std::move(accessPointDiscoveryAgent2));
         REQUIRE_NOTHROW(accessPointManager.reset());
@@ -49,7 +49,7 @@ TEST_CASE("AccessPointManager instance reflects basic properties", "[wifi][core]
 
     SECTION("GetAllAccessPoints() returns an empty list")
     {
-        auto accessPointManager{ AccessPointManager::Create(std::make_unique<Test::AccessPointFactoryTest>()) };
+        auto accessPointManager{ AccessPointManager::Create() };
         REQUIRE(std::empty(accessPointManager->GetAllAccessPoints()));
     }
 }
@@ -66,7 +66,7 @@ TEST_CASE("AccessPointManager persists access points reported by discovery agent
     auto* accessPointDiscoveryAgentOperationsTestPtr{ accessPointDiscoveryAgentOperationsTest.get() };
     auto accessPointDiscoveryAgentTest{ AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperationsTest)) };
 
-    auto accessPointManager{ AccessPointManager::Create(std::make_unique<Test::AccessPointFactoryTest>()) };
+    auto accessPointManager{ AccessPointManager::Create() };
     accessPointManager->AddDiscoveryAgent(std::move(accessPointDiscoveryAgentTest));
 
     SECTION("Access points from arrival events are persisted via GetAccessPoint()")
@@ -131,7 +131,7 @@ TEST_CASE("AccessPointManager discards access points reported to have departed b
     auto* accessPointDiscoveryAgentOperationsTestPtr{ accessPointDiscoveryAgentOperationsTest.get() };
     auto accessPointDiscoveryAgentTest{ AccessPointDiscoveryAgent::Create(std::move(accessPointDiscoveryAgentOperationsTest)) };
 
-    auto accessPointManager{ AccessPointManager::Create(std::make_unique<Test::AccessPointFactoryTest>()) };
+    auto accessPointManager{ AccessPointManager::Create() };
     accessPointManager->AddDiscoveryAgent(std::move(accessPointDiscoveryAgentTest));
 
     SECTION("Access points reported to have departed are not accessible via GetAccessPoint()")


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Avoid duplication of kernel calls (via nl80211) upon access point creation. 

### Technical Details

The prior design had access point discovery agents raise discovery change events whose payload was the presence change itself (arrived, departed) and the interface name. While this works, nearly every consumer in nearly every scenario would take this and immediately create an `IAccessPoint` instance, which would re-do many of the operations the discovery agent had performed to determine the interface name.

The design is now updated for the access point discovery change event payload to contain a `std::shared_ptr<IAccessPoint>` which is created by the agent itself. The agent is responsible for the creation of the `IAccessPoint`, and at least in the case of the Linux agents, they now take a `IAccessPointFactory` that controls the creation of the `IAccesPoint`. This still allows the creation policy to be controller by the top-level consumer as they orchestrate the creation of the discovery agent and factory.

Now that the discovery agent(s) create the instances, the `AccessPointManager` no longer needs to do this, and so, no longer takes a `std::shared_ptr<IAccessPointFactory>` nor creates any of the instances.

### Test Results

* Ran `netremote-cli wifi enumaps` and ensured the output matches that of the previous design+impl.
* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
