### PR TITLE
Add self-hosted Linux runner

### DIFF
--- a/.github/actions/build-with-selfhost/action.yml
+++ b/.github/actions/build-with-selfhost/action.yml
@@ -1,0 +1,69 @@
+ 
+name: 'build-on-selfhost'
+description: 'Build the repository on a self-hosted Linux runner'
+inputs:
+  build-type:
+    required: false
+    default: 'Debug'
+    description: 'The CMake build type (CMAKE_BUILD_TYPE) to run.'
+  install:
+    required: false
+    default: 'false'
+    description: 'Invoke CMake install for the project'
+  test:
+    required: false
+    default: 'true'
+    description: 'Invoke CMake CTest for the project'
+  package:
+    required: false
+    default: 'false'
+    description: 'Invoke CMake CPack for the project'
+  publish-artifacts:
+    required: false
+    default: 'false'
+    description: 'Publish build artifacts'
+  preset-name:
+    required: false
+    default: 'dev-linux'
+    description: 'The name of the preset to use for all CMake operations (configure, build, test, install, package)'
+
+runs:
+  using: 'composite'
+  steps:
+  - name: CMake Configure
+    if: ${{ ! inputs.arch }}
+    run: cmake --preset ${{ inputs.preset-name }} --fresh -DCMAKE_BUILD_TYPE=${{ inputs.build-type }}
+    shell: bash
+
+  - name: CMake Configure Cross-Compile ${{ inputs.arch }}
+    if: ${{ inputs.arch }}
+    run: cmake --preset ${{ inputs.preset-name }} --fresh -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DNETREMOTE_EXCLUDE_TESTS=TRUE -A ${{ inputs.arch }}
+    shell: bash
+
+  - name: CMake Build
+    run: cmake --build --preset ${{ inputs.preset-name }} --config ${{ inputs.build-type }}
+    shell: bash
+
+  - name: CMake Test (ctest)
+    if: ${{ inputs.test == 'true' && ! inputs.arch }}
+    run: ctest --preset ${{ inputs.preset-name }} -C ${{ inputs.build-type }}
+    shell: bash
+
+  - name: CMake Install
+    if: inputs.install == 'true'
+    run: cmake --build --preset ${{ inputs.preset-name }} --target install --config ${{ inputs.build-type }}
+    shell: bash
+
+  - name: CMake Package (cpack)
+    if: inputs.package == 'true'
+    run: cpack --preset ${{ inputs.preset-name }} -C ${{ inputs.build-type }}
+    shell: bash
+
+  - name: Publish Artifacts
+    if: inputs.publish-artifacts == 'true'
+    uses: actions/upload-artifact@v3
+    with:
+      name: release-package-${{ runner.os }}-${{ inputs.build-type }}-${{ inputs.arch != '' && inputs.arch || runner.arch }}
+      path: |
+        ${{ github.workspace }}/out/package/${{ inputs.preset-name }}/*.tar.*
+        ${{ github.workspace }}/out/package/${{ inputs.preset-name }}/*.zip

--- a/.github/actions/build-with-selfhost/action.yml
+++ b/.github/actions/build-with-selfhost/action.yml
@@ -46,7 +46,7 @@ runs:
 
   - name: CMake Test (ctest)
     if: ${{ inputs.test == 'true' && ! inputs.arch }}
-    run: ctest --preset ${{ inputs.preset-name }} -C ${{ inputs.build-type }}
+    run: ctest --preset non-root -C ${{ inputs.build-type }}
     shell: bash
 
   - name: CMake Install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Initialize CodeQL
-      if: inputs.analyze-codeql == true && contains(matrix.config.os, 'windows')
+      if: inputs.analyze-codeql == true
       uses: github/codeql-action/init@v2
       with:
         languages: 'cpp'
@@ -117,5 +117,5 @@ jobs:
         publish-artifacts: ${{ inputs.publish-artifacts }}
 
     - name: Perform CodeQL Analysis
-      if: inputs.analyze-codeql == true && contains(matrix.config.os, 'windows')
+      if: inputs.analyze-codeql == true
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
  
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       if: inputs.analyze-codeql == true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,14 +39,7 @@ on:
         default: "[ 'Debug' ]"
         type: string
         description: 'The CMake build types (CMAKE_BUILD_TYPE) to run (must be encoded as a JSON array)'
-      preset-name:
-        required: true
-        default: 'dev-windows'
-        type: choice
-        options:
-          - 'dev-windows'
-          - 'release-windows'
-        description: 'The name of the preset to use for all CMake operations (configure, build, test, install, package)'
+
   workflow_call:
     inputs:
       build-types:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,10 +79,6 @@ on:
         required: false
         default: false
         type: boolean
-      preset-name:
-        required: false
-        default: 'dev-windows'
-        type: string
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Build Linux
       if: ${{ contains(matrix.config.os, 'ubuntu-23.10') }}
-      uses: ./github/actions/build-with-selfhost
+      uses: ./.github/actions/build-with-selfhost
       with:
         build-type: ${{ matrix.build-type }}
         install: ${{ inputs.install }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Build Linux
       if: ${{ contains(matrix.config.os, 'ubuntu-23.10') }}
-      uses: ./github/actions/build/with-selfhost
+      uses: ./github/actions/build-with-selfhost
       with:
         build-type: ${{ matrix.build-type }}
         install: ${{ inputs.install }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         config:
           - { os: windows-2022 }
           - { os: windows-2022, arch: 'ARM64' }
-          - { os: ubuntu-22.04 }
+          - { os: [ self-hosted, ubuntu-23.10 ] }
         build-type: ${{ fromJson(inputs.build-types) }}
     runs-on: ${{ matrix.config.os }}
  
@@ -105,11 +105,16 @@ jobs:
         test: ${{ inputs.test }}
         package: ${{ inputs.package }}
         publish-artifacts: ${{ inputs.publish-artifacts }}
-        preset-name: ${{ inputs.preset-name }}
 
     - name: Build Linux
       if: ${{ contains(matrix.config.os, 'ubuntu') }}
-      uses: ./.github/actions/build-with-docker
+      uses: ./github/actions/build/with-selfhost
+      with:
+        build-type: ${{ matrix.build-type }}
+        install: ${{ inputs.install }}
+        test: ${{ inputs.test }}
+        package: ${{ inputs.package }}
+        publish-artifacts: ${{ inputs.publish-artifacts }}
 
     - name: Perform CodeQL Analysis
       if: inputs.analyze-codeql == true && contains(matrix.config.os, 'windows')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
         publish-artifacts: ${{ inputs.publish-artifacts }}
 
     - name: Build Linux
-      if: ${{ contains(matrix.config.os, 'ubuntu') }}
+      if: ${{ contains(matrix.config.os, 'ubuntu-23.10') }}
       uses: ./github/actions/build/with-selfhost
       with:
         build-type: ${{ matrix.build-type }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,4 +20,4 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       build-types: "[ 'Debug' ]"
-      test: false
+      test: true


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Enable running tests in CI/CD.
* Enable building Linux portions of the project on a native host instead of in a Docker container.

### Technical Details

* Add self-hosted Linux runner `mrstux` which runs ubuntu 23.10.
* Add GitHuib action for building Linux on a self-hosted machine.
* CMake workflow changes:
    - Remove `preset-name` input. 
    - Remove CodeQL Windows restriction.
    - Update Linux build to use self-hosted runner.
* Re-enable running tests in CI/CD workflow.

### Test Results

* Ran [workflow](https://github.com/microsoft/netremote/actions/runs/7660815563/job/20878913370) and verified completion for both Windows and Linux os targets.

### Reviewer Focus

* None

### Future Work

* vcpkg binary caching still needs to be fixed for Windows.

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
