### PR TITLE
Accept linux-specific factory for AccessPointDiscoveryAgentOperationsNetlink

### DIFF
--- a/src/linux/libnl-helpers/Netlink80211Interface.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Interface.cxx
@@ -158,5 +158,5 @@ Nl80211Interface::Enumerate()
 std::optional<Nl80211Wiphy>
 Nl80211Interface::GetWiphy() const
 {
-    return Nl80211Wiphy::FromIndex(WiphyIndex); 
+    return Nl80211Wiphy::FromIndex(WiphyIndex);
 }

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
@@ -26,6 +26,18 @@ struct Nl80211Interface
     uint32_t Index;
     uint32_t WiphyIndex;
 
+    Nl80211Interface() = default;
+
+    /**
+     * @brief Construct a new Nl80211Interface object with the specified attributes.
+     *
+     * @param name The name of the interface.
+     * @param type The nl80211_iftype of the interface.
+     * @param index The interface index in the kernel.
+     * @param wiphyIndex The phy interface index in the kernel.
+     */
+    Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index, uint32_t wiphyIndex) noexcept;
+
     /**
      * @brief Parse a netlink message into an Nl80211Interface. The netlink message must contain a response to the
      * NL80211_CMD_GET_INTERFACE command, which is encoded as a NL80211_CMD_NEW_INTERFACE.
@@ -48,8 +60,8 @@ struct Nl80211Interface
 
     /**
      * @brief Get the Wiphy (PHY) object associated with this interface.
-     * 
-     * @return std::optional<Nl80211Wiphy> 
+     *
+     * @return std::optional<Nl80211Wiphy>
      */
     std::optional<Nl80211Wiphy>
     GetWiphy() const;
@@ -61,17 +73,6 @@ struct Nl80211Interface
      */
     std::string
     ToString() const;
-
-private:
-    /**
-     * @brief Construct a new Nl80211Interface object with the specified attributes.
-     *
-     * @param name The name of the interface.
-     * @param type The nl80211_iftype of the interface.
-     * @param index The interface index in the kernel.
-     * @param wiphyIndex The phy interface index in the kernel.
-     */
-    Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index, uint32_t wiphyIndex) noexcept;
 };
 
 } // namespace Microsoft::Net::Netlink::Nl80211

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -30,7 +30,7 @@ using Microsoft::Net::Netlink::NetlinkMessage;
 using Microsoft::Net::Netlink::NetlinkSocket;
 using Microsoft::Net::Netlink::Nl80211::Nl80211ProtocolState;
 
-AccessPointDiscoveryAgentOperationsNetlink::AccessPointDiscoveryAgentOperationsNetlink(std::shared_ptr<IAccessPointFactory> accessPointFactory) :
+AccessPointDiscoveryAgentOperationsNetlink::AccessPointDiscoveryAgentOperationsNetlink(std::shared_ptr<AccessPointFactoryLinux> accessPointFactory) :
     m_accessPointFactory(std::move(accessPointFactory)),
     m_cookie(CookieValid),
     m_netlink80211ProtocolState(Nl80211ProtocolState::Instance())
@@ -141,9 +141,10 @@ IsNl80211InterfaceTypeAp(const Nl80211Interface &nl80211Interface)
  * @return std::shared_ptr<IAccessPoint>
  */
 std::shared_ptr<IAccessPoint>
-MakeAccessPoint(std::shared_ptr<IAccessPointFactory> accessPointFactory, const Nl80211Interface &nl80211Interface)
+MakeAccessPoint(std::shared_ptr<AccessPointFactoryLinux> accessPointFactory, const Nl80211Interface &nl80211Interface)
 {
-    return accessPointFactory->Create(nl80211Interface.Name);
+    auto createArgs = std::make_unique<AccessPointCreateArgsLinux>(std::move(nl80211Interface));
+    return accessPointFactory->Create(nl80211Interface.Name, std::move(createArgs));
 }
 } // namespace detail
 

