### PR TITLE
Update protobuf Wi-Fi API types to match the 802.11 specification

### DIFF
--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -9,7 +9,7 @@ import "WifiCore.proto";
 message WifiEnumerateAccessPointsResultItem
 {
     string AccessPointId = 1;
-    Microsoft.Net.Wifi.AccessPointCapabilities Capabilities = 2;
+    Microsoft.Net.Wifi.Dot11AccessPointCapabilities Capabilities = 2;
     bool IsEnabled = 3;
 }
 
@@ -42,7 +42,7 @@ message WifiAccessPointOperationStatus
 message WifiAccessPointEnableRequest
 {
     string AccessPointId = 1;
-    Microsoft.Net.Wifi.AccessPointConfiguration Configuration = 2;
+    Microsoft.Net.Wifi.Dot11AccessPointConfiguration Configuration = 2;
 }
 
 message WifiAccessPointEnableResult

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -62,6 +62,32 @@ enum Dot11AuthenticationAlgorithm
     Dot11AuthenticationAlgorithmOwe = 11;
 }
 
+// 802.11 Authentication and Key Management (AKM) Suites.
+enum Dot11AkmSuite
+{
+    Dot11AkmSuiteReserved0 = 0;
+    Dot11AkmSuite8021x = 1;
+    Dot11AkmSuitePsk = 2;
+    Dot11AkmSuiteFt8021x = 3;
+    Dot11AkmSuiteFtPsk = 4;
+    Dot11AkmSuite8021xSha256 = 5;
+    Dot11AkmSuitePskSha256 = 6;
+    Dot11AkmSuiteTdls = 7;
+    Dot11AkmSuiteSae = 8;
+    Dot11AkmSuiteFtSae = 9;
+    Dot11AkmSuiteApPeerKey = 10;
+    Dot11AkmSuite8021xSuiteB = 11;
+    Dot11AkmSuite8021xSuiteB192 = 12;
+    Dot11AkmSuiteFt8021xSha384 = 13;
+    Dot11AkmSuiteFilsSha256 = 14;
+    Dot11AkmSuiteFilsSha384 = 15;
+    Dot11AkmSuiteFtFilsSha256 = 16;
+    Dot11AkmSuiteFtFilsSha384 = 17;
+    Dot11AkmSuiteOwe = 18;
+    Dot11AkmSuiteFtPskSha384 = 19;
+    Dot11AkmSuitePskSha384 = 20;
+}
+
 enum Dot11CipherAlgorithm
 {
     option allow_alias = true;

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -44,6 +44,8 @@ enum Dot11PhyType
     Dot11PhyTypeEht = 8;
 }
 
+// 802.11 Authentication Algorithms.
+// Values map to those defined in IEEE 802.11-2020, Section 9.4.1.1.
 enum Dot11AuthenticationAlgorithm
 {
     Dot11AuthenticationAlgorithmUnknown = 0;

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -9,13 +9,15 @@ enum Dot11FrequencyBand
     
     Dot11FrequencyBandUnknown = 0;
     Dot11FrequencyBand2400MHz = 1;
-    Dot11FrequencyBand2_4GHz = 1;
-    Dot11FrequencyBandTwoPoint4GHz = 1;
     Dot11FrequencyBand5000MHz = 2;
-    Dot11FrequencyBand5_0GHz = 2;
-    Dot11FrequencyBandFiveGHz = 2;
     Dot11FrequencyBand6000MHz = 3;
+
+    Dot11FrequencyBand2_4GHz = 1;
     Dot11FrequencyBand6_0GHz = 3;
+    Dot11FrequencyBand5_0GHz = 2;
+    
+    Dot11FrequencyBandTwoPoint4GHz = 1;
+    Dot11FrequencyBandFiveGHz = 2;
     Dot11FrequencyBandSixGHz = 3;
 }
 

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -66,27 +66,28 @@ enum Dot11AuthenticationAlgorithm
 // Values map to those defined in IEEE 802.11-2020, Section 9.4.2.24.3, Table 9-151.
 enum Dot11AkmSuite
 {
-    Dot11AkmSuiteReserved0 = 0;
-    Dot11AkmSuite8021x = 1;
-    Dot11AkmSuitePsk = 2;
-    Dot11AkmSuiteFt8021x = 3;
-    Dot11AkmSuiteFtPsk = 4;
-    Dot11AkmSuite8021xSha256 = 5;
-    Dot11AkmSuitePskSha256 = 6;
-    Dot11AkmSuiteTdls = 7;
-    Dot11AkmSuiteSae = 8;
-    Dot11AkmSuiteFtSae = 9;
-    Dot11AkmSuiteApPeerKey = 10;
-    Dot11AkmSuite8021xSuiteB = 11;
-    Dot11AkmSuite8021xSuiteB192 = 12;
-    Dot11AkmSuiteFt8021xSha384 = 13;
-    Dot11AkmSuiteFilsSha256 = 14;
-    Dot11AkmSuiteFilsSha384 = 15;
-    Dot11AkmSuiteFtFilsSha256 = 16;
-    Dot11AkmSuiteFtFilsSha384 = 17;
-    Dot11AkmSuiteOwe = 18;
-    Dot11AkmSuiteFtPskSha384 = 19;
-    Dot11AkmSuitePskSha384 = 20;
+    Dot11AkmSuiteUnknown = 0;
+    Dot11AkmSuiteReserved0 = 1;
+    Dot11AkmSuite8021x = 2;
+    Dot11AkmSuitePsk = 3;
+    Dot11AkmSuiteFt8021x = 4;
+    Dot11AkmSuiteFtPsk = 5;
+    Dot11AkmSuite8021xSha256 = 6;
+    Dot11AkmSuitePskSha256 = 7;
+    Dot11AkmSuiteTdls = 8;
+    Dot11AkmSuiteSae = 9;
+    Dot11AkmSuiteFtSae = 10;
+    Dot11AkmSuiteApPeerKey = 11;
+    Dot11AkmSuite8021xSuiteB = 12;
+    Dot11AkmSuite8021xSuiteB192 = 13;
+    Dot11AkmSuiteFt8021xSha384 = 14;
+    Dot11AkmSuiteFilsSha256 = 15;
+    Dot11AkmSuiteFilsSha384 = 16;
+    Dot11AkmSuiteFtFilsSha256 = 17;
+    Dot11AkmSuiteFtFilsSha384 = 18;
+    Dot11AkmSuiteOwe = 19;
+    Dot11AkmSuiteFtPskSha384 = 20;
+    Dot11AkmSuitePskSha384 = 21;
 }
 
 // 802.11 Cipher suites.

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -62,7 +62,8 @@ enum Dot11AuthenticationAlgorithm
     Dot11AuthenticationAlgorithmOwe = 11;
 }
 
-// 802.11 Authentication and Key Management (AKM) Suites.
+// 802.11 Authentication and Key Management (AKM) suites.
+// Values map to those defined in IEEE 802.11-2020, Section 9.4.2.24.3, Table 9-151.
 enum Dot11AkmSuite
 {
     Dot11AkmSuiteReserved0 = 0;
@@ -88,27 +89,24 @@ enum Dot11AkmSuite
     Dot11AkmSuitePskSha384 = 20;
 }
 
-enum Dot11CipherAlgorithm
+// 802.11 Cipher suites.
+// Values map to those defined in IEEE 802.11-2020, Section 9.4.2.24.2, Table 9-149.
+enum Dot11CipherSuite
 {
-    option allow_alias = true;
-
-    Dot11CipherAlgorithmUnknown = 0;
-    Dot11CipherAlgorithmNone = 1;
-    Dot11CipherAlgorithmWep = 2;
-    Dot11CipherAlgorithmWep40 = 3;
-    Dot11CipherAlgorithmWep104 = 4;
-    Dot11CipherAlgorithmTkip = 5;
-    Dot11CipherAlgorithmBip = 6;
-    Dot11CipherAlgorithmBipCmac128 = 6;
-    Dot11CipherAlgorithmBipGmac128 = 7;
-    Dot11CipherAlgorithmBipGmac256 = 8;
-    Dot11CipherAlgorithmBipCmac256 = 9;
-    Dot11CipherAlgorithmGcmp = 10;
-    Dot11CipherAlgorithmGcmp128 = 10;
-    Dot11CipherAlgorithmGcmp256 = 11;
-    Dot11CipherAlgorithmCcmp256 = 12;
-    Dot11CipherAlgorithmWpaUseGroup = 13;
-    Dot11CipherAlgorithmRsnUseGroup = 13;
+    Dot11CipherSuiteUnknown = 0;
+    Dot11CipherSuiteBipCmac128 = 1;
+    Dot11CipherSuiteBipCmac256 = 2;
+    Dot11CipherSuiteBipGmac128 = 3;
+    Dot11CipherSuiteBipGmac256 = 4;
+    Dot11CipherSuiteCcmp128 = 5;
+    Dot11CipherSuiteCcmp256 = 6;
+    Dot11CipherSuiteGcmp128 = 7;
+    Dot11CipherSuiteGcmp256 = 8;
+    Dot11CipherSuiteGroupAddressesTrafficNotAllowed = 9;
+    Dot11CipherSuiteTkip = 10;
+    Dot11CipherSuiteUseGroup = 11;
+    Dot11CipherSuiteWep104 = 12;
+    Dot11CipherSuiteWep40 = 13;
 }
 
 message Dot11Ssid
@@ -141,7 +139,7 @@ message AccessPointConfiguration
     Dot11MacAddress Bssid = 2;
     Dot11PhyType PhyType = 3;
     Dot11AuthenticationAlgorithm AuthenticationAlgorithm = 4;
-    Dot11CipherAlgorithm EncryptionAlgorithm = 5;
+    Dot11CipherSuite CipherSuite = 5;
     repeated RadioBand Bands = 6;
 }
 
@@ -150,7 +148,7 @@ message AccessPointCapabilities
     repeated Microsoft.Net.Wifi.RadioBand Bands = 1;
     repeated Microsoft.Net.Wifi.Dot11PhyType PhyTypes = 2;
     repeated Microsoft.Net.Wifi.Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 3;
-    repeated Microsoft.Net.Wifi.Dot11CipherAlgorithm EncryptionAlgorithms = 4;
+    repeated Microsoft.Net.Wifi.Dot11CipherSuite CipherSuites = 4;
 }
 
 enum AccessPointState

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -25,20 +25,22 @@ enum Dot11PhyType
 
     Dot11PhyTypeUnknown = 0;
     Dot11PhyTypeB = 1;
-    Dot11PhyTypeHrdsss = 1;
     Dot11PhyTypeG = 2;
-    Dot11PhyTypeErp = 2;
     Dot11PhyTypeN = 3;
-    Dot11PhyTypeHt = 3;
     Dot11PhyTypeA = 4;
-    Dot11PhyTypeOfdm = 4;
     Dot11PhyTypeAC = 5;
-    Dot11PhyTypeVht = 5;
     Dot11PhyTypeAD = 6;
-    Dot11PhyTypeDmg = 6;
     Dot11PhyTypeAX = 7;
-    Dot11PhyTypeHe = 7;
     Dot11PhyTypeBE = 8;
