### PR TITLE
Disable file logging by default in Linux server.

### DIFF
--- a/src/common/server/NetRemoteServerConfiguration.cxx
+++ b/src/common/server/NetRemoteServerConfiguration.cxx
@@ -26,6 +26,11 @@ ConfigureCliAppOptions(CLI::App& app, NetRemoteServerConfiguration& config)
         config.LogVerbosity,
         "The log verbosity level. Supply multiple times to increase verbosity (0=warnings, errors, and fatal messages, 1=info messages, 2=debug messages, 3=verbose messages)");
 
+    app.add_flag(
+        "--enable-file-logging",
+        config.EnableFileLogging,
+        "Enable logging to file (disabled by default)");
+
     return app;
 }
 

--- a/src/common/server/include/microsoft/net/remote/NetRemoteServerConfiguration.hxx
+++ b/src/common/server/include/microsoft/net/remote/NetRemoteServerConfiguration.hxx
@@ -64,6 +64,11 @@ struct NetRemoteServerConfiguration
      * and a level of 3 or above will show all verbose messages.
      */
     uint32_t LogVerbosity{ 0 };
+   
+    /**
+     * @brief Whether to enable logging to file or not.
+     */
+    bool EnableFileLogging{ false };
 
     /**
      * @brief Access point manager instance.

--- a/src/linux/server/Main.cxx
+++ b/src/linux/server/Main.cxx
@@ -41,10 +41,11 @@ main(int argc, char *argv[])
 
     // Configure logging, appending all loggers to the default instance.
     plog::init<notstd::to_underlying(LogInstanceId::Console)>(logSeverity, &colorConsoleAppender);
-    plog::init<notstd::to_underlying(LogInstanceId::File)>(logSeverity, &rollingFileAppender);
-    plog::init(logSeverity)
-        .addAppender(plog::get<notstd::to_underlying(LogInstanceId::Console)>())
-        .addAppender(plog::get<notstd::to_underlying(LogInstanceId::File)>());
+    plog::init(logSeverity).addAppender(plog::get<notstd::to_underlying(LogInstanceId::Console)>());
+    if (configuration.EnableFileLogging) {
+        plog::init<notstd::to_underlying(LogInstanceId::File)>(logSeverity, &rollingFileAppender);
+        plog::init(logSeverity).addAppender(plog::get<notstd::to_underlying(LogInstanceId::File)>());
+    }
 
     // Create an access point manager and discovery agent.
     {


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

Avoid logging to file when not necessary. Since we're mostly targeting distros with systemd, logging is not needed by default since `stdout` is collected by default and forwarded to the systemd journal, which can then be accessed with standardized tooling (eg. `journalctl`) and in mostly arbitrary formats (syslog, json, xml, etc.).

### Technical Details

* Avoid adding a rolling file logger unless explicitly requested via a new command-line argument `--enable-file-logging`, supported by a new field `NetRemoteServerConfiguration::EnableFileLogging`.

### Test Results

* Ran `netremote-server --enable-file-logging <required args>` and verified a log file was produced in the working directory.
* Ran `netremote-server <required args>` and verified no log file was produced in the working directory.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
