### PR TITLE
Populate AKMs in capabilities portion of WifiEnumerateAccessPoints

### DIFF
--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -149,7 +149,7 @@ message Dot11AccessPointCapabilities
 {
     repeated Microsoft.Net.Wifi.Dot11FrequencyBand Bands = 1;
     repeated Microsoft.Net.Wifi.Dot11PhyType PhyTypes = 2;
-    repeated Microsoft.Net.Wifi.Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 3;
+    repeated Microsoft.Net.Wifi.Dot11AkmSuite AkmSuites = 3;
     repeated Microsoft.Net.Wifi.Dot11CipherSuite CipherSuites = 4;
 }
 

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -226,12 +226,12 @@ IeeeAccessPointCapabilitiesToNetRemoteAccessPointCapabilities(const Microsoft::N
         std::make_move_iterator(std::end(bands))
     };
 
-    std::vector<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm> authenticationAlgorithms(std::size(ieeeCapabilities.AuthenticationAlgorithms));
-    std::ranges::transform(ieeeCapabilities.AuthenticationAlgorithms, std::begin(authenticationAlgorithms), IeeeAuthenticationAlgorithmToNetRemoteAuthenticationAlgorithm);
+    std::vector<Microsoft::Net::Wifi::Dot11AkmSuite> akmSuites(std::size(ieeeCapabilities.AkmSuites));
+    std::ranges::transform(ieeeCapabilities.AkmSuites, std::begin(akmSuites), Ieee80211AkmSuiteToNetRemoteAkm);
 
-    *capabilities.mutable_authenticationalgorithms() = {
-        std::make_move_iterator(std::begin(authenticationAlgorithms)),
-        std::make_move_iterator(std::end(authenticationAlgorithms))
+    *capabilities.mutable_akmsuites() = {
+        std::make_move_iterator(std::begin(akmSuites)),
+        std::make_move_iterator(std::end(akmSuites))
     };
 
     std::vector<Microsoft::Net::Wifi::Dot11CipherSuite> cipherSuites(std::size(ieeeCapabilities.CipherSuites));

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -145,7 +145,7 @@ Ieee80211AkmSuiteToNetRemoteAkm(Ieee80211AkmSuite akmSuite)
         return Dot11AkmSuite::Dot11AkmSuiteFt8021xSha384;
     case Ieee80211AkmSuite::FilsSha256:
         return Dot11AkmSuite::Dot11AkmSuiteFilsSha256;
-    case Ieee80211AkmSuite::FilsSha284:
+    case Ieee80211AkmSuite::FilsSha384:
         return Dot11AkmSuite::Dot11AkmSuiteFilsSha384;
     case Ieee80211AkmSuite::FtFilsSha256:
         return Dot11AkmSuite::Dot11AkmSuiteFtFilsSha256;

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -60,13 +60,15 @@ NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::Dot11Access
            << indent1 << bandName;
     }
 
+    constexpr auto AkmSuitePrefixLength = std::size(std::string_view("Dot11AuthenticationAlgorithm"));
     ss << '\n'
        << indent0
-       << "Authentication Algorithms:";
-    for (const auto& authenticationAlgorithm : accessPointCapabilities.authenticationalgorithms()) {
+       << "Authentication and Key Management (AKM) Suites:";
+    for (const auto& akmSuite : accessPointCapabilities.akmsuites()) {
+        std::string_view akmSuiteName(magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11AkmSuite>(akmSuite)));
+        akmSuiteName.remove_prefix(AkmSuitePrefixLength);
         ss << '\n'
-           << indent1
-           << magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm>(authenticationAlgorithm));
+           << indent1 << akmSuiteName;
     }
 
     constexpr auto CipherAlgorithmPrefixLength = std::size(std::string_view("Dot11CipherSuite"));

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -9,8 +9,6 @@
 #include <plog/Log.h>
 
 using namespace Microsoft::Net::Remote;
-
-using namespace Microsoft::Net::Remote;
 using namespace Microsoft::Net::Remote::Service;
 using namespace Microsoft::Net::Remote::Wifi;
 
@@ -60,7 +58,7 @@ NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::Dot11Access
            << indent1 << bandName;
     }
 