+
+    // Modulation type aliases.
+    Dot11PhyTypeHrdsss = 1;
+    Dot11PhyTypeErp = 2;
+    Dot11PhyTypeHt = 3;
+    Dot11PhyTypeOfdm = 4;
+    Dot11PhyTypeVht = 5;
+    Dot11PhyTypeDmg = 6;
+    Dot11PhyTypeHe = 7;
     Dot11PhyTypeEht = 8;
 }
 

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -44,22 +44,15 @@ enum Dot11PhyType
 
 enum Dot11AuthenticationAlgorithm
 {
-    option allow_alias = true;
-
     Dot11AuthenticationAlgorithmUnknown = 0;
-    Dot11AuthenticationAlgorithmOpen = 1;
-    Dot11AuthenticationAlgorithmSharedKey = 2;
-    Dot11AuthenticationAlgorithmWpa = 3;
-    Dot11AuthenticationAlgorithmWpaPsk = 4;
-    Dot11AuthenticationAlgorithmWpaNone = 5;
-    Dot11AuthenticationAlgorithmRsna = 6;
-    Dot11AuthenticationAlgorithmRsnaPsk = 7;
-    Dot11AuthenticationAlgorithmWpa3 = 8;
-    Dot11AuthenticationAlgorithmWpa3Enterprise192 = 8;
-    Dot11AuthenticationAlgorithmWpa3Enterprise = 9;
-    Dot11AuthenticationAlgorithmSae = 10;
-    Dot11AuthenticationAlgorithmWpa3Personal = 10;
-    Dot11AuthenticationAlgorithmOwe = 11;
+    Dot11AuthenticationAlgorithmSharedKey = 1;
+    Dot11AuthenticationAlgorithmOpenSystem = 2;
+    Dot11AuthenticationAlgorithmFastBssTransition = 3;
+    Dot11AuthenticationAlgorithmSae = 4;
+    Dot11AuthenticationAlgorithmFils = 5;
+    Dot11AuthenticationAlgorithmFilsPfs = 6;
+    Dot11AuthenticationAlgorithmFilsPublicKey = 7;
+    Dot11AuthenticationAlgorithmVendorSpecific = 8;
 }
 
 // 802.11 Authentication and Key Management (AKM) suites.

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -3,20 +3,20 @@ syntax = "proto3";
 
 package Microsoft.Net.Wifi;
 
-enum RadioBand
+enum Dot11FrequencyBand
 {
     option allow_alias = true;
     
-    RadioBandUnknown = 0;
-    RadioBand2400MHz = 1;
-    RadioBand2_4GHz = 1;
-    RadioBandTwoPoint4GHz = 1;
-    RadioBand5000MHz = 2;
-    RadioBand5_0GHz = 2;
-    RadioBandFiveGHz = 2;
-    RadioBand6000MHz = 3;
-    RadioBand6_0GHz = 3;
-    RadioBandSixGHz = 3;
+    Dot11FrequencyBandUnknown = 0;
+    Dot11FrequencyBand2400MHz = 1;
+    Dot11FrequencyBand2_4GHz = 1;
+    Dot11FrequencyBandTwoPoint4GHz = 1;
+    Dot11FrequencyBand5000MHz = 2;
+    Dot11FrequencyBand5_0GHz = 2;
+    Dot11FrequencyBandFiveGHz = 2;
+    Dot11FrequencyBand6000MHz = 3;
+    Dot11FrequencyBand6_0GHz = 3;
+    Dot11FrequencyBandSixGHz = 3;
 }
 
 enum Dot11PhyType
@@ -134,12 +134,12 @@ message AccessPointConfiguration
     Dot11PhyType PhyType = 3;
     Dot11AuthenticationAlgorithm AuthenticationAlgorithm = 4;
     Dot11CipherSuite CipherSuite = 5;
-    repeated RadioBand Bands = 6;
+    repeated Dot11FrequencyBand Bands = 6;
 }
 
 message AccessPointCapabilities
 {
-    repeated Microsoft.Net.Wifi.RadioBand Bands = 1;
+    repeated Microsoft.Net.Wifi.Dot11FrequencyBand Bands = 1;
     repeated Microsoft.Net.Wifi.Dot11PhyType PhyTypes = 2;
     repeated Microsoft.Net.Wifi.Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 3;
     repeated Microsoft.Net.Wifi.Dot11CipherSuite CipherSuites = 4;

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -118,7 +118,7 @@ message Dot11MacAddress
     bytes Value = 1;
 }
 
-message SharedKey
+message Dot11SharedKey
 {
     oneof Value
     {
@@ -127,7 +127,7 @@ message SharedKey
     }
 }
 
-message AccessPointConfiguration
+message Dot11AccessPointConfiguration
 {
     Dot11Ssid Ssid = 1;
     Dot11MacAddress Bssid = 2;
@@ -137,7 +137,7 @@ message AccessPointConfiguration
     repeated Dot11FrequencyBand Bands = 6;
 }
 
-message AccessPointCapabilities
+message Dot11AccessPointCapabilities
 {
     repeated Microsoft.Net.Wifi.Dot11FrequencyBand Bands = 1;
     repeated Microsoft.Net.Wifi.Dot11PhyType PhyTypes = 2;
@@ -145,7 +145,7 @@ message AccessPointCapabilities
     repeated Microsoft.Net.Wifi.Dot11CipherSuite CipherSuites = 4;
 }
 
-enum AccessPointState
+enum Dot11AccessPointState
 {
     AccessPointStateUnknown = 0;
 }

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -15,12 +15,14 @@ enum Dot11FrequencyBand
     Dot11FrequencyBand2_4GHz = 1;
     Dot11FrequencyBand6_0GHz = 3;
     Dot11FrequencyBand5_0GHz = 2;
-    
+
     Dot11FrequencyBandTwoPoint4GHz = 1;
     Dot11FrequencyBandFiveGHz = 2;
     Dot11FrequencyBandSixGHz = 3;
 }
 