--- a/src/linux/wifi/apmanager/CMakeLists.txt
+++ b/src/linux/wifi/apmanager/CMakeLists.txt
@@ -25,11 +25,5 @@ target_link_libraries(wifi-apmanager-linux
         libnl-helpers
         wifi-apmanager
         wifi-core
-)
-
-install(
-    TARGETS wifi-apmanager-linux
-    EXPORT ${PROJECT_NAME}
-    FILE_SET HEADERS
-    PUBLIC_HEADER DESTINATION "${NETREMOTE_DIR_INSTALL_PUBLIC_HEADER_BASE}/${WIFI_APMANAGER_LINUX_PUBLIC_INCLUDE_SUFFIX}"
+        wifi-core-linux
 )

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -14,6 +14,7 @@
 #include <microsoft/net/netlink/NetlinkSocket.hxx>
 #include <microsoft/net/netlink/nl80211/Netlink80211Interface.hxx>
 #include <microsoft/net/netlink/nl80211/Netlink80211ProtocolState.hxx>
+#include <microsoft/net/wifi/AccessPointLinux.hxx>
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <microsoft/net/wifi/IAccessPointDiscoveryAgentOperations.hxx>
 #include <netlink/netlink.h>
@@ -29,7 +30,12 @@ namespace Microsoft::Net::Wifi
 struct AccessPointDiscoveryAgentOperationsNetlink :
     public IAccessPointDiscoveryAgentOperations
 {
-    AccessPointDiscoveryAgentOperationsNetlink(std::shared_ptr<IAccessPointFactory> accessPointFactory);
+    /**
+     * @brief Construct a new AccessPointDiscoveryAgentOperationsNetlink object with the specified access point factory.
+     *
+     * @param accessPointFactory The access point factory to use for creating access points.
+     */
+    AccessPointDiscoveryAgentOperationsNetlink(std::shared_ptr<AccessPointFactoryLinux> accessPointFactory);
 
     virtual ~AccessPointDiscoveryAgentOperationsNetlink();
 
@@ -101,7 +107,7 @@ private:
     ProcessNetlinkMessage(struct nl_msg *netlinkMessage, AccessPointPresenceEventCallback &accessPointPresenceEventCallback);
 
 private:
-    std::shared_ptr<IAccessPointFactory> m_accessPointFactory;
+    std::shared_ptr<AccessPointFactoryLinux> m_accessPointFactory;
 
     // Cookie used to validate that the callback context is valid.
     static constexpr uint32_t CookieValid{ 0x8BADF00Du };

--- a/src/linux/wifi/core/AccessPointLinux.cxx
+++ b/src/linux/wifi/core/AccessPointLinux.cxx
@@ -1,8 +1,19 @@
 
+#include <stdexcept>
+
 #include <microsoft/net/wifi/AccessPointControllerLinux.hxx>
 #include <microsoft/net/wifi/AccessPointLinux.hxx>
+#include <plog/Log.h>
+
+using Microsoft::Net::Netlink::Nl80211::Nl80211Interface;
 
 using namespace Microsoft::Net::Wifi;
+
+AccessPointLinux::AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Microsoft::Net::Netlink::Nl80211::Nl80211Interface nl80211Interface) :
+    AccessPoint(interfaceName, std::move(accessPointControllerFactory)),
+    m_nl80211Interface{ std::move(nl80211Interface) }
+{
+}
 
 std::unique_ptr<IAccessPointController>
 AccessPointLinux::CreateController()
@@ -17,7 +28,17 @@ AccessPointFactoryLinux::Create(std::string_view interfaceName)
 }
 
 std::shared_ptr<IAccessPoint>
-AccessPointFactoryLinux::Create(std::string_view interfaceName, [[maybe_unused]] std::unique_ptr<IAccessPointCreateArgs> createArgs)
+AccessPointFactoryLinux::Create(std::string_view interfaceName, std::unique_ptr<IAccessPointCreateArgs> createArgs)
 {
-    return std::make_shared<AccessPointLinux>(interfaceName, GetControllerFactory());
+    auto createArgsLinux = dynamic_cast<AccessPointCreateArgsLinux *>(createArgs.get());
+    if (createArgsLinux == nullptr) {
+        throw std::runtime_error("invalid arguments passed to AccessPointFactoryLinux::Create; this is a bug!");
+    }
+
+    return std::make_shared<AccessPointLinux>(interfaceName, GetControllerFactory(), std::move(createArgsLinux->Interface));
+}
+
+AccessPointCreateArgsLinux::AccessPointCreateArgsLinux(Nl80211Interface nl80211Interface) :
+    Interface{ std::move(nl80211Interface) }
+{
 }

