### PR TITLE
Add dev-windows test preset.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -225,6 +225,13 @@
                     "name": "(root)"
                 }
             }
+        },
+        {
+            "name": "dev-windows",
+            "configurePreset": "dev-windows",
+            "inherits": [
+                "test-common"
+            ]
         }
     ]
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow Windows tests to be run from CI/CD.

### Technical Details

* Add `dev-windows` preset which inherits the common test preset settings, but targets Windows.

### Test Results

* Ran [CI/CD workflow](https://github.com/microsoft/netremote/actions/runs/7663403946) and validated tests were run and passed.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
