### PR TITLE
Add CMake test preset for running non-root tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ obj/
 # CMake
 build/
 out/
+Testing/
 
 # vcpkg
 vcpkg_installed*/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -203,7 +203,8 @@
             "name": "test-common",
             "hidden": true,
             "output": {
-                "outputOnFailure": true
+                "outputOnFailure": true,
+                "shortProgress": true
             }
         },
         {
@@ -214,24 +215,16 @@
             ]
         },
         {
-            "name": "local-base",
-            "hidden": true,
-            "description": "Run tests that don't require a remote connection",
+            "name": "non-root",
+            "configurePreset": "dev-linux",
             "inherits": [
                 "test-common"
             ],
             "filter": {
-                "include": {
-                    "label": "[local]"
+                "exclude": {
+                    "name": "(root)"
                 }
             }
-        },
-        {
-            "name": "local",
-            "configurePreset": "dev-linux",
-            "inherits": [
-                "local-base"
-            ]
         }
     ]
 }

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -8,7 +8,7 @@
 
 #include "detail/WpaDaemonManager.hxx"
 
-TEST_CASE("Create a Hostapd instance", "[wpa][hostapd][client][remote]")
+TEST_CASE("Create a Hostapd instance (root)", "[wpa][hostapd][client][remote]")
 {
     using namespace Wpa;
 
@@ -40,7 +40,7 @@ TEST_CASE("Create a Hostapd instance", "[wpa][hostapd][client][remote]")
     }
 }
 
-TEST_CASE("Send Ping() command", "[wpa][hostapd][client][remote]")
+TEST_CASE("Send Ping() command (root)", "[wpa][hostapd][client][remote]")
 {
     using namespace Wpa;
 
@@ -58,7 +58,7 @@ TEST_CASE("Send Ping() command", "[wpa][hostapd][client][remote]")
     }
 }
 
-TEST_CASE("Send command: GetStatus()", "[wpa][hostapd][client][remote]")
+TEST_CASE("Send command: GetStatus() (root)", "[wpa][hostapd][client][remote]")
 {
     using namespace Wpa;
 
@@ -96,7 +96,7 @@ TEST_CASE("Send command: GetStatus()", "[wpa][hostapd][client][remote]")
     }
 }
 
-TEST_CASE("Send GetProperty() command", "[wpa][hostapd][client][remote]")
+TEST_CASE("Send GetProperty() command (root)", "[wpa][hostapd][client][remote]")
 {
     using namespace Wpa;
 
@@ -135,7 +135,7 @@ TEST_CASE("Send GetProperty() command", "[wpa][hostapd][client][remote]")
     }
 }
 
-TEST_CASE("Send SetProperty() command", "[wpa][hostapd][client][remote]")
+TEST_CASE("Send SetProperty() command (root)", "[wpa][hostapd][client][remote]")
 {
     using namespace Wpa;
 
@@ -159,7 +159,7 @@ TEST_CASE("Send SetProperty() command", "[wpa][hostapd][client][remote]")
     // TODO: validate that the property was actually set. Need to find a property whose value is retrievable.
 }
 
-TEST_CASE("Send control commands: Enable(), Disable()", "[wpa][hostapd][client][remote]")
+TEST_CASE("Send control commands: Enable(), Disable() (root)", "[wpa][hostapd][client][remote]")
 {
     using namespace Wpa;
 
@@ -211,7 +211,7 @@ TEST_CASE("Send control commands: Enable(), Disable()", "[wpa][hostapd][client][
 // Also, keep Terminate() test cases at end-of-file since Catch2 will run
 // tests in declaration order by default, which minimizes the possibility
 // of a test case being run after the daemon has been terminated.
-TEST_CASE("Send command: Terminate() doesn't throw", "[wpa][hostapd][client][remote]")
+TEST_CASE("Send command: Terminate() doesn't throw (root)", "[wpa][hostapd][client][remote]")
 {
     using namespace Wpa;
 
@@ -219,7 +219,7 @@ TEST_CASE("Send command: Terminate() doesn't throw", "[wpa][hostapd][client][rem
     REQUIRE_NOTHROW(hostapd.Terminate());
 }
 
-TEST_CASE("Send command: Terminate() ping failure", "[wpa][hostapd][client][remote]")
+TEST_CASE("Send command: Terminate() ping failure (root)", "[wpa][hostapd][client][remote]")
 {
     using namespace Wpa;
     using namespace std::chrono_literals;

--- a/tests/unit/linux/wpa-controller/TestWpaController.cxx
+++ b/tests/unit/linux/wpa-controller/TestWpaController.cxx
@@ -15,7 +15,7 @@ constexpr auto WpaTypesSupported = {
 };
 } // namespace TestDetail
 
-TEST_CASE("Send/receive WpaController request/response", "[wpa][hostapd][client][remote]")
+TEST_CASE("Send/receive WpaController request/response (root)", "[wpa][hostapd][client][remote]")
 {
     using namespace TestDetail;
     using namespace Wpa;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure inner dev loop can run unit tests without seeing failures due to running tests that require root. The prior solution of using a ctest label filter does not work since Catch2 doesn't actually pass tags as ctest labels, see:
    - catchorg/Catch2#2613
    - catchorg/Catch2#2690
* Related to #93

### Technical Details

* Annotate tests requiring root by suffixing the string `(root)` to the test name so they can be filtered with a regex.
* Add `non-root` CMake test preset with a regex to exclude all tests with the `(root)` string.
* Remove `local` CMake test preset since this requires ctest labels.
* Add `Testing` ctest temporary directory to `.gitignore`.
* Enable short-progress test output for all test presets.

### Test Results

* Ran `non-root` ctest preset from VSCode and verified all tests pass:

<img width="444" alt="image" src="https://github.com/microsoft/netremote/assets/2082148/0689c2e1-ac32-4cb5-94cc-0a6c1304fab2">

### Reviewer Focus

* None

### Future Work

* One Catch2 passes tags as labels, the `(root)` string should be removed from test names.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