--- a/src/linux/wifi/core/CMakeLists.txt
+++ b/src/linux/wifi/core/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(wifi-core-linux
     PRIVATE
         plog::plog
     PUBLIC
+        libnl-helpers
         wifi-core
         wpa-controller
 )

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointLinux.hxx
@@ -6,6 +6,7 @@
 #include <string_view>
 
 #include <microsoft/net/wifi/AccessPoint.hxx>
+#include <microsoft/net/netlink/nl80211/Netlink80211Interface.hxx>
 
 namespace Microsoft::Net::Wifi
 {
@@ -16,12 +17,25 @@ struct AccessPointLinux :
     public AccessPoint
 {
     /**
-     * @brief Inherit the constructors from the base class.
+     * @brief Construct a new AccessPointLinux object with the specified interface name, access point controller
+     * factory, and nl80211 interface.
+     * 
+     * @param interfaceName The name of the interface.
+     * @param accessPointControllerFactory The access point controller factory to use for creating access point.
+     * @param nl80211Interface The nl80211 interface object.
      */
-    using AccessPoint::AccessPoint;
+    AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Microsoft::Net::Netlink::Nl80211::Nl80211Interface nl80211Interface);
 
+    /**
+     * @brief Create a IAccessPointController object of type AccessPointControllerLinux.
+     * 
+     * @return std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController> 
+     */
     virtual std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController>
     CreateController() override;
+
+private:
+    Microsoft::Net::Netlink::Nl80211::Nl80211Interface m_nl80211Interface;
 };
 
 /**
@@ -50,6 +64,22 @@ struct AccessPointFactoryLinux :
      */
     virtual std::shared_ptr<IAccessPoint>
     Create(std::string_view interfaceName, std::unique_ptr<IAccessPointCreateArgs> createArgs) override;
+};
+
+/**
+ * @brief Arguments to be passed to the Linux access point during creation.
+ */
+struct AccessPointCreateArgsLinux :
+    public IAccessPointCreateArgs
+{
+    /**
+     * @brief Construct a new AccessPointCreateArgsLinux object with the specified nl80211 interface.
+     * 
+     * @param nl80211Interface The nl80211 interface object.
+     */
+    AccessPointCreateArgsLinux(Microsoft::Net::Netlink::Nl80211::Nl80211Interface nl80211Interface);
+
+    Microsoft::Net::Netlink::Nl80211::Nl80211Interface Interface;
 };
 } // namespace Microsoft::Net::Wifi
 

--- a/tests/unit/linux/wifi/CMakeLists.txt
+++ b/tests/unit/linux/wifi/CMakeLists.txt
@@ -1,3 +1,4 @@
 
 add_subdirectory(apmanager)
 add_subdirectory(core)
+add_subdirectory(helpers)

--- a/tests/unit/linux/wifi/apmanager/CMakeLists.txt
+++ b/tests/unit/linux/wifi/apmanager/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(wifi-apmanager-linux-test-unit
         plog::plog
         strings
         wifi-apmanager-linux
-        wifi-test-helpers
+        wifi-test-helpers-linux
 )
 
 catch_discover_tests(wifi-apmanager-linux-test-unit)

--- a/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -6,6 +6,7 @@
 
 #include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
 #include <microsoft/net/wifi/test/AccessPointTest.hxx>
+#include <microsoft/net/wifi/test/AccessPointFactoryLinuxTest.hxx>
 
 TEST_CASE("Create AccessPointDiscoveryAgentOperationsNetlink", "[wifi][core][apmanager]")
 {
@@ -14,7 +15,7 @@ TEST_CASE("Create AccessPointDiscoveryAgentOperationsNetlink", "[wifi][core][apm
 
     SECTION("Create doesn't cause a crash")
     {
-        REQUIRE_NOTHROW(AccessPointDiscoveryAgentOperationsNetlink{ std::make_shared<AccessPointFactoryTest>() });
+        REQUIRE_NOTHROW(AccessPointDiscoveryAgentOperationsNetlink{ std::make_shared<AccessPointFactoryLinuxTest>() });
     }
 }
 
@@ -25,7 +26,7 @@ TEST_CASE("Destroy AccessPointDiscoveryAgentOperationsNetlink", "[wifi][core][ap
 
     SECTION("Destroy doesn't cause a crash")
     {
-        std::optional<AccessPointDiscoveryAgentOperationsNetlink> accessPointDiscoveryAgent(std::make_shared<AccessPointFactoryTest>());
+        std::optional<AccessPointDiscoveryAgentOperationsNetlink> accessPointDiscoveryAgent(std::make_shared<AccessPointFactoryLinuxTest>());
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.reset());
     }
 }
