### PR TITLE
Hook up lower layers to implement capabilities portion of WifiEnumerateAccessPoints

### DIFF
--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -218,8 +218,8 @@ IeeeAccessPointCapabilitiesToNetRemoteAccessPointCapabilities(const Microsoft::N
         std::make_move_iterator(std::end(phyTypes))
     };
 
-    std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand> bands(std::size(ieeeCapabilities.Dot11FrequencyBands));
-    std::ranges::transform(ieeeCapabilities.Dot11FrequencyBands, std::begin(bands), IeeeDot11FrequencyBandToNetRemoteDot11FrequencyBand);
+    std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand> bands(std::size(ieeeCapabilities.FrequencyBands));
+    std::ranges::transform(ieeeCapabilities.FrequencyBands, std::begin(bands), IeeeDot11FrequencyBandToNetRemoteDot11FrequencyBand);
 
     *capabilities.mutable_bands() = {
         std::make_move_iterator(std::begin(bands)),

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -37,12 +37,16 @@ NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::Dot11Access
 
     std::stringstream ss;
 
+    constexpr auto PhyTypePrefixLength = std::size(std::string_view("Dot11PhyType"));
     ss << indent0
-       << "Phy Types:";
+       << "Phy Types: ";
     for (const auto& phyType : accessPointCapabilities.phytypes()) {
-        ss << '\n'
-           << indent1
-           << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11PhyType>(phyType));
+        std::string_view phyTypeName(magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11PhyType>(phyType)));
+        phyTypeName.remove_prefix(PhyTypePrefixLength);
+        if (phyType != accessPointCapabilities.phytypes()[0]) {
+            ss << ' ';
+        }
+        ss << phyTypeName;
     }
 
     constexpr auto BandPrefixLength = std::size(std::string_view("Dot11FrequencyBand"));

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -23,11 +23,11 @@ namespace detail
 {
 /**
  * @brief Generate a string representation of a Dot11AccessPointCapabilities object.
- * 
+ *
  * @param accessPointCapabilities The object to generate a string representation of.
  * @param indentationLevel The indentation level to use.
  * @param indentation The number of spaces in each indentation level.
- * @return std::string 
+ * @return std::string
  */
 std::string
 NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::Dot11AccessPointCapabilities& accessPointCapabilities, std::size_t indentationLevel = 1, std::size_t indentation = 2)
@@ -38,7 +38,7 @@ NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::Dot11Access
     std::stringstream ss;
 
     ss << indent0
-       <<  "Phy Types:";
+       << "Phy Types:";
     for (const auto& phyType : accessPointCapabilities.phytypes()) {
         ss << '\n'
            << indent1
@@ -63,13 +63,15 @@ NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::Dot11Access
            << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm>(authenticationAlgorithm));
     }
 
+    constexpr auto CipherAlgorithmPrefixLength = std::size(std::string_view("Dot11CipherSuite"));
     ss << '\n'
        << indent0
        << "Cipher Algorithms:";
     for (const auto& ciperSuite : accessPointCapabilities.ciphersuites()) {
+        std::string_view cipherSuiteName(magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11CipherSuite>(ciperSuite)));
+        cipherSuiteName.remove_prefix(CipherAlgorithmPrefixLength);
         ss << '\n'
-           << indent1
-           << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11CipherSuite>(ciperSuite));
+           << indent1 << cipherSuiteName;
     }
 
     return ss.str();

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -45,13 +45,15 @@ NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::Dot11Access
            << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11PhyType>(phyType));
     }
 
+    constexpr auto BandPrefixLength = std::size(std::string_view("Dot11FrequencyBand"));
     ss << '\n'
        << indent0
        << "Bands:";
     for (const auto& band : accessPointCapabilities.bands()) {
+        std::string_view bandName(magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11FrequencyBand>(band)));
+        bandName.remove_prefix(BandPrefixLength);
         ss << '\n'
