### PR TITLE
Add API to update frequency bands

### DIFF
--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -13,4 +13,5 @@ service NetRemote
     rpc WifiAccessPointDisable (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableResult);
     rpc WifiAccessPointSetPhyType (Microsoft.Net.Remote.Wifi.WifiAccessPointSetPhyTypeRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetPhyTypeResult);
     rpc WifiAccessPointSetAuthenticationConfiguration (Microsoft.Net.Remote.Wifi.WifiAccessPointSetAuthenticationConfigurationRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetAuthenticationConfigurationResult);
+    rpc WifiAccessPointSetFrequencyBands (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsResult);
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -85,3 +85,15 @@ message WifiAccessPointSetAuthenticationConfigurationResult
     string AccessPointId = 1;
     WifiAccessPointOperationStatus Status = 2;
 }
+
+message WifiAccessPointSetFrequencyBandsRequest
+{
+    string AccessPointId = 1;
+    repeated Microsoft.Net.Wifi.Dot11FrequencyBand FrequencyBands = 2;
+}
+
+message WifiAccessPointSetFrequencyBandsResult
+{
+    string AccessPointId = 1;
+    WifiAccessPointOperationStatus Status = 2;
+}

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -476,11 +476,14 @@ NetRemoteService::WifiAccessPointSetFrequencyBands([[maybe_unused]] ::grpc::Serv
 
     WifiAccessPointOperationStatus status{};
 
-    auto frequencyBands = request->frequencybands();
+    const auto& frequencyBands = request->frequencybands();
 
-    if (frequencyBands.size() <= 1 && frequencyBands[0] == Dot11FrequencyBand::Dot11FrequencyBandUnknown) {
+    if (std::empty(frequencyBands)) {
         status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
         status.set_message("No frequency band provided");
+    } else if (std::ranges::find(frequencyBands, Dot11FrequencyBand::Dot11FrequencyBandUnknown) != std::cend(frequencyBands)) {
+        status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+        status.set_message("Invalid frequency band provided");
     } else {
         auto accessPointWeak = m_accessPointManager->GetAccessPoint(request->accesspointid());
         auto accessPointController = detail::IAccessPointWeakToAccessPointController(accessPointWeak);

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -364,11 +364,6 @@ NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerConte
 
 using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus;
 using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode;
-using Microsoft::Net::Wifi::Dot11AccessPointAuthenticationConfiguration;
-using Microsoft::Net::Wifi::Dot11AkmSuiteConfiguration;
-using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
-using Microsoft::Net::Wifi::Dot11CipherSuite;
-using Microsoft::Net::Wifi::Dot11PhyType;
 
 ::grpc::Status
 NetRemoteService::WifiAccessPointEnable([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableResult* response)
@@ -404,6 +399,8 @@ NetRemoteService::WifiAccessPointDisable([[maybe_unused]] ::grpc::ServerContext*
     return grpc::Status::OK;
 }
 
+using Microsoft::Net::Wifi::Dot11PhyType;
+
 ::grpc::Status
 NetRemoteService::WifiAccessPointSetPhyType([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetPhyTypeRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetPhyTypeResult* response)
 {
@@ -433,6 +430,10 @@ NetRemoteService::WifiAccessPointSetPhyType([[maybe_unused]] ::grpc::ServerConte
     return grpc::Status::OK;
 }
 
+using Microsoft::Net::Wifi::Dot11AccessPointAuthenticationConfiguration;
+using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
+using Microsoft::Net::Wifi::Dot11CipherSuite;
+
 ::grpc::Status
 NetRemoteService::WifiAccessPointSetAuthenticationConfiguration([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetAuthenticationConfigurationRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetAuthenticationConfigurationResult* response)
 {
@@ -457,6 +458,39 @@ NetRemoteService::WifiAccessPointSetAuthenticationConfiguration([[maybe_unused]]
         }
 
         // TODO: Use accessPointController to set authentication algorithm.
+        status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
+    }
+
+    response->set_accesspointid(request->accesspointid());
+    *response->mutable_status() = std::move(status);
+
+    return grpc::Status::OK;
+}
+
+using Microsoft::Net::Wifi::Dot11FrequencyBand;
+
+::grpc::Status
+NetRemoteService::WifiAccessPointSetFrequencyBands([[maybe_unused]] ::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsResult* response)
+{
+    LOGD << std::format("Received WifiAccessPointSetFrequencyBands request for access point id {}", request->accesspointid());
+
+    WifiAccessPointOperationStatus status{};
+
+    auto frequencyBands = request->frequencybands();
+
+    if (frequencyBands.size() <= 1 && frequencyBands[0] == Dot11FrequencyBand::Dot11FrequencyBandUnknown) {
+        status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+        status.set_message("No frequency band provided");
+    } else {
+        auto accessPointWeak = m_accessPointManager->GetAccessPoint(request->accesspointid());
+        auto accessPointController = detail::IAccessPointWeakToAccessPointController(accessPointWeak);
+        if (!accessPointController) {
+            LOGE << std::format("Failed to create controller for access point {}", request->accesspointid());
+            status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointInvalid);
+            status.set_message(std::format("Failed to create controller for access point {}", request->accesspointid()));
+        }
+
+        // TODO: Use accessPointController to set frequency bands.
         status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
     }
 

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -47,6 +47,9 @@ private:
     virtual ::grpc::Status
     WifiAccessPointSetAuthenticationConfiguration(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetAuthenticationConfigurationRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetAuthenticationConfigurationResult* response) override;
 
+    virtual ::grpc::Status
+    WifiAccessPointSetFrequencyBands(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsResult* response) override;
+
 protected:
     bool
     ValidateWifiAccessPointEnableRequest(const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus& status);

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -313,8 +313,5 @@ TEST_CASE("WifiAccessPointSetFrequencyBands API", "[basic][rpc][client][remote]"
         REQUIRE(setFrequencyBandsStatus.ok());
         REQUIRE(setFrequencyBandsResult.accesspointid() == setFrequencyBandsRequest.accesspointid());
         REQUIRE(setFrequencyBandsResult.has_status());
-        REQUIRE(setFrequencyBandsResult.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
-        REQUIRE(setFrequencyBandsResult.status().message().empty());
-        REQUIRE(setFrequencyBandsResult.status().has_details() == false);
     }
 }

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -256,3 +256,65 @@ TEST_CASE("WifiAccessPointSetAuthenticationConfiguration API", "[basic][rpc][cli
         REQUIRE(setAuthConfigurationResult.has_status());
     }
 }
+
+TEST_CASE("WifiAccessPointSetFrequencyBands API", "[basic][rpc][client][remote]")
+{
+    using namespace Microsoft::Net::Remote;
+    using namespace Microsoft::Net::Remote::Service;
+    using namespace Microsoft::Net::Remote::Wifi;
+    using namespace Microsoft::Net::Wifi;
+
+    constexpr auto SsidName{ "TestWifiAccessPointSetFrequencyBands" };
+
+    NetRemoteServerConfiguration Configuration{
+        .ServerAddress = RemoteServiceAddressHttp,
+        .AccessPointManager = AccessPointManager::Create(),
+    };
+
+    NetRemoteServer server{ Configuration };
+    server.Run();
+
+    auto channel = grpc::CreateChannel(RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());
+    auto client = NetRemote::NewStub(channel);
+
+    Dot11AccessPointConfiguration apConfiguration{};
+    apConfiguration.mutable_ssid()->set_name(SsidName);
+    apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
+    apConfiguration.set_authenticationalgorithm(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);
+    apConfiguration.set_ciphersuite(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
+    apConfiguration.mutable_bands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
+    apConfiguration.mutable_bands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
+
+    WifiAccessPointEnableRequest request{};
+    request.set_accesspointid("TestWifiAccessPointSetFrequencyBands");
+    *request.mutable_configuration() = std::move(apConfiguration);
+
+    WifiAccessPointEnableResult result{};
+    grpc::ClientContext clientContext{};
+
+    auto status = client->WifiAccessPointEnable(&clientContext, request, &result);
+    REQUIRE(status.ok());
+    REQUIRE(result.accesspointid() == request.accesspointid());
+    REQUIRE(result.has_status());
+    REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
+    REQUIRE(result.status().message().empty());
+    REQUIRE(result.status().has_details() == false);
+
+    SECTION("Can be called")
+    {
+        WifiAccessPointSetFrequencyBandsRequest setFrequencyBandsRequest{};
+        setFrequencyBandsRequest.set_accesspointid("TestWifiAccessPointSetFrequencyBands");
+        setFrequencyBandsRequest.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand6_0GHz);
+
+        WifiAccessPointSetFrequencyBandsResult setFrequencyBandsResult{};
+        grpc::ClientContext setFrequencyBandsClientContext{};
+
+        auto setFrequencyBandsStatus = client->WifiAccessPointSetFrequencyBands(&setFrequencyBandsClientContext, setFrequencyBandsRequest, &setFrequencyBandsResult);
+        REQUIRE(setFrequencyBandsStatus.ok());
+        REQUIRE(setFrequencyBandsResult.accesspointid() == setFrequencyBandsRequest.accesspointid());
+        REQUIRE(setFrequencyBandsResult.has_status());
+        REQUIRE(setFrequencyBandsResult.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
+        REQUIRE(setFrequencyBandsResult.status().message().empty());
+        REQUIRE(setFrequencyBandsResult.status().has_details() == false);
+    }
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

This PR adds an API to update the frequency bands of an AP configuration.

### Technical Details

* Added `WifiAccessPointSetFrequencyBands` API and associated types to `NetRemoteService.proto` and `NetRemoteWifi.proto`.
* Added placeholder impl to `NetRemoteService.*xx`.
* Added unit test to `TestNetRemoteServiceClient.cxx`.

### Test Results

Unit tests pass.

### Reviewer Focus

None.

### Future Work

Properly fill in API implementation and improve unit test accordingly.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