@@ -37,20 +38,20 @@ TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::Start", "[wifi][core][apm
 
     SECTION("Start doesn't cause a crash")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Start([](auto &&, auto &&) {}));
     }
 
     SECTION("Start doesn't cause a crash when called twice")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Start([](auto &&, auto &&) {}));
     }
 
     SECTION("Start doesn't cause a crash when called with a null callback")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Start(nullptr));
     }
 }
@@ -62,20 +63,20 @@ TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::Stop", "[wifi][core][apma
 
     SECTION("Stop doesn't cause a crash when Start hasn't been called")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Stop());
     }
 
     SECTION("Stop doesn't cause a crash when Start has been called")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Stop());
     }
 
     SECTION("Stop doesn't cause a crash when called twice")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
         accessPointDiscoveryAgent.Stop();
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Stop());
@@ -83,7 +84,7 @@ TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::Stop", "[wifi][core][apma
 
     SECTION("Stop doesn't cause a crash when called with a null callback")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         accessPointDiscoveryAgent.Start(nullptr);
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.Stop());
     }
@@ -96,27 +97,27 @@ TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync", "[wifi][core
 
     SECTION("ProbeAsync doesn't cause a crash when Start hasn't been called")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
     }
 
     SECTION("ProbeAsync doesn't cause a crash when Start has been called")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
     }
 
     SECTION("ProbeAsync doesn't cause a crash when Stop has been called")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         accessPointDiscoveryAgent.Stop();
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
     }
 
     SECTION("ProbeAsync doesn't cause a crash when called twice")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         accessPointDiscoveryAgent.Start([](auto &&, auto &&) {});
         accessPointDiscoveryAgent.ProbeAsync();
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
@@ -124,7 +125,7 @@ TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync", "[wifi][core
 
     SECTION("ProbeAsync doesn't cause a crash when called after a Start/Stop sequence")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         accessPointDiscoveryAgent.Start(nullptr);
         accessPointDiscoveryAgent.Stop();
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync());
@@ -132,20 +133,20 @@ TEST_CASE("AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync", "[wifi][core
 
     SECTION("ProbeAsync returns a valid future")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         accessPointDiscoveryAgent.Start(nullptr);
         REQUIRE(accessPointDiscoveryAgent.ProbeAsync().valid());
     }
 
     SECTION("ProbeAsync result can be obtained without causing a crash")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync().get());
     }
 
     SECTION("ProbeAsync result is valid")
     {
-        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryTest>() };
+        AccessPointDiscoveryAgentOperationsNetlink accessPointDiscoveryAgent{ std::make_shared<AccessPointFactoryLinuxTest>() };
         REQUIRE_NOTHROW(accessPointDiscoveryAgent.ProbeAsync().get().clear());
     }
 }