-    constexpr auto AkmSuitePrefixLength = std::size(std::string_view("Dot11AuthenticationAlgorithm"));
+    constexpr auto AkmSuitePrefixLength = std::size(std::string_view("Dot11AkmSuite"));
     ss << '\n'
        << indent0
        << "Authentication and Key Management (AKM) Suites:";

--- a/src/common/wifi/core/CMakeLists.txt
+++ b/src/common/wifi/core/CMakeLists.txt
@@ -22,6 +22,11 @@ target_sources(wifi-core
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/Ieee80211AccessPointCapabilities.hxx
 )
 
+target_link_libraries(wifi-core
+    PUBLIC
+        notstd
+)
+
 install(
     TARGETS wifi-core
     EXPORT ${PROJECT_NAME}

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -4,6 +4,9 @@
 
 #include <cmath>
 #include <cstdint>
+#include <initializer_list>
+
+#include <notstd/Utility.hxx>
 
 namespace Microsoft::Net::Wifi
 {
@@ -187,12 +190,40 @@ enum class Ieee80211AkmSuite : uint32_t {
     Ieee8011xSuiteB192 = MakeIeee80211Suite(Ieee80211AkmSuiteId8021xSuiteB192),
     Ft8021xSha384 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFt8021xSha384),
     FilsSha256 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFilsSha256),
-    FilsSha284 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFilsSha384),
+    FilsSha384 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFilsSha384),
     FtFilsSha256 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFtFilsSha256),
     FtFilsSha384 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFtFilsSha384),
     Owe = MakeIeee80211Suite(Ieee80211AkmSuiteIdOwe),
     FtPskSha384 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFtPskSha384),
     PskSha384 = MakeIeee80211Suite(Ieee80211AkmSuiteIdPskSha384),