+// 802.11 PHY Types.
+// Values map to those defined in IEEE 802.11-2020, Annex C, Page 3934, 'dot11PHYType'.
 enum Dot11PhyType
 {
     option allow_alias = true;

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -29,49 +29,49 @@ NetRemoteService::GetAccessPointManager() noexcept
 namespace detail
 {
 using Microsoft::Net::Wifi::Dot11PhyType;
-using Microsoft::Net::Wifi::IeeeProtocol;
+using Microsoft::Net::Wifi::Ieee80211Protocol;
 
 Dot11PhyType
-IeeeProtocolToNetRemotePhyType(IeeeProtocol ieeeProtocol)
+IeeeProtocolToNetRemotePhyType(Ieee80211Protocol ieeeProtocol)
 {
     switch (ieeeProtocol) {
-    case IeeeProtocol::Unknown:
+    case Ieee80211Protocol::Unknown:
         return Dot11PhyType::Dot11PhyTypeUnknown;
-    case IeeeProtocol::B:
+    case Ieee80211Protocol::B:
         return Dot11PhyType::Dot11PhyTypeB;
-    case IeeeProtocol::G:
+    case Ieee80211Protocol::G:
         return Dot11PhyType::Dot11PhyTypeG;
-    case IeeeProtocol::N:
+    case Ieee80211Protocol::N:
         return Dot11PhyType::Dot11PhyTypeN;
-    case IeeeProtocol::A:
+    case Ieee80211Protocol::A:
         return Dot11PhyType::Dot11PhyTypeA;
-    case IeeeProtocol::AC:
+    case Ieee80211Protocol::AC:
         return Dot11PhyType::Dot11PhyTypeAC;
-    case IeeeProtocol::AD:
+    case Ieee80211Protocol::AD:
         return Dot11PhyType::Dot11PhyTypeAD;
-    case IeeeProtocol::AX:
+    case Ieee80211Protocol::AX:
         return Dot11PhyType::Dot11PhyTypeAX;
-    case IeeeProtocol::BE:
+    case Ieee80211Protocol::BE:
         return Dot11PhyType::Dot11PhyTypeBE;
     }
 
     return Dot11PhyType::Dot11PhyTypeUnknown;
 }
 
-using Microsoft::Net::Wifi::IeeeDot11FrequencyBand;
+using Microsoft::Net::Wifi::Ieee80211FrequencyBand;
 using Microsoft::Net::Wifi::Dot11FrequencyBand;
 
 Dot11FrequencyBand
-IeeeDot11FrequencyBandToNetRemoteDot11FrequencyBand(IeeeDot11FrequencyBand ieeeDot11FrequencyBand)
+IeeeDot11FrequencyBandToNetRemoteDot11FrequencyBand(Ieee80211FrequencyBand ieeeDot11FrequencyBand)
 {
     switch (ieeeDot11FrequencyBand) {
-    case IeeeDot11FrequencyBand::Unknown:
+    case Ieee80211FrequencyBand::Unknown:
         return Dot11FrequencyBand::Dot11FrequencyBandUnknown;
-    case IeeeDot11FrequencyBand::TwoPointFourGHz:
+    case Ieee80211FrequencyBand::TwoPointFourGHz:
         return Dot11FrequencyBand::Dot11FrequencyBandTwoPoint4GHz;
-    case IeeeDot11FrequencyBand::FiveGHz:
+    case Ieee80211FrequencyBand::FiveGHz:
         return Dot11FrequencyBand::Dot11FrequencyBandFiveGHz;
-    case IeeeDot11FrequencyBand::SixGHz:
+    case Ieee80211FrequencyBand::SixGHz:
         return Dot11FrequencyBand::Dot11FrequencyBandSixGHz;
     }
 
@@ -79,29 +79,29 @@ IeeeDot11FrequencyBandToNetRemoteDot11FrequencyBand(IeeeDot11FrequencyBand ieeeD
 }
 
 using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
-using Microsoft::Net::Wifi::IeeeAuthenticationAlgorithm;
+using Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm;
 
 Dot11AuthenticationAlgorithm
-IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm(IeeeAuthenticationAlgorithm ieeeAuthenticationAlgorithm)
+IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm(Ieee80211AuthenticationAlgorithm ieeeAuthenticationAlgorithm)
 {
     switch (ieeeAuthenticationAlgorithm) {
-    case IeeeAuthenticationAlgorithm::Unknown:
+    case Ieee80211AuthenticationAlgorithm::Unknown:
         return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmUnknown;
-    case IeeeAuthenticationAlgorithm::OpenSystem:
+    case Ieee80211AuthenticationAlgorithm::OpenSystem:
         return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmOpenSystem;
-    case IeeeAuthenticationAlgorithm::SharedKey:
+    case Ieee80211AuthenticationAlgorithm::SharedKey:
         return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey;
-    case IeeeAuthenticationAlgorithm::FastBssTransition:
+    case Ieee80211AuthenticationAlgorithm::FastBssTransition:
         return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFastBssTransition;
-    case IeeeAuthenticationAlgorithm::Sae:
+    case Ieee80211AuthenticationAlgorithm::Sae:
         return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSae;
-    case IeeeAuthenticationAlgorithm::Fils:
+    case Ieee80211AuthenticationAlgorithm::Fils:
         return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFils;
-    case IeeeAuthenticationAlgorithm::FilsPfs:
+    case Ieee80211AuthenticationAlgorithm::FilsPfs:
         return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFilsPfs;
-    case IeeeAuthenticationAlgorithm::FilsPublicKey:
+    case Ieee80211AuthenticationAlgorithm::FilsPublicKey:
         return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFilsPublicKey;
-    case IeeeAuthenticationAlgorithm::VendorSpecific:
+    case Ieee80211AuthenticationAlgorithm::VendorSpecific:
         return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmVendorSpecific;
     }
 
@@ -109,53 +109,53 @@ IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm(IeeeAuthentication
 }
 
 using Microsoft::Net::Wifi::Dot11AkmSuite;
-using Microsoft::Net::Wifi::IeeeAkmSuite;
+using Microsoft::Net::Wifi::Ieee80211AkmSuite;
 
 Dot11AkmSuite
-IeeeAkmSuiteToNetRemoteAkm(IeeeAkmSuite akmSuite)
+Ieee80211AkmSuiteToNetRemoteAkm(Ieee80211AkmSuite akmSuite)
 {
     switch (akmSuite) {
-    case IeeeAkmSuite::Reserved0:
+    case Ieee80211AkmSuite::Reserved0:
         return Dot11AkmSuite::Dot11AkmSuiteReserved0;
-    case IeeeAkmSuite::Ieee8021x:
+    case Ieee80211AkmSuite::Ieee8021x:
         return Dot11AkmSuite::Dot11AkmSuite8021x;
-    case IeeeAkmSuite::Psk:
+    case Ieee80211AkmSuite::Psk:
         return Dot11AkmSuite::Dot11AkmSuitePsk;
-    case IeeeAkmSuite::Ft8021x:
+    case Ieee80211AkmSuite::Ft8021x:
         return Dot11AkmSuite::Dot11AkmSuiteFt8021x;
-    case IeeeAkmSuite::FtPsk:
+    case Ieee80211AkmSuite::FtPsk:
         return Dot11AkmSuite::Dot11AkmSuiteFtPsk;
-    case IeeeAkmSuite::Ieee8021xSha256:
+    case Ieee80211AkmSuite::Ieee8021xSha256:
         return Dot11AkmSuite::Dot11AkmSuite8021xSha256;
-    case IeeeAkmSuite::PskSha256:
+    case Ieee80211AkmSuite::PskSha256:
         return Dot11AkmSuite::Dot11AkmSuitePskSha256;
-    case IeeeAkmSuite::Tdls:
+    case Ieee80211AkmSuite::Tdls:
         return Dot11AkmSuite::Dot11AkmSuiteTdls;
-    case IeeeAkmSuite::Sae:
+    case Ieee80211AkmSuite::Sae:
         return Dot11AkmSuite::Dot11AkmSuiteSae;
-    case IeeeAkmSuite::FtSae:
+    case Ieee80211AkmSuite::FtSae:
         return Dot11AkmSuite::Dot11AkmSuiteFtSae;
-    case IeeeAkmSuite::ApPeerKey:
+    case Ieee80211AkmSuite::ApPeerKey:
         return Dot11AkmSuite::Dot11AkmSuiteApPeerKey;
-    case IeeeAkmSuite::Ieee8021xSuiteB:
+    case Ieee80211AkmSuite::Ieee8021xSuiteB:
         return Dot11AkmSuite::Dot11AkmSuite8021xSuiteB;
-    case IeeeAkmSuite::Ieee8011xSuiteB192:
+    case Ieee80211AkmSuite::Ieee8011xSuiteB192:
         return Dot11AkmSuite::Dot11AkmSuite8021xSuiteB192;
-    case IeeeAkmSuite::Ft8021xSha384:
+    case Ieee80211AkmSuite::Ft8021xSha384:
         return Dot11AkmSuite::Dot11AkmSuiteFt8021xSha384;
-    case IeeeAkmSuite::FilsSha256:
+    case Ieee80211AkmSuite::FilsSha256:
         return Dot11AkmSuite::Dot11AkmSuiteFilsSha256;
-    case IeeeAkmSuite::FilsSha284:
+    case Ieee80211AkmSuite::FilsSha284:
         return Dot11AkmSuite::Dot11AkmSuiteFilsSha384;
-    case IeeeAkmSuite::FtFilsSha256:
+    case Ieee80211AkmSuite::FtFilsSha256:
         return Dot11AkmSuite::Dot11AkmSuiteFtFilsSha256;
-    case IeeeAkmSuite::FtFilsSha384:
+    case Ieee80211AkmSuite::FtFilsSha384:
         return Dot11AkmSuite::Dot11AkmSuiteFtFilsSha384;
-    case IeeeAkmSuite::Owe:
+    case Ieee80211AkmSuite::Owe:
         return Dot11AkmSuite::Dot11AkmSuiteOwe;
-    case IeeeAkmSuite::FtPskSha384:
+    case Ieee80211AkmSuite::FtPskSha384:
         return Dot11AkmSuite::Dot11AkmSuiteFtPskSha384;
-    case IeeeAkmSuite::PskSha384:
+    case Ieee80211AkmSuite::PskSha384:
         return Dot11AkmSuite::Dot11AkmSuitePskSha384;
     }
 
@@ -163,39 +163,39 @@ IeeeAkmSuiteToNetRemoteAkm(IeeeAkmSuite akmSuite)
 }
 
 using Microsoft::Net::Wifi::Dot11CipherSuite;
-using Microsoft::Net::Wifi::IeeeCipherSuite;
+using Microsoft::Net::Wifi::Ieee80211CipherSuite;
 
 Dot11CipherSuite
-IeeeCipherAlgorithmToNetRemoteCipherSuite(IeeeCipherSuite ieeeCipherSuite)
+IeeeCipherAlgorithmToNetRemoteCipherSuite(Ieee80211CipherSuite ieeeCipherSuite)
 {
     switch (ieeeCipherSuite) {
-    case IeeeCipherSuite::Unknown:
+    case Ieee80211CipherSuite::Unknown:
         return Dot11CipherSuite::Dot11CipherSuiteUnknown;
-    case IeeeCipherSuite::BipCmac128:
+    case Ieee80211CipherSuite::BipCmac128:
         return Dot11CipherSuite::Dot11CipherSuiteBipCmac128;
-    case IeeeCipherSuite::BipCmac256:
+    case Ieee80211CipherSuite::BipCmac256:
         return Dot11CipherSuite::Dot11CipherSuiteBipCmac256;
-    case IeeeCipherSuite::BipGmac128:
+    case Ieee80211CipherSuite::BipGmac128:
         return Dot11CipherSuite::Dot11CipherSuiteBipGmac128;
-    case IeeeCipherSuite::BipGmac256:
+    case Ieee80211CipherSuite::BipGmac256:
         return Dot11CipherSuite::Dot11CipherSuiteBipGmac256;
-    case IeeeCipherSuite::Ccmp128:
+    case Ieee80211CipherSuite::Ccmp128:
         return Dot11CipherSuite::Dot11CipherSuiteCcmp128;
-    case IeeeCipherSuite::Ccmp256:
+    case Ieee80211CipherSuite::Ccmp256:
         return Dot11CipherSuite::Dot11CipherSuiteCcmp256;
-    case IeeeCipherSuite::Gcmp128:
+    case Ieee80211CipherSuite::Gcmp128:
         return Dot11CipherSuite::Dot11CipherSuiteGcmp128;
-    case IeeeCipherSuite::Gcmp256:
+    case Ieee80211CipherSuite::Gcmp256:
         return Dot11CipherSuite::Dot11CipherSuiteGcmp256;
-    case IeeeCipherSuite::GroupAddressesTrafficNotAllowed:
+    case Ieee80211CipherSuite::GroupAddressesTrafficNotAllowed:
         return Dot11CipherSuite::Dot11CipherSuiteGroupAddressesTrafficNotAllowed;
-    case IeeeCipherSuite::Tkip:
+    case Ieee80211CipherSuite::Tkip:
         return Dot11CipherSuite::Dot11CipherSuiteTkip;
-    case IeeeCipherSuite::UseGroup:
+    case Ieee80211CipherSuite::UseGroup:
         return Dot11CipherSuite::Dot11CipherSuiteUseGroup;
-    case IeeeCipherSuite::Wep104:
+    case Ieee80211CipherSuite::Wep104:
         return Dot11CipherSuite::Dot11CipherSuiteWep104;
-    case IeeeCipherSuite::Wep40:
+    case Ieee80211CipherSuite::Wep40:
         return Dot11CipherSuite::Dot11CipherSuiteWep40;
     }
 

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -127,6 +127,85 @@ IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm(Microsoft::Net::Wi
     return authenticationAlgorithm;
 }
 
+Microsoft::Net::Wifi::Dot11AkmSuite
+IeeeAkmSuiteToNetRemoteAkm(Microsoft::Net::Wifi::IeeeAkmSuite akmSuite)
+{
+    using Microsoft::Net::Wifi::Dot11AkmSuite;
+    using Microsoft::Net::Wifi::IeeeAkmSuite;
+
+    Dot11AkmSuite akm{ Dot11AkmSuite::Dot11AkmSuiteUnknown };
+
+    switch (akmSuite) {
+    case IeeeAkmSuite::Reserved0:
+        akm = Dot11AkmSuite::Dot11AkmSuiteReserved0;
+        break;
+    case IeeeAkmSuite::Ieee8021x:
+        akm = Dot11AkmSuite::Dot11AkmSuite8021x;
+        break;
+    case IeeeAkmSuite::Psk:
+        akm = Dot11AkmSuite::Dot11AkmSuitePsk;
+        break;
+    case IeeeAkmSuite::Ft8021x:
+        akm = Dot11AkmSuite::Dot11AkmSuiteFt8021x;
+        break;
+    case IeeeAkmSuite::FtPsk:
+        akm = Dot11AkmSuite::Dot11AkmSuiteFtPsk;
+        break;
+    case IeeeAkmSuite::Ieee8021xSha256:
+        akm = Dot11AkmSuite::Dot11AkmSuite8021xSha256;
+        break;
+    case IeeeAkmSuite::PskSha256:
+        akm = Dot11AkmSuite::Dot11AkmSuitePskSha256;
+        break;
+    case IeeeAkmSuite::Tdls:
+        akm = Dot11AkmSuite::Dot11AkmSuiteTdls;
+        break;
+    case IeeeAkmSuite::Sae:
+        akm = Dot11AkmSuite::Dot11AkmSuiteSae;
+        break;
+    case IeeeAkmSuite::FtSae:
+        akm = Dot11AkmSuite::Dot11AkmSuiteFtSae;
+        break;
+    case IeeeAkmSuite::ApPeerKey:
+        akm = Dot11AkmSuite::Dot11AkmSuiteApPeerKey;
+        break;
+    case IeeeAkmSuite::Ieee8021xSuiteB:
+        akm = Dot11AkmSuite::Dot11AkmSuite8021xSuiteB;
+        break;
+    case IeeeAkmSuite::Ieee8011xSuiteB192:
+        akm = Dot11AkmSuite::Dot11AkmSuite8021xSuiteB192;
+        break;
+    case IeeeAkmSuite::Ft8021xSha384:
+        akm = Dot11AkmSuite::Dot11AkmSuiteFt8021xSha384;
+        break;
+    case IeeeAkmSuite::FilsSha256:
+        akm = Dot11AkmSuite::Dot11AkmSuiteFilsSha256;
+        break;
+    case IeeeAkmSuite::FilsSha284:
+        akm = Dot11AkmSuite::Dot11AkmSuiteFilsSha384;
+        break;
+    case IeeeAkmSuite::FtFilsSha256:
+        akm = Dot11AkmSuite::Dot11AkmSuiteFtFilsSha256;
+        break;
+    case IeeeAkmSuite::FtFilsSha384:
+        akm = Dot11AkmSuite::Dot11AkmSuiteFtFilsSha384;
+        break;
+    case IeeeAkmSuite::Owe:
+        akm = Dot11AkmSuite::Dot11AkmSuiteOwe;
+        break;
+    case IeeeAkmSuite::FtPskSha384:
+        akm = Dot11AkmSuite::Dot11AkmSuiteFtPskSha384;
+        break;
+    case IeeeAkmSuite::PskSha384:
+        akm = Dot11AkmSuite::Dot11AkmSuitePskSha384;
+        break;
+    default:
+        break;
+    }
+    
+    return akm;
+}
+
 Microsoft::Net::Wifi::Dot11CipherSuite
 IeeeCipherAlgorithmToNetRemoteCipherSuite(Microsoft::Net::Wifi::IeeeCipherSuite ieeeCipherSuite)
 {

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -127,54 +127,62 @@ IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm(Microsoft::Net::Wi
     return authenticationAlgorithm;
 }
 
-Microsoft::Net::Wifi::Dot11CipherAlgorithm
-IeeeCipherAlgorithmToNetRemoteCipherAlgorithm(Microsoft::Net::Wifi::IeeeCipherSuite ieeeCipherSuite)
+Microsoft::Net::Wifi::Dot11CipherSuite
+IeeeCipherAlgorithmToNetRemoteCipherSuite(Microsoft::Net::Wifi::IeeeCipherSuite ieeeCipherSuite)
 {
-    using Microsoft::Net::Wifi::Dot11CipherAlgorithm;
+    using Microsoft::Net::Wifi::Dot11CipherSuite;
     using Microsoft::Net::Wifi::IeeeCipherSuite;
 
-    Dot11CipherAlgorithm cipherAlgorithm{ Dot11CipherAlgorithm::Dot11CipherAlgorithmUnknown };
+    Dot11CipherSuite cipherSuite{ Dot11CipherSuite::Dot11CipherSuiteUnknown };
 
     switch (ieeeCipherSuite) {
     case IeeeCipherSuite::Unknown:
-        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmNone;
-        break;
-    case IeeeCipherSuite::Wep40:
-        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmWep40;
-        break;
-    case IeeeCipherSuite::Tkip:
-        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmTkip;
-        break;
-    // case IeeeCipherSuite::Ccmp128: // FIXME
-    case IeeeCipherSuite::Wep104:
-        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmWep104;
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteUnknown;
         break;
     case IeeeCipherSuite::BipCmac128:
-        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmBipCmac128;
-        break;
-    case IeeeCipherSuite::Gcmp128:
-        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmGcmp128;
-        break;
-    case IeeeCipherSuite::Gcmp256:
-        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmGcmp256;
-        break;
-    case IeeeCipherSuite::Ccmp256:
-        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmCcmp256;
-        break;
-    case IeeeCipherSuite::BipGmac128:
-        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmBipGmac128;
-        break;
-    case IeeeCipherSuite::BipGmac256:
-        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmBipGmac256;
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteBipCmac128;
         break;
     case IeeeCipherSuite::BipCmac256:
-        cipherAlgorithm = Dot11CipherAlgorithm::Dot11CipherAlgorithmBipCmac256;
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteBipCmac256;
+        break;
+    case IeeeCipherSuite::BipGmac128:
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteBipGmac128;
+        break;
+    case IeeeCipherSuite::BipGmac256:
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteBipGmac256;
+        break;
+    case IeeeCipherSuite::Ccmp128:
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteCcmp128;
+        break;
+    case IeeeCipherSuite::Ccmp256:
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteCcmp256;
+        break;
+    case IeeeCipherSuite::Gcmp128:
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteGcmp128;
+        break;
+    case IeeeCipherSuite::Gcmp256:
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteGcmp256;
+        break;
+    case IeeeCipherSuite::GroupAddressesTrafficNotAllowed:
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteGroupAddressesTrafficNotAllowed;
+        break;
+    case IeeeCipherSuite::Tkip:
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteTkip;
+        break;
+    case IeeeCipherSuite::UseGroup:
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteUseGroup;
+        break;
+    case IeeeCipherSuite::Wep104:
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteWep104;
+        break;
+    case IeeeCipherSuite::Wep40:
+        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteWep40;
         break;
     default:
         break;
     }
 
-    return cipherAlgorithm;
+    return cipherSuite;
 }
 
 Microsoft::Net::Wifi::AccessPointCapabilities
@@ -209,12 +217,12 @@ IeeeAccessPointCapabilitiesToNetRemoteAccessPointCapabilities(const Microsoft::N
         std::make_move_iterator(std::end(authenticationAlgorithms))
     };
 
-    std::vector<Microsoft::Net::Wifi::Dot11CipherAlgorithm> encryptionAlgorithms(std::size(ieeeCapabilities.EncryptionAlgorithms));
-    std::ranges::transform(ieeeCapabilities.EncryptionAlgorithms, std::begin(encryptionAlgorithms), IeeeCipherAlgorithmToNetRemoteCipherAlgorithm);
+    std::vector<Microsoft::Net::Wifi::Dot11CipherSuite> cipherSuites(std::size(ieeeCapabilities.CipherSuites));
+    std::ranges::transform(ieeeCapabilities.CipherSuites, std::begin(cipherSuites), IeeeCipherAlgorithmToNetRemoteCipherSuite);
 
-    *capabilities.mutable_encryptionalgorithms() = {
-        std::make_move_iterator(std::begin(encryptionAlgorithms)),
-        std::make_move_iterator(std::end(encryptionAlgorithms))
+    *capabilities.mutable_ciphersuites() = {
+        std::make_move_iterator(std::begin(cipherSuites)),
+        std::make_move_iterator(std::end(cipherSuites))
     };
 
     return capabilities;
@@ -327,7 +335,7 @@ NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerConte
 using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus;
 using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode;
 using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
-using Microsoft::Net::Wifi::Dot11CipherAlgorithm;
+using Microsoft::Net::Wifi::Dot11CipherSuite;
 using Microsoft::Net::Wifi::Dot11PhyType;
 
 ::grpc::Status
@@ -391,9 +399,9 @@ NetRemoteService::ValidateWifiAccessPointEnableRequest(const ::Microsoft::Net::R
         status.set_message("No authentication algorithm provided");
         return false;
     }
-    if (configuration.encryptionalgorithm() == Dot11CipherAlgorithm::Dot11CipherAlgorithmUnknown) {
+    if (configuration.ciphersuite() == Dot11CipherSuite::Dot11CipherSuiteUnknown) {
         status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
-        status.set_message("No encryption algorithm provided");
+        status.set_message("No cipher suite provided");
         return false;
     }
     if (std::empty(configuration.bands())) {

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -28,249 +28,178 @@ NetRemoteService::GetAccessPointManager() noexcept
 
 namespace detail
 {
-Microsoft::Net::Wifi::Dot11PhyType
-IeeeProtocolToNetRemotePhyType(Microsoft::Net::Wifi::IeeeProtocol ieeeProtocol)
+using Microsoft::Net::Wifi::Dot11PhyType;
+using Microsoft::Net::Wifi::IeeeProtocol;
+
+Dot11PhyType
+IeeeProtocolToNetRemotePhyType(IeeeProtocol ieeeProtocol)
 {
-    using Microsoft::Net::Wifi::Dot11PhyType;
-    using Microsoft::Net::Wifi::IeeeProtocol;
-
-    Dot11PhyType phyType{ Dot11PhyType::Dot11PhyTypeUnknown };
-
     switch (ieeeProtocol) {
+    case IeeeProtocol::Unknown:
+        return Dot11PhyType::Dot11PhyTypeUnknown;
     case IeeeProtocol::B:
-        phyType = Dot11PhyType::Dot11PhyTypeB;
-        break;
+        return Dot11PhyType::Dot11PhyTypeB;
     case IeeeProtocol::G:
-        phyType = Dot11PhyType::Dot11PhyTypeG;
-        break;
+        return Dot11PhyType::Dot11PhyTypeG;
     case IeeeProtocol::N:
-        phyType = Dot11PhyType::Dot11PhyTypeN;
-        break;
+        return Dot11PhyType::Dot11PhyTypeN;
     case IeeeProtocol::A:
-        phyType = Dot11PhyType::Dot11PhyTypeA;
-        break;
+        return Dot11PhyType::Dot11PhyTypeA;
     case IeeeProtocol::AC:
-        phyType = Dot11PhyType::Dot11PhyTypeAC;
-        break;
+        return Dot11PhyType::Dot11PhyTypeAC;
     case IeeeProtocol::AD:
-        phyType = Dot11PhyType::Dot11PhyTypeAD;
-        break;
+        return Dot11PhyType::Dot11PhyTypeAD;
     case IeeeProtocol::AX:
-        phyType = Dot11PhyType::Dot11PhyTypeAX;
-        break;
+        return Dot11PhyType::Dot11PhyTypeAX;
     case IeeeProtocol::BE:
-        phyType = Dot11PhyType::Dot11PhyTypeBE;
-        break;
-    default:
-        break;
+        return Dot11PhyType::Dot11PhyTypeBE;
     }
 
-    return phyType;
+    return Dot11PhyType::Dot11PhyTypeUnknown;
 }
 
-Microsoft::Net::Wifi::RadioBand
-IeeeFrequencyBandToNetRemoteRadioBand(Microsoft::Net::Wifi::IeeeFrequencyBand ieeeFrequencyBand)
+using Microsoft::Net::Wifi::IeeeFrequencyBand;
+using Microsoft::Net::Wifi::RadioBand;
+
+RadioBand
+IeeeFrequencyBandToNetRemoteRadioBand(IeeeFrequencyBand ieeeFrequencyBand)
 {
-    using Microsoft::Net::Wifi::IeeeFrequencyBand;
-    using Microsoft::Net::Wifi::RadioBand;
-
-    RadioBand band{ RadioBand::RadioBandUnknown };
-
     switch (ieeeFrequencyBand) {
+    case IeeeFrequencyBand::Unknown:
+        return RadioBand::RadioBandUnknown;
     case IeeeFrequencyBand::TwoPointFourGHz:
-        band = RadioBand::RadioBandTwoPoint4GHz;
-        break;
+        return RadioBand::RadioBandTwoPoint4GHz;
     case IeeeFrequencyBand::FiveGHz:
-        band = RadioBand::RadioBandFiveGHz;
-        break;
+        return RadioBand::RadioBandFiveGHz;
     case IeeeFrequencyBand::SixGHz:
-        band = RadioBand::RadioBandSixGHz;
-        break;
-    default:
-        break;
+        return RadioBand::RadioBandSixGHz;
     }
 
-    return band;
+    return RadioBand::RadioBandUnknown;
 }
 
-Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm
-IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm(Microsoft::Net::Wifi::IeeeAuthenticationAlgorithm ieeeAuthenticationAlgorithm)
+using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
+using Microsoft::Net::Wifi::IeeeAuthenticationAlgorithm;
+
+Dot11AuthenticationAlgorithm
+IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm(IeeeAuthenticationAlgorithm ieeeAuthenticationAlgorithm)
 {
-    using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
-    using Microsoft::Net::Wifi::IeeeAuthenticationAlgorithm;
-
-    Dot11AuthenticationAlgorithm authenticationAlgorithm{ Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmUnknown };
-
     switch (ieeeAuthenticationAlgorithm) {
     case IeeeAuthenticationAlgorithm::Unknown:
-        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmUnknown;
-        break;
+        return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmUnknown;
     case IeeeAuthenticationAlgorithm::OpenSystem:
-        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmOpenSystem;
-        break;
+        return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmOpenSystem;
     case IeeeAuthenticationAlgorithm::SharedKey:
-        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey;
-        break;
+        return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey;
     case IeeeAuthenticationAlgorithm::FastBssTransition:
-        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFastBssTransition;
-        break;
+        return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFastBssTransition;
     case IeeeAuthenticationAlgorithm::Sae:
-        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSae;
-        break;
+        return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSae;
     case IeeeAuthenticationAlgorithm::Fils:
-        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFils;
-        break;
+        return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFils;
     case IeeeAuthenticationAlgorithm::FilsPfs:
-        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFilsPfs;
-        break;
+        return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFilsPfs;
     case IeeeAuthenticationAlgorithm::FilsPublicKey:
-        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFilsPublicKey;
-        break;
+        return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFilsPublicKey;
     case IeeeAuthenticationAlgorithm::VendorSpecific:
-        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmVendorSpecific;
-        break;
-    default:
-        break;
+        return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmVendorSpecific;
     }
 
-    return authenticationAlgorithm;
+    return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmUnknown;
 }
 
-Microsoft::Net::Wifi::Dot11AkmSuite
-IeeeAkmSuiteToNetRemoteAkm(Microsoft::Net::Wifi::IeeeAkmSuite akmSuite)
+using Microsoft::Net::Wifi::Dot11AkmSuite;
+using Microsoft::Net::Wifi::IeeeAkmSuite;
+
+Dot11AkmSuite
+IeeeAkmSuiteToNetRemoteAkm(IeeeAkmSuite akmSuite)
 {
-    using Microsoft::Net::Wifi::Dot11AkmSuite;
-    using Microsoft::Net::Wifi::IeeeAkmSuite;
-
-    Dot11AkmSuite akm{ Dot11AkmSuite::Dot11AkmSuiteUnknown };
-
     switch (akmSuite) {
     case IeeeAkmSuite::Reserved0:
-        akm = Dot11AkmSuite::Dot11AkmSuiteReserved0;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteReserved0;
     case IeeeAkmSuite::Ieee8021x:
-        akm = Dot11AkmSuite::Dot11AkmSuite8021x;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuite8021x;
     case IeeeAkmSuite::Psk:
-        akm = Dot11AkmSuite::Dot11AkmSuitePsk;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuitePsk;
     case IeeeAkmSuite::Ft8021x:
-        akm = Dot11AkmSuite::Dot11AkmSuiteFt8021x;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteFt8021x;
     case IeeeAkmSuite::FtPsk:
-        akm = Dot11AkmSuite::Dot11AkmSuiteFtPsk;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteFtPsk;
     case IeeeAkmSuite::Ieee8021xSha256:
-        akm = Dot11AkmSuite::Dot11AkmSuite8021xSha256;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuite8021xSha256;
     case IeeeAkmSuite::PskSha256:
-        akm = Dot11AkmSuite::Dot11AkmSuitePskSha256;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuitePskSha256;
     case IeeeAkmSuite::Tdls:
-        akm = Dot11AkmSuite::Dot11AkmSuiteTdls;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteTdls;
     case IeeeAkmSuite::Sae:
-        akm = Dot11AkmSuite::Dot11AkmSuiteSae;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteSae;
     case IeeeAkmSuite::FtSae:
-        akm = Dot11AkmSuite::Dot11AkmSuiteFtSae;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteFtSae;
     case IeeeAkmSuite::ApPeerKey:
-        akm = Dot11AkmSuite::Dot11AkmSuiteApPeerKey;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteApPeerKey;
     case IeeeAkmSuite::Ieee8021xSuiteB:
-        akm = Dot11AkmSuite::Dot11AkmSuite8021xSuiteB;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuite8021xSuiteB;
     case IeeeAkmSuite::Ieee8011xSuiteB192:
-        akm = Dot11AkmSuite::Dot11AkmSuite8021xSuiteB192;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuite8021xSuiteB192;
     case IeeeAkmSuite::Ft8021xSha384:
-        akm = Dot11AkmSuite::Dot11AkmSuiteFt8021xSha384;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteFt8021xSha384;
     case IeeeAkmSuite::FilsSha256:
-        akm = Dot11AkmSuite::Dot11AkmSuiteFilsSha256;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteFilsSha256;
     case IeeeAkmSuite::FilsSha284:
-        akm = Dot11AkmSuite::Dot11AkmSuiteFilsSha384;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteFilsSha384;
     case IeeeAkmSuite::FtFilsSha256:
-        akm = Dot11AkmSuite::Dot11AkmSuiteFtFilsSha256;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteFtFilsSha256;
     case IeeeAkmSuite::FtFilsSha384:
-        akm = Dot11AkmSuite::Dot11AkmSuiteFtFilsSha384;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteFtFilsSha384;
     case IeeeAkmSuite::Owe:
-        akm = Dot11AkmSuite::Dot11AkmSuiteOwe;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteOwe;
     case IeeeAkmSuite::FtPskSha384:
-        akm = Dot11AkmSuite::Dot11AkmSuiteFtPskSha384;
-        break;
+        return Dot11AkmSuite::Dot11AkmSuiteFtPskSha384;
     case IeeeAkmSuite::PskSha384:
-        akm = Dot11AkmSuite::Dot11AkmSuitePskSha384;
-        break;
-    default:
-        break;
+        return Dot11AkmSuite::Dot11AkmSuitePskSha384;
     }
 
-    return akm;
+    return Dot11AkmSuite::Dot11AkmSuiteUnknown;
 }
 
-Microsoft::Net::Wifi::Dot11CipherSuite
-IeeeCipherAlgorithmToNetRemoteCipherSuite(Microsoft::Net::Wifi::IeeeCipherSuite ieeeCipherSuite)
+using Microsoft::Net::Wifi::Dot11CipherSuite;
+using Microsoft::Net::Wifi::IeeeCipherSuite;
+
+Dot11CipherSuite
+IeeeCipherAlgorithmToNetRemoteCipherSuite(IeeeCipherSuite ieeeCipherSuite)
 {
-    using Microsoft::Net::Wifi::Dot11CipherSuite;
-    using Microsoft::Net::Wifi::IeeeCipherSuite;
-
-    Dot11CipherSuite cipherSuite{ Dot11CipherSuite::Dot11CipherSuiteUnknown };
-
     switch (ieeeCipherSuite) {
     case IeeeCipherSuite::Unknown:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteUnknown;
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteUnknown;
     case IeeeCipherSuite::BipCmac128:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteBipCmac128;
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteBipCmac128;
     case IeeeCipherSuite::BipCmac256:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteBipCmac256;
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteBipCmac256;
     case IeeeCipherSuite::BipGmac128:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteBipGmac128;
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteBipGmac128;
     case IeeeCipherSuite::BipGmac256:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteBipGmac256;
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteBipGmac256;
     case IeeeCipherSuite::Ccmp128:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteCcmp128;
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteCcmp128;
     case IeeeCipherSuite::Ccmp256:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteCcmp256;
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteCcmp256;
     case IeeeCipherSuite::Gcmp128:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteGcmp128;
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteGcmp128;
     case IeeeCipherSuite::Gcmp256:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteGcmp256;
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteGcmp256;
     case IeeeCipherSuite::GroupAddressesTrafficNotAllowed:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteGroupAddressesTrafficNotAllowed;
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteGroupAddressesTrafficNotAllowed;
     case IeeeCipherSuite::Tkip:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteTkip;
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteTkip;
     case IeeeCipherSuite::UseGroup:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteUseGroup;
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteUseGroup;
     case IeeeCipherSuite::Wep104:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteWep104;
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteWep104;
     case IeeeCipherSuite::Wep40:
-        cipherSuite = Dot11CipherSuite::Dot11CipherSuiteWep40;
-        break;
-    default:
-        break;
+        return Dot11CipherSuite::Dot11CipherSuiteWep40;
     }
 
-    return cipherSuite;
+    return Dot11CipherSuite::Dot11CipherSuiteUnknown;
 }
 
 Microsoft::Net::Wifi::AccessPointCapabilities

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -102,24 +102,33 @@ IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm(Microsoft::Net::Wi
     Dot11AuthenticationAlgorithm authenticationAlgorithm{ Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmUnknown };
 
     switch (ieeeAuthenticationAlgorithm) {
+    case IeeeAuthenticationAlgorithm::Unknown:
+        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmUnknown;
+        break;
     case IeeeAuthenticationAlgorithm::OpenSystem:
-        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmOpen;
+        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmOpenSystem;
         break;
     case IeeeAuthenticationAlgorithm::SharedKey:
         authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey;
         break;
+    case IeeeAuthenticationAlgorithm::FastBssTransition:
+        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFastBssTransition;
+        break;
     case IeeeAuthenticationAlgorithm::Sae:
         authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSae;
         break;
-    // The following cases do not map to Dot11AuthenticationAlgorithm types. This appears to be because the Microsoft
-    // authentication algorithm definitions do not map 1-1 with the 802.11 definitions. Instead, they more resemble an
-    // 802.11 AKM. Fixing this requires a breaking API change, so will be deferred.
-    //
-    // case IeeeAuthenticationAlgorithm::FastBssTransition:
-    // case IeeeAuthenticationAlgorithm::Fils:
-    // case IeeeAuthenticationAlgorithm::FilsPfs:
-    // case IeeeAuthenticationAlgorithm::FilsPublicKey:
-    //
+    case IeeeAuthenticationAlgorithm::Fils:
+        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFils;
+        break;
+    case IeeeAuthenticationAlgorithm::FilsPfs:
+        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFilsPfs;
+        break;
+    case IeeeAuthenticationAlgorithm::FilsPublicKey:
+        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmFilsPublicKey;
+        break;
+    case IeeeAuthenticationAlgorithm::VendorSpecific:
+        authenticationAlgorithm = Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmVendorSpecific;
+        break;
     default:
         break;
     }
@@ -202,7 +211,7 @@ IeeeAkmSuiteToNetRemoteAkm(Microsoft::Net::Wifi::IeeeAkmSuite akmSuite)
     default:
         break;
     }
-    
+
     return akm;
 }
 

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -202,13 +202,13 @@ IeeeCipherAlgorithmToNetRemoteCipherSuite(IeeeCipherSuite ieeeCipherSuite)
     return Dot11CipherSuite::Dot11CipherSuiteUnknown;
 }
 
-Microsoft::Net::Wifi::AccessPointCapabilities
+Microsoft::Net::Wifi::Dot11AccessPointCapabilities
 IeeeAccessPointCapabilitiesToNetRemoteAccessPointCapabilities(const Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities& ieeeCapabilities)
 {
-    using Microsoft::Net::Wifi::AccessPointCapabilities;
+    using Microsoft::Net::Wifi::Dot11AccessPointCapabilities;
     using Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities;
 
-    AccessPointCapabilities capabilities{};
+    Dot11AccessPointCapabilities capabilities{};
 
     std::vector<Microsoft::Net::Wifi::Dot11PhyType> phyTypes(std::size(ieeeCapabilities.Protocols));
     std::ranges::transform(ieeeCapabilities.Protocols, std::begin(phyTypes), IeeeProtocolToNetRemotePhyType);
@@ -246,7 +246,7 @@ IeeeAccessPointCapabilitiesToNetRemoteAccessPointCapabilities(const Microsoft::N
 }
 
 using Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResultItem;
-using Microsoft::Net::Wifi::AccessPointCapabilities;
+using Microsoft::Net::Wifi::Dot11AccessPointCapabilities;
 
 static constexpr auto AccessPointIdInvalid{ "invalid" };
 
@@ -265,7 +265,7 @@ IAccessPointToNetRemoteAccessPointResultItem(IAccessPoint& accessPoint)
 
     bool isEnabled{ false };
     std::string id{};
-    Microsoft::Net::Wifi::AccessPointCapabilities capabilities{};
+    Microsoft::Net::Wifi::Dot11AccessPointCapabilities capabilities{};
 
     auto interfaceName = accessPoint.GetInterfaceName();
     id.assign(std::cbegin(interfaceName), std::cend(interfaceName));

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -58,24 +58,24 @@ IeeeProtocolToNetRemotePhyType(IeeeProtocol ieeeProtocol)
     return Dot11PhyType::Dot11PhyTypeUnknown;
 }
 
-using Microsoft::Net::Wifi::IeeeFrequencyBand;
-using Microsoft::Net::Wifi::RadioBand;
+using Microsoft::Net::Wifi::IeeeDot11FrequencyBand;
+using Microsoft::Net::Wifi::Dot11FrequencyBand;
 
-RadioBand
-IeeeFrequencyBandToNetRemoteRadioBand(IeeeFrequencyBand ieeeFrequencyBand)
+Dot11FrequencyBand
+IeeeDot11FrequencyBandToNetRemoteDot11FrequencyBand(IeeeDot11FrequencyBand ieeeDot11FrequencyBand)
 {
-    switch (ieeeFrequencyBand) {
-    case IeeeFrequencyBand::Unknown:
-        return RadioBand::RadioBandUnknown;
-    case IeeeFrequencyBand::TwoPointFourGHz:
-        return RadioBand::RadioBandTwoPoint4GHz;
-    case IeeeFrequencyBand::FiveGHz:
-        return RadioBand::RadioBandFiveGHz;
-    case IeeeFrequencyBand::SixGHz:
-        return RadioBand::RadioBandSixGHz;
+    switch (ieeeDot11FrequencyBand) {
+    case IeeeDot11FrequencyBand::Unknown:
+        return Dot11FrequencyBand::Dot11FrequencyBandUnknown;
+    case IeeeDot11FrequencyBand::TwoPointFourGHz:
+        return Dot11FrequencyBand::Dot11FrequencyBandTwoPoint4GHz;
+    case IeeeDot11FrequencyBand::FiveGHz:
+        return Dot11FrequencyBand::Dot11FrequencyBandFiveGHz;
+    case IeeeDot11FrequencyBand::SixGHz:
+        return Dot11FrequencyBand::Dot11FrequencyBandSixGHz;
     }
 
-    return RadioBand::RadioBandUnknown;
+    return Dot11FrequencyBand::Dot11FrequencyBandUnknown;
 }
 
 using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
@@ -218,8 +218,8 @@ IeeeAccessPointCapabilitiesToNetRemoteAccessPointCapabilities(const Microsoft::N
         std::make_move_iterator(std::end(phyTypes))
     };
 
-    std::vector<Microsoft::Net::Wifi::RadioBand> bands(std::size(ieeeCapabilities.FrequencyBands));
-    std::ranges::transform(ieeeCapabilities.FrequencyBands, std::begin(bands), IeeeFrequencyBandToNetRemoteRadioBand);
+    std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand> bands(std::size(ieeeCapabilities.Dot11FrequencyBands));
+    std::ranges::transform(ieeeCapabilities.Dot11FrequencyBands, std::begin(bands), IeeeDot11FrequencyBandToNetRemoteDot11FrequencyBand);
 
     *capabilities.mutable_bands() = {
         std::make_move_iterator(std::begin(bands)),

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -51,7 +51,7 @@ NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::AccessPoint
     for (const auto& band : accessPointCapabilities.bands()) {
         ss << '\n'
            << indent1
-           << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::RadioBand>(band));
+           << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11FrequencyBand>(band));
     }
 
     ss << '\n'

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -22,7 +22,7 @@ NetRemoteCliHandlerOperations::NetRemoteCliHandlerOperations(std::shared_ptr<Net
 namespace detail
 {
 /**
- * @brief Generate a string representation of a AccessPointCapabilities object.
+ * @brief Generate a string representation of a Dot11AccessPointCapabilities object.
  * 
  * @param accessPointCapabilities The object to generate a string representation of.
  * @param indentationLevel The indentation level to use.
@@ -30,7 +30,7 @@ namespace detail
  * @return std::string 
  */
 std::string
-NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::AccessPointCapabilities& accessPointCapabilities, std::size_t indentationLevel = 1, std::size_t indentation = 2)
+NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::Dot11AccessPointCapabilities& accessPointCapabilities, std::size_t indentationLevel = 1, std::size_t indentation = 2)
 {
     const auto indent0 = std::string((indentationLevel + 0) * indentation, ' ');
     const auto indent1 = std::string((indentationLevel + 1) * indentation, ' ');

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -66,10 +66,10 @@ NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::AccessPoint
     ss << '\n'
        << indent0
        << "Cipher Algorithms:";
-    for (const auto& ciperAlgorithm : accessPointCapabilities.encryptionalgorithms()) {
+    for (const auto& ciperSuite : accessPointCapabilities.ciphersuites()) {
         ss << '\n'
            << indent1
-           << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11CipherAlgorithm>(ciperAlgorithm));
+           << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11CipherSuite>(ciperSuite));
     }
 
     return ss.str();

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -7,7 +7,7 @@
 
 namespace Microsoft::Net::Wifi
 {
-enum class IeeeDot11FrequencyBand {
+enum class Ieee80211FrequencyBand {
     Unknown,
     TwoPointFourGHz,
     FiveGHz,
@@ -21,7 +21,7 @@ namespace Literals
  * @brief User-defined literal operator for allowing use of _GHz to specify
  * frequency band enumeration values.
  */
-inline constexpr Microsoft::Net::Wifi::IeeeDot11FrequencyBand
+inline constexpr Microsoft::Net::Wifi::Ieee80211FrequencyBand
 operator"" _GHz(long double value) noexcept
 {
     /**
@@ -39,13 +39,13 @@ operator"" _GHz(long double value) noexcept
     constexpr auto TwoPointFourGHzTolerance = 8.89045781438113635886e-17L;
 
     if (std::fabs(value - 2.4) <= TwoPointFourGHzTolerance) {
-        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::TwoPointFourGHz;
+        return Microsoft::Net::Wifi::Ieee80211FrequencyBand::TwoPointFourGHz;
     } else if (value == 5.0) {
-        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::FiveGHz;
+        return Microsoft::Net::Wifi::Ieee80211FrequencyBand::FiveGHz;
     } else if (value == 6.0) {
-        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::SixGHz;
+        return Microsoft::Net::Wifi::Ieee80211FrequencyBand::SixGHz;
     } else {
-        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::Unknown;
+        return Microsoft::Net::Wifi::Ieee80211FrequencyBand::Unknown;
     }
 }
 
@@ -55,22 +55,22 @@ operator"" _GHz(long double value) noexcept
  * @brief User-defined literal operator for allowing use of _MHz to specify
  * frequency band enumeration values.
  */
-inline constexpr Microsoft::Net::Wifi::IeeeDot11FrequencyBand
+inline constexpr Microsoft::Net::Wifi::Ieee80211FrequencyBand
 operator"" _MHz(unsigned long long int value) noexcept
 {
     if (value == 2400) {
-        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::TwoPointFourGHz;
+        return Microsoft::Net::Wifi::Ieee80211FrequencyBand::TwoPointFourGHz;
     } else if (value == 5000) {
-        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::FiveGHz;
+        return Microsoft::Net::Wifi::Ieee80211FrequencyBand::FiveGHz;
     } else if (value == 6000) {
-        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::SixGHz;
+        return Microsoft::Net::Wifi::Ieee80211FrequencyBand::SixGHz;
     } else {
-        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::Unknown;
+        return Microsoft::Net::Wifi::Ieee80211FrequencyBand::Unknown;
     }
 }
 } // namespace Literals
 
-enum class IeeeProtocol {
+enum class Ieee80211Protocol {
     Unknown,
     B,
     G,
@@ -127,7 +127,7 @@ MakeIeee80211Suite(uint8_t suiteId)
  *
  * Defined in IEEE 802.11-2020, Section 9.4.1.1, Figure 9-82.
  */
-enum class IeeeAuthenticationAlgorithm : uint16_t {
+enum class Ieee80211AuthenticationAlgorithm : uint16_t {
     Unknown = 0x0000,
     OpenSystem = 0x0001,
     SharedKey = 0x0002,
@@ -144,55 +144,55 @@ enum class IeeeAuthenticationAlgorithm : uint16_t {
  *
  * Defined in IEEE 802.11-2020, Section 9.4.2.24.3, Table 9-151.
  */
-static constexpr uint8_t IeeeAkmSuiteIdReserved0 = 0;
-static constexpr uint8_t IeeeAkmSuiteId8021x = 1;
-static constexpr uint8_t IeeeAkmSuiteIdPsk = 2;
-static constexpr uint8_t IeeeAkmSuiteIdFt8021x = 3;
-static constexpr uint8_t IeeeAkmSuiteIdFtPsk = 4;
-static constexpr uint8_t IeeeAkmSuiteId8021xSha256 = 5;
-static constexpr uint8_t IeeeAkmSuiteIdPskSha256 = 6;
-static constexpr uint8_t IeeeAkmSuiteIdTdls = 7;
-static constexpr uint8_t IeeeAkmSuiteIdSae = 8;
-static constexpr uint8_t IeeeAkmSuiteIdFtSae = 9;
-static constexpr uint8_t IeeeAkmSuiteIdApPeerKey = 10;
-static constexpr uint8_t IeeeAkmSuiteId8021xSuiteB = 11;
-static constexpr uint8_t IeeeAkmSuiteId8021xSuiteB192 = 12;
-static constexpr uint8_t IeeeAkmSuiteIdFt8021xSha384 = 13;
-static constexpr uint8_t IeeeAkmSuiteIdFilsSha256 = 14;
-static constexpr uint8_t IeeeAkmSuiteIdFilsSha384 = 15;
-static constexpr uint8_t IeeeAkmSuiteIdFtFilsSha256 = 16;
-static constexpr uint8_t IeeeAkmSuiteIdFtFilsSha384 = 17;
-static constexpr uint8_t IeeeAkmSuiteIdOwe = 18;
-static constexpr uint8_t IeeeAkmSuiteIdFtPskSha384 = 19;
-static constexpr uint8_t IeeeAkmSuiteIdPskSha384 = 20;
+static constexpr uint8_t Ieee80211AkmSuiteIdReserved0 = 0;
+static constexpr uint8_t Ieee80211AkmSuiteId8021x = 1;
+static constexpr uint8_t Ieee80211AkmSuiteIdPsk = 2;
+static constexpr uint8_t Ieee80211AkmSuiteIdFt8021x = 3;
+static constexpr uint8_t Ieee80211AkmSuiteIdFtPsk = 4;
+static constexpr uint8_t Ieee80211AkmSuiteId8021xSha256 = 5;
+static constexpr uint8_t Ieee80211AkmSuiteIdPskSha256 = 6;
+static constexpr uint8_t Ieee80211AkmSuiteIdTdls = 7;
+static constexpr uint8_t Ieee80211AkmSuiteIdSae = 8;
+static constexpr uint8_t Ieee80211AkmSuiteIdFtSae = 9;
+static constexpr uint8_t Ieee80211AkmSuiteIdApPeerKey = 10;
+static constexpr uint8_t Ieee80211AkmSuiteId8021xSuiteB = 11;
+static constexpr uint8_t Ieee80211AkmSuiteId8021xSuiteB192 = 12;
+static constexpr uint8_t Ieee80211AkmSuiteIdFt8021xSha384 = 13;
+static constexpr uint8_t Ieee80211AkmSuiteIdFilsSha256 = 14;
+static constexpr uint8_t Ieee80211AkmSuiteIdFilsSha384 = 15;
+static constexpr uint8_t Ieee80211AkmSuiteIdFtFilsSha256 = 16;
+static constexpr uint8_t Ieee80211AkmSuiteIdFtFilsSha384 = 17;
+static constexpr uint8_t Ieee80211AkmSuiteIdOwe = 18;
+static constexpr uint8_t Ieee80211AkmSuiteIdFtPskSha384 = 19;
+static constexpr uint8_t Ieee80211AkmSuiteIdPskSha384 = 20;
 
 /**
  * @brief IEEE 802.11 Authentication and Key Management (AKM) Suites.
  *
  * Defined in IEEE 802.11-2020, Section 9.4.2.24.3, Table 9-151.
  */
-enum class IeeeAkmSuite : uint32_t {
-    Reserved0 = MakeIeee80211Suite(IeeeAkmSuiteIdReserved0),
-    Ieee8021x = MakeIeee80211Suite(IeeeAkmSuiteId8021x),
-    Psk = MakeIeee80211Suite(IeeeAkmSuiteIdPsk),
-    Ft8021x = MakeIeee80211Suite(IeeeAkmSuiteIdFt8021x),
-    FtPsk = MakeIeee80211Suite(IeeeAkmSuiteIdFtPsk),
-    Ieee8021xSha256 = MakeIeee80211Suite(IeeeAkmSuiteId8021xSha256),
-    PskSha256 = MakeIeee80211Suite(IeeeAkmSuiteIdPskSha256),
-    Tdls = MakeIeee80211Suite(IeeeAkmSuiteIdTdls),
-    Sae = MakeIeee80211Suite(IeeeAkmSuiteIdSae),
-    FtSae = MakeIeee80211Suite(IeeeAkmSuiteIdFtSae),
-    ApPeerKey = MakeIeee80211Suite(IeeeAkmSuiteIdApPeerKey),
-    Ieee8021xSuiteB = MakeIeee80211Suite(IeeeAkmSuiteId8021xSuiteB),
-    Ieee8011xSuiteB192 = MakeIeee80211Suite(IeeeAkmSuiteId8021xSuiteB192),
-    Ft8021xSha384 = MakeIeee80211Suite(IeeeAkmSuiteIdFt8021xSha384),
-    FilsSha256 = MakeIeee80211Suite(IeeeAkmSuiteIdFilsSha256),
-    FilsSha284 = MakeIeee80211Suite(IeeeAkmSuiteIdFilsSha384),
-    FtFilsSha256 = MakeIeee80211Suite(IeeeAkmSuiteIdFtFilsSha256),
-    FtFilsSha384 = MakeIeee80211Suite(IeeeAkmSuiteIdFtFilsSha384),
-    Owe = MakeIeee80211Suite(IeeeAkmSuiteIdOwe),
-    FtPskSha384 = MakeIeee80211Suite(IeeeAkmSuiteIdFtPskSha384),
-    PskSha384 = MakeIeee80211Suite(IeeeAkmSuiteIdPskSha384),
+enum class Ieee80211AkmSuite : uint32_t {
+    Reserved0 = MakeIeee80211Suite(Ieee80211AkmSuiteIdReserved0),
+    Ieee8021x = MakeIeee80211Suite(Ieee80211AkmSuiteId8021x),
+    Psk = MakeIeee80211Suite(Ieee80211AkmSuiteIdPsk),
+    Ft8021x = MakeIeee80211Suite(Ieee80211AkmSuiteIdFt8021x),
+    FtPsk = MakeIeee80211Suite(Ieee80211AkmSuiteIdFtPsk),
+    Ieee8021xSha256 = MakeIeee80211Suite(Ieee80211AkmSuiteId8021xSha256),
+    PskSha256 = MakeIeee80211Suite(Ieee80211AkmSuiteIdPskSha256),
+    Tdls = MakeIeee80211Suite(Ieee80211AkmSuiteIdTdls),
+    Sae = MakeIeee80211Suite(Ieee80211AkmSuiteIdSae),
+    FtSae = MakeIeee80211Suite(Ieee80211AkmSuiteIdFtSae),
+    ApPeerKey = MakeIeee80211Suite(Ieee80211AkmSuiteIdApPeerKey),
+    Ieee8021xSuiteB = MakeIeee80211Suite(Ieee80211AkmSuiteId8021xSuiteB),
+    Ieee8011xSuiteB192 = MakeIeee80211Suite(Ieee80211AkmSuiteId8021xSuiteB192),
+    Ft8021xSha384 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFt8021xSha384),
+    FilsSha256 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFilsSha256),
+    FilsSha284 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFilsSha384),
+    FtFilsSha256 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFtFilsSha256),
+    FtFilsSha384 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFtFilsSha384),
+    Owe = MakeIeee80211Suite(Ieee80211AkmSuiteIdOwe),
+    FtPskSha384 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFtPskSha384),
+    PskSha384 = MakeIeee80211Suite(Ieee80211AkmSuiteIdPskSha384),
 };
 
 /**
@@ -220,7 +220,7 @@ static constexpr uint8_t Ieee80211CipherSuiteIdBipCmac256 = 13;
  *
  * Defined in IEEE 802.11-2020, Section 9.4.2.24.2, Table 9-149.
  */
-enum class IeeeCipherSuite : uint32_t {
+enum class Ieee80211CipherSuite : uint32_t {
     Unknown = MakeIeeeSuite(OuiInvalid, 0),
     BipCmac128 = MakeIeee80211Suite(Ieee80211CipherSuiteIdBipCmac128),
     BipCmac256 = MakeIeee80211Suite(Ieee80211CipherSuiteIdBipCmac256),

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -128,6 +128,7 @@ MakeIeee80211Suite(uint8_t suiteId)
  * Defined in IEEE 802.11-2020, Section 9.4.1.1, Figure 9-82.
  */
 enum class IeeeAuthenticationAlgorithm : uint16_t {
+    Unknown = 0x0000,
     OpenSystem = 0x0001,
     SharedKey = 0x0002,
     FastBssTransition = 0x0003,

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -7,7 +7,7 @@
 
 namespace Microsoft::Net::Wifi
 {
-enum class IeeeFrequencyBand {
+enum class IeeeDot11FrequencyBand {
     Unknown,
     TwoPointFourGHz,
     FiveGHz,
@@ -21,7 +21,7 @@ namespace Literals
  * @brief User-defined literal operator for allowing use of _GHz to specify
  * frequency band enumeration values.
  */
-inline constexpr Microsoft::Net::Wifi::IeeeFrequencyBand
+inline constexpr Microsoft::Net::Wifi::IeeeDot11FrequencyBand
 operator"" _GHz(long double value) noexcept
 {
     /**
@@ -39,13 +39,13 @@ operator"" _GHz(long double value) noexcept
     constexpr auto TwoPointFourGHzTolerance = 8.89045781438113635886e-17L;
 
     if (std::fabs(value - 2.4) <= TwoPointFourGHzTolerance) {
-        return Microsoft::Net::Wifi::IeeeFrequencyBand::TwoPointFourGHz;
+        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::TwoPointFourGHz;
     } else if (value == 5.0) {
-        return Microsoft::Net::Wifi::IeeeFrequencyBand::FiveGHz;
+        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::FiveGHz;
     } else if (value == 6.0) {
-        return Microsoft::Net::Wifi::IeeeFrequencyBand::SixGHz;
+        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::SixGHz;
     } else {
-        return Microsoft::Net::Wifi::IeeeFrequencyBand::Unknown;
+        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::Unknown;
     }
 }
 
@@ -55,17 +55,17 @@ operator"" _GHz(long double value) noexcept
  * @brief User-defined literal operator for allowing use of _MHz to specify
  * frequency band enumeration values.
  */
-inline constexpr Microsoft::Net::Wifi::IeeeFrequencyBand
+inline constexpr Microsoft::Net::Wifi::IeeeDot11FrequencyBand
 operator"" _MHz(unsigned long long int value) noexcept
 {
     if (value == 2400) {
-        return Microsoft::Net::Wifi::IeeeFrequencyBand::TwoPointFourGHz;
+        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::TwoPointFourGHz;
     } else if (value == 5000) {
-        return Microsoft::Net::Wifi::IeeeFrequencyBand::FiveGHz;
+        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::FiveGHz;
     } else if (value == 6000) {
-        return Microsoft::Net::Wifi::IeeeFrequencyBand::SixGHz;
+        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::SixGHz;
     } else {
-        return Microsoft::Net::Wifi::IeeeFrequencyBand::Unknown;
+        return Microsoft::Net::Wifi::IeeeDot11FrequencyBand::Unknown;
     }
 }
 } // namespace Literals

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
@@ -16,7 +16,7 @@ struct Ieee80211AccessPointCapabilities
     std::vector<IeeeProtocol> Protocols;
     std::vector<IeeeFrequencyBand> FrequencyBands;
     std::vector<IeeeAuthenticationAlgorithm> AuthenticationAlgorithms;
-    std::vector<IeeeCipherSuite> EncryptionAlgorithms;
+    std::vector<IeeeCipherSuite> CipherSuites;
 };
 } // namespace Microsoft::Net::Wifi
 

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
@@ -13,10 +13,10 @@ namespace Microsoft::Net::Wifi
  */
 struct Ieee80211AccessPointCapabilities
 {
-    std::vector<IeeeProtocol> Protocols;
-    std::vector<IeeeDot11FrequencyBand> Dot11FrequencyBands;
-    std::vector<IeeeAuthenticationAlgorithm> AuthenticationAlgorithms;
-    std::vector<IeeeCipherSuite> CipherSuites;
+    std::vector<Ieee80211Protocol> Protocols;
+    std::vector<Ieee80211FrequencyBand> Dot11FrequencyBands;
+    std::vector<Ieee80211AuthenticationAlgorithm> AuthenticationAlgorithms;
+    std::vector<Ieee80211CipherSuite> CipherSuites;
 };
 } // namespace Microsoft::Net::Wifi
 

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
@@ -14,7 +14,7 @@ namespace Microsoft::Net::Wifi
 struct Ieee80211AccessPointCapabilities
 {
     std::vector<IeeeProtocol> Protocols;
-    std::vector<IeeeFrequencyBand> FrequencyBands;
+    std::vector<IeeeDot11FrequencyBand> Dot11FrequencyBands;
     std::vector<IeeeAuthenticationAlgorithm> AuthenticationAlgorithms;
     std::vector<IeeeCipherSuite> CipherSuites;
 };

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -95,8 +95,8 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
         apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
         apConfiguration.set_authenticationalgorithm(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);
         apConfiguration.set_ciphersuite(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
-        apConfiguration.mutable_bands()->Add(RadioBand::RadioBand2_4GHz);
-        apConfiguration.mutable_bands()->Add(RadioBand::RadioBand5_0GHz);
+        apConfiguration.mutable_bands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
+        apConfiguration.mutable_bands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
 
         WifiAccessPointEnableRequest request{};
         request.set_accesspointid("TestWifiAccessPointEnable");

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -90,7 +90,7 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
 
     SECTION("Can be called")
     {
-        AccessPointConfiguration apConfiguration{};
+        Dot11AccessPointConfiguration apConfiguration{};
         apConfiguration.mutable_ssid()->set_name(SsidName);
         apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
         apConfiguration.set_authenticationalgorithm(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -94,7 +94,7 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
         apConfiguration.mutable_ssid()->set_name(SsidName);
         apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
         apConfiguration.set_authenticationalgorithm(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);
-        apConfiguration.set_encryptionalgorithm(Dot11CipherAlgorithm::Dot11CipherAlgorithmCcmp256);
+        apConfiguration.set_ciphersuite(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
         apConfiguration.mutable_bands()->Add(RadioBand::RadioBand2_4GHz);
         apConfiguration.mutable_bands()->Add(RadioBand::RadioBand5_0GHz);
 

--- a/tests/unit/wifi/core/TestIeee80211.cxx
+++ b/tests/unit/wifi/core/TestIeee80211.cxx
@@ -7,22 +7,22 @@
 #include <catch2/catch_test_macros.hpp>
 
 #ifndef _MSC_VER 
-TEST_CASE("IeeeFrequencyBand GHz literals translate correctly", "[wifi][core]")
+TEST_CASE("IeeeDot11FrequencyBand GHz literals translate correctly", "[wifi][core]")
 {
     using namespace Microsoft::Net::Wifi::Literals;
 
-    using Microsoft::Net::Wifi::IeeeFrequencyBand;
+    using Microsoft::Net::Wifi::IeeeDot11FrequencyBand;
 
     SECTION("Valid literal values are correct")
     {
-        REQUIRE(2.4_GHz == IeeeFrequencyBand::TwoPointFourGHz);
-        REQUIRE(5.0_GHz == IeeeFrequencyBand::FiveGHz);
-        REQUIRE(6.0_GHz == IeeeFrequencyBand::SixGHz);
+        REQUIRE(2.4_GHz == IeeeDot11FrequencyBand::TwoPointFourGHz);
+        REQUIRE(5.0_GHz == IeeeDot11FrequencyBand::FiveGHz);
+        REQUIRE(6.0_GHz == IeeeDot11FrequencyBand::SixGHz);
     }
 
     SECTION("Invalid literal values translate to 'Unknown'")
     {
-        static constexpr std::initializer_list<IeeeFrequencyBand> InvalidBandValues{
+        static constexpr std::initializer_list<IeeeDot11FrequencyBand> InvalidBandValues{
             0.0_GHz,
             1.0_GHz,
             2.0_GHz,
@@ -44,29 +44,29 @@ TEST_CASE("IeeeFrequencyBand GHz literals translate correctly", "[wifi][core]")
         };
 
         for (const auto& invalidBand : InvalidBandValues) {
-            REQUIRE(invalidBand == IeeeFrequencyBand::Unknown);
+            REQUIRE(invalidBand == IeeeDot11FrequencyBand::Unknown);
         }
     }
 }
 
 #endif // _MSC_VER
 
-TEST_CASE("IeeeFrequencyBand MHz literals translate correctly", "[wifi][core]")
+TEST_CASE("IeeeDot11FrequencyBand MHz literals translate correctly", "[wifi][core]")
 {
     using namespace Microsoft::Net::Wifi::Literals;
 
-    using Microsoft::Net::Wifi::IeeeFrequencyBand;
+    using Microsoft::Net::Wifi::IeeeDot11FrequencyBand;
 
     SECTION("Valid literal values are correct")
     {
-        REQUIRE(2400_MHz == IeeeFrequencyBand::TwoPointFourGHz);
-        REQUIRE(5000_MHz == IeeeFrequencyBand::FiveGHz);
-        REQUIRE(6000_MHz == IeeeFrequencyBand::SixGHz);
+        REQUIRE(2400_MHz == IeeeDot11FrequencyBand::TwoPointFourGHz);
+        REQUIRE(5000_MHz == IeeeDot11FrequencyBand::FiveGHz);
+        REQUIRE(6000_MHz == IeeeDot11FrequencyBand::SixGHz);
     }
 
     SECTION("Invalid literal values translate to 'Unknown'")
     {
-        static constexpr std::initializer_list<IeeeFrequencyBand> InvalidBandValues{
+        static constexpr std::initializer_list<IeeeDot11FrequencyBand> InvalidBandValues{
             0_MHz,
             1_MHz,
             2_MHz,
@@ -84,7 +84,7 @@ TEST_CASE("IeeeFrequencyBand MHz literals translate correctly", "[wifi][core]")
         };
 
         for (const auto& invalidBand : InvalidBandValues) {
-            REQUIRE(invalidBand == IeeeFrequencyBand::Unknown);
+            REQUIRE(invalidBand == IeeeDot11FrequencyBand::Unknown);
         }
     }
 }

--- a/tests/unit/wifi/core/TestIeee80211.cxx
+++ b/tests/unit/wifi/core/TestIeee80211.cxx
@@ -11,18 +11,18 @@ TEST_CASE("IeeeDot11FrequencyBand GHz literals translate correctly", "[wifi][cor
 {
     using namespace Microsoft::Net::Wifi::Literals;
 
-    using Microsoft::Net::Wifi::IeeeDot11FrequencyBand;
+    using Microsoft::Net::Wifi::Ieee80211FrequencyBand;
 
     SECTION("Valid literal values are correct")
     {
-        REQUIRE(2.4_GHz == IeeeDot11FrequencyBand::TwoPointFourGHz);
-        REQUIRE(5.0_GHz == IeeeDot11FrequencyBand::FiveGHz);
-        REQUIRE(6.0_GHz == IeeeDot11FrequencyBand::SixGHz);
+        REQUIRE(2.4_GHz == Ieee80211FrequencyBand::TwoPointFourGHz);
+        REQUIRE(5.0_GHz == Ieee80211FrequencyBand::FiveGHz);
+        REQUIRE(6.0_GHz == Ieee80211FrequencyBand::SixGHz);
     }
 
     SECTION("Invalid literal values translate to 'Unknown'")
     {
-        static constexpr std::initializer_list<IeeeDot11FrequencyBand> InvalidBandValues{
+        static constexpr std::initializer_list<Ieee80211FrequencyBand> InvalidBandValues{
             0.0_GHz,
             1.0_GHz,
             2.0_GHz,
@@ -44,29 +44,29 @@ TEST_CASE("IeeeDot11FrequencyBand GHz literals translate correctly", "[wifi][cor
         };
 
         for (const auto& invalidBand : InvalidBandValues) {
-            REQUIRE(invalidBand == IeeeDot11FrequencyBand::Unknown);
+            REQUIRE(invalidBand == Ieee80211FrequencyBand::Unknown);
         }
     }
 }
 
 #endif // _MSC_VER
 
-TEST_CASE("IeeeDot11FrequencyBand MHz literals translate correctly", "[wifi][core]")
+TEST_CASE("Ieee80211FrequencyBand MHz literals translate correctly", "[wifi][core]")
 {
     using namespace Microsoft::Net::Wifi::Literals;
 
-    using Microsoft::Net::Wifi::IeeeDot11FrequencyBand;
+    using Microsoft::Net::Wifi::Ieee80211FrequencyBand;
 
     SECTION("Valid literal values are correct")
     {
-        REQUIRE(2400_MHz == IeeeDot11FrequencyBand::TwoPointFourGHz);
-        REQUIRE(5000_MHz == IeeeDot11FrequencyBand::FiveGHz);
-        REQUIRE(6000_MHz == IeeeDot11FrequencyBand::SixGHz);
+        REQUIRE(2400_MHz == Ieee80211FrequencyBand::TwoPointFourGHz);
+        REQUIRE(5000_MHz == Ieee80211FrequencyBand::FiveGHz);
+        REQUIRE(6000_MHz == Ieee80211FrequencyBand::SixGHz);
     }
 
     SECTION("Invalid literal values translate to 'Unknown'")
     {
-        static constexpr std::initializer_list<IeeeDot11FrequencyBand> InvalidBandValues{
+        static constexpr std::initializer_list<Ieee80211FrequencyBand> InvalidBandValues{
             0_MHz,
             1_MHz,
             2_MHz,
@@ -84,7 +84,7 @@ TEST_CASE("IeeeDot11FrequencyBand MHz literals translate correctly", "[wifi][cor
         };
 
         for (const auto& invalidBand : InvalidBandValues) {
-            REQUIRE(invalidBand == IeeeDot11FrequencyBand::Unknown);
+            REQUIRE(invalidBand == Ieee80211FrequencyBand::Unknown);
         }
     }
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [X] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the API reflects the architecture and definitions described in the 802.11 (2020) specification.

### Technical Details

* [`protocol/protos/NetRemoteWifi.proto`](diffhunk://#diff-6006f039c48087ef112cbf8140124f95894fdf0bb4a0617f1dbfcbc58f8bceaaL12-R12): Renamed `AccessPointCapabilities` to `Dot11AccessPointCapabilities` and `AccessPointConfiguration` to `Dot11AccessPointConfiguration` in `WifiEnumerateAccessPointsResultItem` and `WifiAccessPointEnableRequest` messages. [[1]](diffhunk://#diff-6006f039c48087ef112cbf8140124f95894fdf0bb4a0617f1dbfcbc58f8bceaaL12-R12) [[2]](diffhunk://#diff-6006f039c48087ef112cbf8140124f95894fdf0bb4a0617f1dbfcbc58f8bceaaL45-R45)

* [`protocol/protos/WifiCore.proto`](diffhunk://#diff-3df74fce9821fe1c514f55df915b54ea11e1365d6eafc1d0916094243c75433dL6-R19): Renamed `RadioBand` enum to `Dot11FrequencyBand` and rearranged its members. Modified the `Dot11PhyType` enum by reordering its members and adding modulation type aliases. Renamed `Dot11CipherAlgorithm` enum to `Dot11CipherSuite` and rearranged its members. Renamed `AccessPointConfiguration`, `AccessPointCapabilities`, and `AccessPointState` messages to `Dot11AccessPointConfiguration`, `Dot11AccessPointCapabilities`, and `Dot11AccessPointState`, respectively. [[1]](diffhunk://#diff-3df74fce9821fe1c514f55df915b54ea11e1365d6eafc1d0916094243c75433dL6-R19) [[2]](diffhunk://#diff-3df74fce9821fe1c514f55df915b54ea11e1365d6eafc1d0916094243c75433dL28-R105) [[3]](diffhunk://#diff-3df74fce9821fe1c514f55df915b54ea11e1365d6eafc1d0916094243c75433dL103-R123) [[4]](diffhunk://#diff-3df74fce9821fe1c514f55df915b54ea11e1365d6eafc1d0916094243c75433dL112-R150)

* [`src/common/service/NetRemoteService.cxx`](diffhunk://#diff-11085dac62f30b4ee462497fa3a0b168e208f6fdcd48e29e61e38e17445d5a92L30-R211): Updated several function implementations to use the renamed types and enums, and to handle the reordered enum members. [[1]](diffhunk://#diff-11085dac62f30b4ee462497fa3a0b168e208f6fdcd48e29e61e38e17445d5a92L30-R211) [[2]](diffhunk://#diff-11085dac62f30b4ee462497fa3a0b168e208f6fdcd48e29e61e38e17445d5a92L196-R222) [[3]](diffhunk://#diff-11085dac62f30b4ee462497fa3a0b168e208f6fdcd48e29e61e38e17445d5a92L212-R249) [[4]](diffhunk://#diff-11085dac62f30b4ee462497fa3a0b168e208f6fdcd48e29e61e38e17445d5a92L243-R268) [[5]](diffhunk://#diff-11085dac62f30b4ee462497fa3a0b168e208f6fdcd48e29e61e38e17445d5a92L330-R355)

### Test Results

* Compile tested. Despite this being a breaking change, compilation ensures existing (local) code was updated correctly.

### Reviewer Focus

* None

### Future Work

* The `Dot11AccessPointConfiguration` structure needs to be updated to allow specification of multiple AKMs and cipher suites.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
