### PR TITLE
Fix script to build mac80211_hwsim kernel module

### DIFF
--- a/.docker/netremote-dev/build-mac80211_hwsim-kmod.sh
+++ b/.docker/netremote-dev/build-mac80211_hwsim-kmod.sh
@@ -79,6 +79,7 @@ fi
 # Update the configuration to build the mac80211_hwsim module and its dependencies.
 echo "Updating kernel configuration to build mac80211_hwsim module and its dependencies..."
 ${KERNEL_CONFIG_UTIL} \
+    --enable CONFIG_WLAN \
     --module CONFIG_RFKILL \
     --module CONFIG_CFG80211 \
     --module CONFIG_MAC80211 \

--- a/.docker/netremote-dev/build-mac80211_hwsim-kmod.sh
+++ b/.docker/netremote-dev/build-mac80211_hwsim-kmod.sh
@@ -68,9 +68,6 @@ cd ${WSL_SRC_DIRECTORY}
 echo "Preparing kernel source with configuration for running kernel..."
 cat /proc/config.gz | gzip -d > .config
 
-echo "Preparing kernel source tree for building external modules..."
-make prepare modules_prepare ${KERNEL_COMPILE_ARG_PARALLEL}
-
 # Ensure kernel helper scripts are available.
 if [[ ! -f ${KERNEL_CONFIG_UTIL} ]]; then
     make scripts
@@ -87,6 +84,9 @@ ${KERNEL_CONFIG_UTIL} \
 
 # Supply defaults for any new/unspecified options in the configuration.
 make olddefconfig
+
+echo "Preparing kernel source tree for building external modules..."
+make prepare modules_prepare ${KERNEL_COMPILE_ARG_PARALLEL}
 
 echo "Building kernel modules..."
 make modules ${KERNEL_COMPILE_ARG_PARALLEL}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the mac80211_hwsim module can be built on newer kernels (5.15.133.1+).

### Technical Details

* Enable `CONFIG_WLAN` feature in case the default ever changes to be disabled, or, if the running kernel has it disabled.
* Move kernel and module prep to after kernel configuration is set.

### Test Results

* Rebuilt kernel with script from scratch and verified `mac80211_hwsim` was build and could be loaded with `modprobe`.

### Reviewer Focus

* Consider whether there is any configuration where this sequence of build steps would not work.

### Future Work

* Hopefully, none.

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