+};
+
+/**
+ * @brief A listing of all known AKMs. Normally, these would be enumerated with magic_enum::enum_values(), however, that
+ * only supports enums with values up to UINT16_MAX-1, and the AKM suite underlying type is uint32_t, so cannot be used.
+ */
+constexpr std::initializer_list<uint32_t> AllIeee80211Akms{
+    notstd::to_underlying(Ieee80211AkmSuite::Reserved0),
+    notstd::to_underlying(Ieee80211AkmSuite::Ieee8021x),
+    notstd::to_underlying(Ieee80211AkmSuite::Psk),
+    notstd::to_underlying(Ieee80211AkmSuite::Ft8021x),
+    notstd::to_underlying(Ieee80211AkmSuite::FtPsk),
+    notstd::to_underlying(Ieee80211AkmSuite::Ieee8021xSha256),
+    notstd::to_underlying(Ieee80211AkmSuite::PskSha256),
+    notstd::to_underlying(Ieee80211AkmSuite::Tdls),
+    notstd::to_underlying(Ieee80211AkmSuite::Sae),
+    notstd::to_underlying(Ieee80211AkmSuite::FtSae),
+    notstd::to_underlying(Ieee80211AkmSuite::ApPeerKey),
+    notstd::to_underlying(Ieee80211AkmSuite::Ieee8021xSuiteB),
+    notstd::to_underlying(Ieee80211AkmSuite::Ieee8011xSuiteB192),
+    notstd::to_underlying(Ieee80211AkmSuite::Ft8021xSha384),
+    notstd::to_underlying(Ieee80211AkmSuite::FilsSha256),
+    notstd::to_underlying(Ieee80211AkmSuite::FilsSha384),
+    notstd::to_underlying(Ieee80211AkmSuite::FtFilsSha256),
+    notstd::to_underlying(Ieee80211AkmSuite::FtFilsSha384),
+    notstd::to_underlying(Ieee80211AkmSuite::Owe),
+    notstd::to_underlying(Ieee80211AkmSuite::FtPskSha384),
+    notstd::to_underlying(Ieee80211AkmSuite::PskSha384),
 };
 
 /**

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
@@ -15,7 +15,7 @@ struct Ieee80211AccessPointCapabilities
 {
     std::vector<Ieee80211Protocol> Protocols;
     std::vector<Ieee80211FrequencyBand> FrequencyBands;
-    std::vector<Ieee80211AuthenticationAlgorithm> AuthenticationAlgorithms;
+    std::vector<Ieee80211AkmSuite> AkmSuites;
     std::vector<Ieee80211CipherSuite> CipherSuites;
 };
 } // namespace Microsoft::Net::Wifi

--- a/src/linux/libnl-helpers/CMakeLists.txt
+++ b/src/linux/libnl-helpers/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(libnl-helpers
     PRIVATE
         magic_enum::magic_enum
         plog::plog
+        wifi-core
     PUBLIC
         nl
         nl-genl

--- a/src/linux/libnl-helpers/Netlink80211Wiphy.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Wiphy.cxx
@@ -17,9 +17,10 @@
 
 using namespace Microsoft::Net::Netlink::Nl80211;
 
-Nl80211Wiphy::Nl80211Wiphy(uint32_t index, std::string_view name, std::vector<uint32_t> cipherSuites, std::unordered_map<nl80211_band, Nl80211WiphyBand> bands, std::vector<nl80211_iftype> supportedInterfaceTypes, bool supportsRoaming) noexcept :
+Nl80211Wiphy::Nl80211Wiphy(uint32_t index, std::string_view name, std::vector<uint32_t> akmSuites, std::vector<uint32_t> cipherSuites, std::unordered_map<nl80211_band, Nl80211WiphyBand> bands, std::vector<nl80211_iftype> supportedInterfaceTypes, bool supportsRoaming) noexcept :
     Index(index),
     Name(name),
+    AkmSuites(std::move(akmSuites)),
     CipherSuites(std::move(cipherSuites)),
     Bands(std::move(bands)),
     SupportedInterfaceTypes(std::move(supportedInterfaceTypes)),
@@ -191,6 +192,9 @@ Nl80211Wiphy::Parse(struct nl_msg *nl80211Message) noexcept
         }
     }
 
+    // Process akm suites.
+    std::vector<uint32_t> akmSuites{};
+
     // Process cipher suites.
     uint32_t *wiphyCipherSuites;
     auto wiphyNumCipherSuites = static_cast<std::size_t>(nla_len(wiphyAttributes[NL80211_ATTR_CIPHER_SUITES])) / sizeof(*wiphyCipherSuites);
@@ -212,7 +216,7 @@ Nl80211Wiphy::Parse(struct nl_msg *nl80211Message) noexcept
     // Process roaming support.
     auto wiphySupportsRoaming = wiphyAttributes[NL80211_ATTR_ROAM_SUPPORT] != nullptr;
 
-    Nl80211Wiphy nl80211Wiphy{ wiphyIndex, wiphyName, std::move(cipherSuites), std::move(wiphyBandMap), std::move(supportedInterfaceTypes), wiphySupportsRoaming };
+    Nl80211Wiphy nl80211Wiphy{ wiphyIndex, wiphyName, std::move(akmSuites), std::move(cipherSuites), std::move(wiphyBandMap), std::move(supportedInterfaceTypes), wiphySupportsRoaming };
     return nl80211Wiphy;
 }
 

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
@@ -26,6 +26,9 @@ struct Nl80211Wiphy
 {
     uint32_t Index;
     std::string Name;
+    // TODO: Add parsing for AKM suites via NL80211_ATTR_AKM_SUITES (count), NL80211_ATTR_IFTYPE_AKM_SUITES,
+    // NL80211_IFTYPE_AKM_ATTR_IFTYPES, NL80211_IFTYPE_AKM_ATTR_SUITES.
+    std::vector<uint32_t> AkmSuites;
     std::vector<uint32_t> CipherSuites;
     std::unordered_map<nl80211_band, Nl80211WiphyBand> Bands;
     std::vector<nl80211_iftype> SupportedInterfaceTypes;
@@ -75,7 +78,7 @@ private:
      * @param index The wiphy index.
      * @param name The wiphy name.
      */