--- a/tests/unit/linux/wifi/core/TestAccessPointFactoryLinux.cxx
+++ b/tests/unit/linux/wifi/core/TestAccessPointFactoryLinux.cxx
@@ -50,28 +50,34 @@ TEST_CASE("Create() function", "[wifi][core][ap][linux]")
 {
     using namespace Microsoft::Net::Wifi;
 
+    using Microsoft::Net::Netlink::Nl80211::Nl80211Interface;
+
     SECTION("Create() doesn't cause a crash")
     {
+        auto createArgs = std::make_unique<AccessPointCreateArgsLinux>(Nl80211Interface{});
         AccessPointFactoryLinux accessPointFactory{ std::make_unique<Test::AccessPointControllerFactoryTest>() };
-        REQUIRE_NOTHROW(accessPointFactory.Create(Test::InterfaceNameDefault));
+        REQUIRE_NOTHROW(accessPointFactory.Create(Test::InterfaceNameDefault, std::move(createArgs)));
     }
 
     SECTION("Create() with empty/null inteface doesn't cause a crash")
     {
+        auto createArgs = std::make_unique<AccessPointCreateArgsLinux>(Nl80211Interface{});
         AccessPointFactoryLinux accessPointFactory{ std::make_unique<Test::AccessPointControllerFactoryTest>() };
-        REQUIRE_NOTHROW(accessPointFactory.Create({}));
+        REQUIRE_NOTHROW(accessPointFactory.Create({}, std::move(createArgs)));
     }
 
     SECTION("Create() with valid input arguments returns non-nullptr instance")
     {
+        auto createArgs = std::make_unique<AccessPointCreateArgsLinux>(Nl80211Interface{});
         AccessPointFactoryLinux accessPointFactory{ std::make_unique<Test::AccessPointControllerFactoryTest>() };
-        REQUIRE(accessPointFactory.Create(Test::InterfaceNameDefault) != nullptr);
+        REQUIRE(accessPointFactory.Create(Test::InterfaceNameDefault, std::move(createArgs)) != nullptr);
     }
 
     SECTION("Create() instance reflects basic properties from base class")
     {
+        auto createArgs = std::make_unique<AccessPointCreateArgsLinux>(Nl80211Interface{});
         AccessPointFactoryLinux accessPointFactory{ std::make_unique<Test::AccessPointControllerFactoryTest>() };
-        const auto accessPoint = accessPointFactory.Create(Test::InterfaceNameDefault);
+        const auto accessPoint = accessPointFactory.Create(Test::InterfaceNameDefault, std::move(createArgs));
         REQUIRE(accessPoint->GetInterfaceName() == Test::InterfaceNameDefault);
     }
 }

