### PR TITLE
Fix crash on access point presence events

### DIFF
--- a/src/linux/libnl-helpers/Netlink80211Interface.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Interface.cxx
@@ -160,3 +160,9 @@ Nl80211Interface::GetWiphy() const
 {
     return Nl80211Wiphy::FromIndex(WiphyIndex);
 }
+
+bool
+Nl80211Interface::IsAccessPoint() const noexcept
+{
+    return (Type == nl80211_iftype::NL80211_IFTYPE_AP);
+}

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
@@ -28,6 +28,9 @@ struct Nl80211Interface
 
     Nl80211Interface() = default;
 
+    auto
+    operator <=>(const Nl80211Interface&) const = default;
+
     /**
      * @brief Construct a new Nl80211Interface object with the specified attributes.
      *
@@ -73,8 +76,30 @@ struct Nl80211Interface
      */
     std::string
     ToString() const;
+
+    /**
+     * @brief Indicates if the interface is an access point.
+     * 
+     * @return true 
+     * @return false 
+     */
+    bool
+    IsAccessPoint() const noexcept;
 };
 
 } // namespace Microsoft::Net::Netlink::Nl80211
+
+namespace std
+{
+template <>
+struct hash<Microsoft::Net::Netlink::Nl80211::Nl80211Interface>
+{
+    size_t
+    operator()(const Microsoft::Net::Netlink::Nl80211::Nl80211Interface& interface) const noexcept
+    {
+        return std::hash<std::string_view>()(interface.Name);
+    }
+};
+} // namespace std
 
 #endif // NETLINK_82011_INTERFACE_HXX

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -7,7 +7,7 @@
 #include <stop_token>
 #include <string>
 #include <thread>
-#include <unordered_map>
+#include <unordered_set>
 
 #include <linux/nl80211.h>
 #include <microsoft/net/netlink/NetlinkMessage.hxx>
@@ -120,13 +120,7 @@ private:
     int m_eventLoopStopFd{ -1 };
     std::jthread m_netlinkMessageProcessingThread;
 
-    struct WifiInterfaceInfo
-    {
-        std::string Name;
-        nl80211_iftype Type;
-    };
-
-    std::unordered_map<int, WifiInterfaceInfo> m_interfaceInfo;
+    std::unordered_set<Microsoft::Net::Netlink::Nl80211::Nl80211Interface> m_interfacesSeen;
     Microsoft::Net::Netlink::Nl80211::Nl80211ProtocolState &m_netlink80211ProtocolState;
 };
 } // namespace Microsoft::Net::Wifi


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure access points that arrive/depart after starting `netremote-server` are handled correctly and do not cause a crash.
* Fix #125

### Technical Details

* Re-use `Nl80211Interface` parsing code for decoding nl80211 event info on presence change events.
* Pass `AccessPointCreateArgsLinux` args when constructing access points in response to presence change events (this is the bug fix).
* Emit info-level log messages on access point presence events.
* Make `Nl80211Interface` suitable for use in unique containers.
* Replace use of `std::unordered_map` of utility structure with `std::unordered_set<Nl80211Interface>` for the "seen" cache.

### Test Results

* All unit tests pass.
* Toggled the hostapd service for an interface while `netremote-server` was running and validated log output was expected:

```bash
Netremote server starting
Netremote server started listening on 0.0.0.0:5047
Handling netlink socket read availabilty
Received netlink message callback
Received NL80211_CMD_SET_INTERFACE nl80211 command message
Invoking access point presence event callback with event args 'interface=wls1, presence=Arrived'
Access Point Discovery Event: Interface wls1 Arrived
Processed netlink message with result 0
Successfully processed netlink messages
Handling netlink socket read availabilty
Received netlink message callback
Received NL80211_CMD_SET_INTERFACE nl80211 command message
Invoking access point presence event callback with event args 'interface=wls1, presence=Departed'
Access Point Discovery Event: Interface wls1 Departed
Processed netlink message with result 0
Successfully processed netlink messages
Handling netlink socket read availabilty
Received netlink message callback
Received NL80211_CMD_SET_INTERFACE nl80211 command message
Invoking access point presence event callback with event args 'interface=wls1, presence=Arrived'
Access Point Discovery Event: Interface wls1 Arrived
Processed netlink message with result 0
Successfully processed netlink messages
```

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