-    Nl80211Wiphy(uint32_t index, std::string_view name, std::vector<uint32_t> cipherSuites, std::unordered_map<nl80211_band, Nl80211WiphyBand> bands, std::vector<nl80211_iftype> supportedInterfaceTypes, bool supportsRoaming) noexcept;
+    Nl80211Wiphy(uint32_t index, std::string_view name, std::vector<uint32_t> akmSuites, std::vector<uint32_t> cipherSuites, std::unordered_map<nl80211_band, Nl80211WiphyBand> bands, std::vector<nl80211_iftype> supportedInterfaceTypes, bool supportsRoaming) noexcept;
 
     /**
      * @brief Creates a new Nl80211Wiphy object, using the specified function to add an identifier to the message,

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -3,13 +3,12 @@
 #include <format>
 #include <ranges>
 
-#include <microsoft/net/wifi/AccessPointControllerLinux.hxx>
-#include <microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx>
-#include <plog/Log.h>
 #include <Wpa/IHostapd.hxx>
 #include <Wpa/ProtocolHostapd.hxx>
 #include <Wpa/WpaCommandStatus.hxx>
 #include <Wpa/WpaResponseStatus.hxx>
+#include <microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx>
+#include <microsoft/net/wifi/AccessPointControllerLinux.hxx>
 
 using namespace Microsoft::Net::Wifi;
 
@@ -27,6 +26,12 @@ Ieee80211CipherSuite
 Nl80211CipherSuiteToIeee80211CipherSuite(uint32_t nl80211CipherSuite) noexcept
 {
     return static_cast<Ieee80211CipherSuite>(nl80211CipherSuite);
+}
+
+Ieee80211AkmSuite
+Nl80211AkmSuiteToIeee80211AkmSuite(uint32_t nl80211AkmSuite) noexcept
+{
+    return static_cast<Ieee80211AkmSuite>(nl80211AkmSuite);
 }
 
 Ieee80211FrequencyBand
@@ -48,7 +53,7 @@ std::vector<Ieee80211Protocol>
 Nl80211WiphyToIeee80211Protocols(const Nl80211Wiphy& nl80211Wiphy)
 {
     // Ieee80211 B & G are always supported.
-    std::vector<Ieee80211Protocol> protocols{ 
+    std::vector<Ieee80211Protocol> protocols{
         Ieee80211Protocol::B,
         Ieee80211Protocol::G,
     };
@@ -62,7 +67,6 @@ Nl80211WiphyToIeee80211Protocols(const Nl80211Wiphy& nl80211Wiphy)
         }
         // TODO: once Nl80211WiphyBand is updated to support HE (AX) and EHT (BE), add them here.
     }
-
 
     // Remove duplicates.
     std::ranges::sort(protocols);
@@ -88,6 +92,10 @@ AccessPointControllerLinux::GetCapabilities()
     // Convert frequency bands.
     capabilities.FrequencyBands = std::vector<Ieee80211FrequencyBand>(std::size(wiphy->Bands));
     std::ranges::transform(std::views::keys(wiphy->Bands), std::begin(capabilities.FrequencyBands), detail::Nl80211BandToIeee80211FrequencyBand);
+
+    // Convert AKM suites.
+    capabilities.AkmSuites = std::vector<Ieee80211AkmSuite>(std::size(wiphy->AkmSuites));
+    std::ranges::transform(wiphy->AkmSuites, std::begin(capabilities.AkmSuites), detail::Nl80211AkmSuiteToIeee80211AkmSuite);
 
     // Convert cipher suites.
     capabilities.CipherSuites = std::vector<Ieee80211CipherSuite>(std::size(wiphy->CipherSuites));


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure supported AKMs are communicated to API clients via `WifiEnumerateAccessPoints`

### Technical Details

* Add parsing for `NL80211_ATTR_AKM_SUITES` in `Nl80211Wiphy` parsing.
* Rename `Ieee80211AkmSuite::FilsSha284` entry to `FilsSha384` (fixing typo).
* 

### Test Results

* All unit tests pass.
* Ran `netremote-cli wifi enumaps` with the following output:
```bash
shadowfax@mrstux:~/src/microsoft/netremote-cmake/out/build/dev-linux/src/linux/tools/cli/Debug$ ./netremote-cli -s 127.0.0.1 wifi enumaps
Executing command WifiEnumerateAccessPoints
[1] wls1
  Phy Types: B G N AC
  Bands:
    5000MHz
    2400MHz
  Authentication and Key Management (AKM) Suites:
    Reserved0
    8021x
    Psk
    Ft8021x
    FtPsk
    8021xSha256
    PskSha256
    Tdls
    Sae
    FtSae
    ApPeerKey
    8021xSuiteB
    8021xSuiteB192
    Ft8021xSha384
    FilsSha256
    FilsSha384
    FtFilsSha256
    FtFilsSha384
    Owe
    FtPskSha384
    PskSha384
  Cipher Algorithms:
    Wep40
    Wep104
    Tkip
    Ccmp128
    BipCmac128
```

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