--- a/tests/unit/linux/wifi/core/TestAccessPointFactoryLinux.cxx
+++ b/tests/unit/linux/wifi/core/TestAccessPointFactoryLinux.cxx
@@ -33,7 +33,7 @@ TEST_CASE("Destroy an AccessPointFactoryLinux instance", "[wifi][core][ap][linux
 {
     using namespace Microsoft::Net::Wifi;
 
-    SECTION("Destroy doesn't cause a crashk with null controller factory")
+    SECTION("Destroy doesn't cause a crash with null controller factory")
     {
         AccessPointFactoryLinux accessPointFactory{ nullptr };
         REQUIRE_NOTHROW(accessPointFactory.~AccessPointFactoryLinux());

--- a/tests/unit/linux/wifi/core/TestAccessPointLinux.cxx
+++ b/tests/unit/linux/wifi/core/TestAccessPointLinux.cxx
@@ -14,24 +14,26 @@ TEST_CASE("Create an AccessPointLinux instance", "[wifi][core][ap][linux]")
 {
     using namespace Microsoft::Net::Wifi;
 
+    using Microsoft::Net::Netlink::Nl80211::Nl80211Interface;
+
     SECTION("Create doesn't cause a crash with null controller factory")
     {
         std::optional<AccessPointLinux> accessPoint;
-        REQUIRE_NOTHROW(accessPoint.emplace(Test::InterfaceNameDefault, nullptr));
+        REQUIRE_NOTHROW(accessPoint.emplace(Test::InterfaceNameDefault, nullptr, Nl80211Interface{}));
     }
 
     SECTION("Create doesn't cause a crash")
     {
         std::optional<AccessPointLinux> accessPoint;
-        REQUIRE_NOTHROW(accessPoint.emplace(Test::InterfaceNameDefault, std::make_unique<Test::AccessPointControllerFactoryTest>()));
+        REQUIRE_NOTHROW(accessPoint.emplace(Test::InterfaceNameDefault, std::make_unique<Test::AccessPointControllerFactoryTest>(), Nl80211Interface{}));
     }
 
     SECTION("Create multiple for same interface doesn't cause a crash")
     {
         std::optional<AccessPointLinux> accessPoint1;
-        REQUIRE_NOTHROW(accessPoint1.emplace(Test::InterfaceNameDefault, std::make_unique<Test::AccessPointControllerFactoryTest>()));
+        REQUIRE_NOTHROW(accessPoint1.emplace(Test::InterfaceNameDefault, std::make_unique<Test::AccessPointControllerFactoryTest>(), Nl80211Interface{}));
 
         std::optional<AccessPointLinux> accessPoint2;
-        REQUIRE_NOTHROW(accessPoint2.emplace(Test::InterfaceNameDefault, std::make_unique<Test::AccessPointControllerFactoryTest>()));
+        REQUIRE_NOTHROW(accessPoint2.emplace(Test::InterfaceNameDefault, std::make_unique<Test::AccessPointControllerFactoryTest>(), Nl80211Interface{}));
     }
 }

--- a/tests/unit/linux/wifi/helpers/AccessPointFactoryLinuxTest.cxx
+++ b/tests/unit/linux/wifi/helpers/AccessPointFactoryLinuxTest.cxx
@@ -1,0 +1,10 @@
+
+#include <microsoft/net/wifi/test/AccessPointControllerTest.hxx>
+#include <microsoft/net/wifi/test/AccessPointFactoryLinuxTest.hxx>
+
+using namespace Microsoft::Net::Wifi::Test;
+
+AccessPointFactoryLinuxTest::AccessPointFactoryLinuxTest() :
+    AccessPointFactoryLinux{ std::make_shared<AccessPointControllerFactoryTest>() }
+{
+}

--- a/tests/unit/linux/wifi/helpers/CMakeLists.txt
+++ b/tests/unit/linux/wifi/helpers/CMakeLists.txt
@@ -1,0 +1,29 @@
+
+add_library(wifi-test-helpers-linux STATIC "")
+
+set(WIFI_TEST_HELPERS_LINUX_PUBLIC_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/include)
+set(WIFI_TEST_HELPERS_LINUX_PUBLIC_INCLUDE_SUFFIX microsoft/net/wifi/test)
+set(WIFI_TEST_HELPERS_LINUX_PUBLIC_INCLUDE_PREFIX ${WIFI_TEST_HELPERS_LINUX_PUBLIC_INCLUDE}/${WIFI_TEST_HELPERS_LINUX_PUBLIC_INCLUDE_SUFFIX})
+
+target_sources(wifi-test-helpers-linux
+    PRIVATE
+        AccessPointFactoryLinuxTest.cxx
+    PUBLIC
+    FILE_SET HEADERS
+    BASE_DIRS ${WIFI_TEST_HELPERS_LINUX_PUBLIC_INCLUDE}
+    FILES
+        ${WIFI_TEST_HELPERS_LINUX_PUBLIC_INCLUDE_PREFIX}/AccessPointFactoryLinuxTest.hxx
+)
+
+target_include_directories(wifi-test-helpers-linux
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC
+        ${WIFI_TEST_HELPERS_LINUX_PUBLIC_INCLUDE}
+)
+
+target_link_libraries(wifi-test-helpers-linux
+    PUBLIC
+        wifi-core-linux
+        wifi-test-helpers
+)

--- a/tests/unit/linux/wifi/helpers/include/microsoft/net/wifi/test/AccessPointFactoryLinuxTest.hxx
+++ b/tests/unit/linux/wifi/helpers/include/microsoft/net/wifi/test/AccessPointFactoryLinuxTest.hxx
@@ -1,0 +1,16 @@
+
+#ifndef ACCESS_POINT_FACTORY_LINUX_TEST_HXX
+#define ACCESS_POINT_FACTORY_LINUX_TEST_HXX
+
+#include <microsoft/net/wifi/AccessPointLinux.hxx>
+
+namespace Microsoft::Net::Wifi::Test
+{
+struct AccessPointFactoryLinuxTest :
+    public Microsoft::Net::Wifi::AccessPointFactoryLinux
+{
+    AccessPointFactoryLinuxTest();
+};
+} // namespace Microsoft::Net::Wifi::Test
+
+#endif // ACCESS_POINT_FACTORY_LINUX_TEST_HXX


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Relax interface restrictions in implementation, specifically related to the `AccessPoint*` hierarchy.

### Technical Details

* Change `AccessPointDiscoveryAgentOperationsNetlink` from accepting the generic `IAccessPointFactory` to a `AccessPointFactoryLinux`, which is intended to be the base for all Linux implementations. Use this to allow capturing the ready-made `Nl80211Interface` which is then passed to the `AccessPointLinux` instance.
* Add Linux-specific wifi test helper library.

### Test Results

* All unit tests pass.
* `netremote-cli wifi enumaps` works as expected.

### Reviewer Focus

* None

### Future Work

* Make use of the `Nl80211Interface` to populate access point capabilities in the API.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