-           << indent1
-           << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11FrequencyBand>(band));
+           << indent1 << bandName;
     }
 
     ss << '\n'

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
@@ -14,7 +14,7 @@ namespace Microsoft::Net::Wifi
 struct Ieee80211AccessPointCapabilities
 {
     std::vector<Ieee80211Protocol> Protocols;
-    std::vector<Ieee80211FrequencyBand> Dot11FrequencyBands;
+    std::vector<Ieee80211FrequencyBand> FrequencyBands;
     std::vector<Ieee80211AuthenticationAlgorithm> AuthenticationAlgorithms;
     std::vector<Ieee80211CipherSuite> CipherSuites;
 };

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
@@ -3,6 +3,7 @@
 #define NETLINK_80211_WIPHY_HXX
 
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -11,9 +12,9 @@
 
 #include <linux/netlink.h>
 #include <linux/nl80211.h>
-#include <netlink/msg.h>
-
+#include <microsoft/net/netlink/NetlinkMessage.hxx>
 #include <microsoft/net/netlink/nl80211/Netlink80211WiphyBand.hxx>
+#include <netlink/msg.h>
 
 namespace Microsoft::Net::Netlink::Nl80211
 {
@@ -38,6 +39,15 @@ struct Nl80211Wiphy
      */
     static std::optional<Nl80211Wiphy>
     FromIndex(uint32_t wiphyIndex);
+
+    /**
+     * @brief Creates a new Nl80211Wiphy object from the specified interface name.
+     *
+     * @param interfaceName The interface name to create the object from.
+     * @return std::optional<Nl80211Wiphy>
+     */
+    static std::optional<Nl80211Wiphy>
+    FromInterfaceName(std::string_view interfaceName);
 
     /**
      * @brief Parse a netlink message into an Nl80211Wiphy. The netlink message must contain a response to the
@@ -66,6 +76,20 @@ private:
      * @param name The wiphy name.
      */
     Nl80211Wiphy(uint32_t index, std::string_view name, std::vector<uint32_t> cipherSuites, std::unordered_map<nl80211_band, Nl80211WiphyBand> bands, std::vector<nl80211_iftype> supportedInterfaceTypes, bool supportsRoaming) noexcept;
+
+    /**
+     * @brief Creates a new Nl80211Wiphy object, using the specified function to add an identifier to the message,
+     * allowing nl80211 to look up the associated interface.
+     *
+     * @param addWiphyIdentifier The function that will add the identifier to the message. This function *must* add one of
+     * the following nl80211 attributes to the passed netlink message argument:
+     *  - NL80211_ATTR_IFINDEX (uint32_t)
+     *  - NL80211_ATTR_WIPHY (uint32_t)
+     *  - NL80211_ATTR_WDEV (uint64_t)
+     * @return std::optional<Nl80211Wiphy>
+     */
+    static std::optional<Nl80211Wiphy>
+    FromId(std::function<void(Microsoft::Net::Netlink::NetlinkMessage&)> addWiphyIdentifier);
 };
 
 } // namespace Microsoft::Net::Netlink::Nl80211

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -28,6 +28,21 @@ Nl80211CipherSuiteToIeee80211CipherSuite(uint32_t nl80211CipherSuite) noexcept
 {
     return static_cast<Ieee80211CipherSuite>(nl80211CipherSuite);
 }
+
+Ieee80211FrequencyBand
+Nl80211BandToIeee80211FrequencyBand(nl80211_band nl80211Band) noexcept
+{
+    switch (nl80211Band) {
+    case NL80211_BAND_2GHZ:
+        return Ieee80211FrequencyBand::TwoPointFourGHz;
+    case NL80211_BAND_5GHZ:
+        return Ieee80211FrequencyBand::FiveGHz;
+    case NL80211_BAND_60GHZ:
+        return Ieee80211FrequencyBand::SixGHz;
+    default:
+        return Ieee80211FrequencyBand::Unknown;
+    }
+}
 } // namespace detail
 
 Ieee80211AccessPointCapabilities
@@ -39,6 +54,10 @@ AccessPointControllerLinux::GetCapabilities()
     }
 
     Ieee80211AccessPointCapabilities capabilities;
+
+    // Convert frequency bands.
+    capabilities.FrequencyBands = std::vector<Ieee80211FrequencyBand>(std::size(wiphy->Bands));
+    std::ranges::transform(std::views::keys(wiphy->Bands), std::begin(capabilities.FrequencyBands), detail::Nl80211BandToIeee80211FrequencyBand);
 
     // Convert cipher suites.
     capabilities.CipherSuites = std::vector<Ieee80211CipherSuite>(std::size(wiphy->CipherSuites));

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -1,7 +1,10 @@
 
+#include <algorithm>
 #include <format>
+#include <ranges>
 
 #include <microsoft/net/wifi/AccessPointControllerLinux.hxx>
+#include <microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx>
 #include <plog/Log.h>
 #include <Wpa/IHostapd.hxx>
 #include <Wpa/ProtocolHostapd.hxx>
@@ -10,17 +13,38 @@
 
 using namespace Microsoft::Net::Wifi;
 
+using Microsoft::Net::Netlink::Nl80211::Nl80211Wiphy;
+
 AccessPointControllerLinux::AccessPointControllerLinux(std::string_view interfaceName) :
     AccessPointController(interfaceName),
     m_hostapd(interfaceName)
 {
 }
 
+namespace detail
+{
+Ieee80211CipherSuite
+Nl80211CipherSuiteToIeee80211CipherSuite(uint32_t nl80211CipherSuite) noexcept
+{
+    return static_cast<Ieee80211CipherSuite>(nl80211CipherSuite);
+}
+} // namespace detail
+
 Ieee80211AccessPointCapabilities
 AccessPointControllerLinux::GetCapabilities()
 {
-    // TODO: Implement this method.
-    return {};
+    auto wiphy = Nl80211Wiphy::FromInterfaceName(GetInterfaceName());
+    if (!wiphy.has_value()) {
+        throw AccessPointControllerException(std::format("Failed to get wiphy for interface {}", GetInterfaceName()));
+    }
+
+    Ieee80211AccessPointCapabilities capabilities;
+
+    // Convert cipher suites.
+    capabilities.CipherSuites = std::vector<Ieee80211CipherSuite>(std::size(wiphy->CipherSuites));
+    std::ranges::transform(wiphy->CipherSuites, std::begin(capabilities.CipherSuites), detail::Nl80211CipherSuiteToIeee80211CipherSuite);
+
+    return capabilities;
 }
 
 bool


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure most access point capabilities are reported via `WifiEnumerateAccessPoints`.

### Technical Details

* Rename `Ieee80211AccessPointCapabilities::Dot11FrequencyBands` field name to `FrequencyBands`.
* Add support to create a `Nl80211Wiphy` from an interface name.
* Populate `Ieee80211AccessPointCapabilities::(Protocols|FrequencyBands|CipherSuites)` fields in `GetCapabilities()` implementation.

### Test Results

* All unit tests pass.
* Ran `netremote-cli wifi enumaps` with the following output:

```bash
shadowfax@mrstux:~/src/microsoft/netremote-cmake/out/build/dev-linux/src/linux/tools/cli/Debug$ ./netremote-cli -s 127.0.0.1 wifi enumaps
Executing command WifiEnumerateAccessPoints
[1] wlx08beac0696fe
  Phy Types: B G N
  Bands:
    2400MHz
  Authentication Algorithms:
  Cipher Algorithms:
    Wep40
    Wep104
    Tkip
    Ccmp128
    Ccmp256
    Gcmp128
    Gcmp256
    BipCmac128
    BipCmac256
    BipGmac128
    BipGmac256

[2] wls1
  Phy Types: B G N AC
  Bands:
    5000MHz
    2400MHz
  Authentication Algorithms:
  Cipher Algorithms:
    Wep40
    Wep104
    Tkip
    Ccmp128
    BipCmac128
```

### Reviewer Focus

* None

### Future Work

* The AKMs are not yet populated since parsing code is needed in the `Netlink80211Wiphy` structure. The nl80211 AKM attributes have a convoluted nesting structure which is deserving of its own PR.
* Consider moving nl80211 <-> Ieee80211 conversion functions into their own file or library.
* Consider adjusting middle portions of `AccessPoint*` hierarchy further to work with `IAccessPoint` instead of interface names to avoid some duplication of execution.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
