### PR TITLE
Add helpers for managing access points for unit tests

### DIFF
--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
@@ -74,7 +74,7 @@ public:
     std::vector<std::weak_ptr<IAccessPoint>>
     GetAllAccessPoints() const;
 
-    ~AccessPointManager() = default;
+    virtual ~AccessPointManager() = default;
     AccessPointManager(const AccessPointManager&) = delete;
     AccessPointManager(AccessPointManager&&) = delete;
     AccessPointManager&
@@ -85,12 +85,9 @@ public:
 protected:
     /**
      * @brief Construct a new AccessPointManager object.
-     *
-     * @param accessPointFactory
      */
     AccessPointManager() = default;
 
-private:
     /**
      * @brief Callback function for all access point agent presence change events.
      *
@@ -106,7 +103,7 @@ private:
      *
      * @param accessPoint The access point to add.
      */
-    void
+    virtual void
     AddAccessPoint(std::shared_ptr<IAccessPoint> accessPoint);
 
     /**
@@ -114,7 +111,7 @@ private:
      *
      * @param accessPoint The access point to remove.
      */
-    void
+    virtual void
     RemoveAccessPoint(std::shared_ptr<IAccessPoint> accessPoint);
 
 private:

--- a/src/common/wifi/core/AccessPoint.cxx
+++ b/src/common/wifi/core/AccessPoint.cxx
@@ -11,7 +11,7 @@ AccessPoint::AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccess
 {}
 
 std::string_view
-AccessPoint::GetInterfaceName() const noexcept
+AccessPoint::GetInterfaceName() const
 {
     return m_interfaceName;
 }

--- a/src/common/wifi/core/AccessPointController.cxx
+++ b/src/common/wifi/core/AccessPointController.cxx
@@ -9,7 +9,7 @@ AccessPointController::AccessPointController(std::string_view interface) :
 }
 
 std::string_view
-AccessPointController::GetInterfaceName() const noexcept
+AccessPointController::GetInterfaceName() const
 {
     return m_interfaceName;
 }

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
@@ -31,7 +31,7 @@ struct AccessPoint :
      * @return std::string_view
      */
     std::string_view
-    GetInterfaceName() const noexcept override;
+    GetInterfaceName() const override;
 
     /**
      * @brief Create a controller object.

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointController.hxx
@@ -31,7 +31,7 @@ struct AccessPointController :
      * @return std::string_view
      */
     std::string_view
-    GetInterfaceName() const noexcept override;
+    GetInterfaceName() const override;
 
 private:
     std::string m_interfaceName;

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
@@ -25,7 +25,7 @@ struct IAccessPoint
      * @return std::string_view
      */
     virtual std::string_view
-    GetInterfaceName() const noexcept = 0;
+    GetInterfaceName() const = 0;
 
     /**
      * @brief Create a new instance that can control the access point.

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -42,7 +42,7 @@ struct IAccessPointController
      * @return std::string_view
      */
     virtual std::string_view
-    GetInterfaceName() const noexcept = 0;
+    GetInterfaceName() const = 0;
 
     /**
      * @brief Get whether the access point is enabled.

--- a/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/tests/unit/linux/wifi/apmanager/TestAccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -5,7 +5,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
-#include <microsoft/net/wifi/test/AccessPointTest.hxx>
 #include <microsoft/net/wifi/test/AccessPointFactoryLinuxTest.hxx>
 
 TEST_CASE("Create AccessPointDiscoveryAgentOperationsNetlink", "[wifi][core][apmanager]")

--- a/tests/unit/wifi/core/TestAccessPoint.cxx
+++ b/tests/unit/wifi/core/TestAccessPoint.cxx
@@ -6,7 +6,6 @@
 #include <microsoft/net/wifi/AccessPoint.hxx>
 #include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <microsoft/net/wifi/test/AccessPointControllerTest.hxx>
-#include <microsoft/net/wifi/test/AccessPointTest.hxx>
 
 namespace Microsoft::Net::Wifi::Test
 {

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -12,7 +12,7 @@ AccessPointControllerTest::AccessPointControllerTest(AccessPointTest *accessPoin
 {}
 
 std::string_view
-AccessPointControllerTest::GetInterfaceName() const noexcept
+AccessPointControllerTest::GetInterfaceName() const
 {
     if (AccessPoint == nullptr) {
         throw std::runtime_error("AccessPointControllerTest::GetInterfaceName called with null AccessPoint");

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -1,33 +1,44 @@
 
+#include <stdexcept>
+
 #include <microsoft/net/wifi/test/AccessPointControllerTest.hxx>
+#include <microsoft/net/wifi/test/AccessPointTest.hxx>
 
 using namespace Microsoft::Net::Wifi;
 using namespace Microsoft::Net::Wifi::Test;
 
-AccessPointControllerTest::AccessPointControllerTest(std::string_view interfaceName) :
-    InterfaceName(interfaceName)
+AccessPointControllerTest::AccessPointControllerTest(AccessPointTest *accessPoint) :
+    AccessPoint(accessPoint)
 {}
 
 std::string_view
 AccessPointControllerTest::GetInterfaceName() const noexcept
 {
-    return InterfaceName;
+    return AccessPoint->InterfaceName;
 }
 
 bool
 AccessPointControllerTest::GetIsEnabled()
 {
-    return IsEnabled;
+    return AccessPoint->IsEnabled;
 }
 
 Ieee80211AccessPointCapabilities
 AccessPointControllerTest::GetCapabilities()
 {
-    return {}; // TODO: return something
+    return AccessPoint->Capabilities;
 }
+
+AccessPointControllerFactoryTest::AccessPointControllerFactoryTest(AccessPointTest *accessPoint) :
+    AccessPoint(accessPoint)
+{}
 
 std::unique_ptr<IAccessPointController>
 AccessPointControllerFactoryTest::Create(std::string_view interfaceName)
 {
-    return std::make_unique<AccessPointControllerTest>(interfaceName);
+    if (AccessPoint != nullptr && interfaceName != AccessPoint->InterfaceName) {
+        throw std::runtime_error("AccessPointControllerFactoryTest::Create called with unexpected interface name");
+    }
+
+    return std::make_unique<AccessPointControllerTest>(AccessPoint);
 }

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -14,18 +14,30 @@ AccessPointControllerTest::AccessPointControllerTest(AccessPointTest *accessPoin
 std::string_view
 AccessPointControllerTest::GetInterfaceName() const noexcept
 {
+    if (AccessPoint == nullptr) {
+        throw std::runtime_error("AccessPointControllerTest::GetInterfaceName called with null AccessPoint");
+    }
+
     return AccessPoint->InterfaceName;
 }
 
 bool
 AccessPointControllerTest::GetIsEnabled()
 {
+    if (AccessPoint == nullptr) {
+        throw std::runtime_error("AccessPointControllerTest::GetIsEnabled called with null AccessPoint");
+    }
+
     return AccessPoint->IsEnabled;
 }
 
 Ieee80211AccessPointCapabilities
 AccessPointControllerTest::GetCapabilities()
 {
+    if (AccessPoint == nullptr) {
+        throw std::runtime_error("AccessPointControllerTest::GetCapabilities called with null AccessPoint");
+    }
+
     return AccessPoint->Capabilities;
 }
 

--- a/tests/unit/wifi/helpers/AccessPointManagerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointManagerTest.cxx
@@ -1,0 +1,16 @@
+
+#include <microsoft/net/wifi/test/AccessPointManagerTest.hxx>
+
+using namespace Microsoft::Net::Wifi::Test;
+
+void
+AccessPointManagerTest::AddAccessPoint(std::shared_ptr<IAccessPoint> accessPoint)
+{
+    return AccessPointManager::AddAccessPoint(std::move(accessPoint));
+}
+
+void
+AccessPointManagerTest::RemoveAccessPoint(std::shared_ptr<IAccessPoint> accessPoint)
+{
+    return AccessPointManager::RemoveAccessPoint(std::move(accessPoint));
+}

--- a/tests/unit/wifi/helpers/AccessPointTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointTest.cxx
@@ -15,7 +15,7 @@ AccessPointTest::AccessPointTest(std::string_view interfaceName, Microsoft::Net:
 {}
 
 std::string_view
-AccessPointTest::GetInterfaceName() const noexcept
+AccessPointTest::GetInterfaceName() const
 {
     return InterfaceName;
 }

--- a/tests/unit/wifi/helpers/AccessPointTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointTest.cxx
@@ -6,7 +6,12 @@ using namespace Microsoft::Net::Wifi;
 using namespace Microsoft::Net::Wifi::Test;
 
 AccessPointTest::AccessPointTest(std::string_view interfaceName) :
-    InterfaceName(interfaceName)
+    AccessPointTest(interfaceName, Ieee80211AccessPointCapabilities{})
+{}
+
+AccessPointTest::AccessPointTest(std::string_view interfaceName, Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities capabilities) :
+    InterfaceName(interfaceName),
+    Capabilities(capabilities)
 {}
 
 std::string_view

--- a/tests/unit/wifi/helpers/AccessPointTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointTest.cxx
@@ -1,6 +1,6 @@
 
-#include <microsoft/net/wifi/test/AccessPointTest.hxx>
 #include <microsoft/net/wifi/test/AccessPointControllerTest.hxx>
+#include <microsoft/net/wifi/test/AccessPointTest.hxx>
 
 using namespace Microsoft::Net::Wifi;
 using namespace Microsoft::Net::Wifi::Test;
@@ -23,7 +23,7 @@ AccessPointTest::GetInterfaceName() const noexcept
 std::unique_ptr<IAccessPointController>
 AccessPointTest::CreateController()
 {
-    return std::make_unique<AccessPointControllerTest>(InterfaceName);
+    return std::make_unique<AccessPointControllerTest>(this);
 }
 
 std::shared_ptr<IAccessPoint>

--- a/tests/unit/wifi/helpers/CMakeLists.txt
+++ b/tests/unit/wifi/helpers/CMakeLists.txt
@@ -8,12 +8,14 @@ set(WIFI_TEST_HELPERS_PUBLIC_INCLUDE_PREFIX ${WIFI_TEST_HELPERS_PUBLIC_INCLUDE}/
 target_sources(wifi-test-helpers
     PRIVATE
         AccessPointControllerTest.cxx
+        AccessPointManagerTest.cxx
         AccessPointTest.cxx
     PUBLIC
     FILE_SET HEADERS
     BASE_DIRS ${WIFI_TEST_HELPERS_PUBLIC_INCLUDE}
     FILES
         ${WIFI_TEST_HELPERS_PUBLIC_INCLUDE_PREFIX}/AccessPointControllerTest.hxx
+        ${WIFI_TEST_HELPERS_PUBLIC_INCLUDE_PREFIX}/AccessPointManagerTest.hxx
         ${WIFI_TEST_HELPERS_PUBLIC_INCLUDE_PREFIX}/AccessPointTest.hxx
 )
 
@@ -26,5 +28,6 @@ target_include_directories(wifi-test-helpers
 
 target_link_libraries(wifi-test-helpers
     PUBLIC
+        wifi-apmanager
         wifi-core
 )

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -36,7 +36,7 @@ struct AccessPointControllerTest final :
      * @return std::string_view
      */
     virtual std::string_view
-    GetInterfaceName() const noexcept override;
+    GetInterfaceName() const override;
 
     /**
      * @brief Get whether the access point is enabled.

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -9,27 +9,84 @@
 
 namespace Microsoft::Net::Wifi::Test
 {
-struct AccessPointControllerTest final :
-    public IAccessPointController
-{
-    AccessPointControllerTest(std::string_view interfaceName);
+struct AccessPointTest;
 
+/**
+ * @brief IAccessPointController implementation for testing purposes.
+ *
+ * This implementation takes an AccessPointTest object which it uses to implement the IAccessPointController interface.
+ * The owner of this class must ensure that the passes AccessPointTest* remains valid for the lifetime of this object.
+ */
+struct AccessPointControllerTest final :
+    public Microsoft::Net::Wifi::IAccessPointController
+{
+    AccessPointTest *AccessPoint{ nullptr };
+
+    /**
+     * @brief Construct a new AccessPointControllerTest object that uses the specified AccessPointTest to implement the
+     * IAccessPointController interface.
+     *
+     * @param accessPoint The access point to use.
+     */
+    AccessPointControllerTest(AccessPointTest *accessPoint);
+
+    /**
+     * @brief Get the interface name associated with this controller.
+     *
+     * @return std::string_view
+     */
     virtual std::string_view
     GetInterfaceName() const noexcept override;
 
+    /**
+     * @brief Get whether the access point is enabled.
+     *
+     * @return true
+     * @return false
+     */
     virtual bool
     GetIsEnabled() override;
 
+    /**
+     * @brief Get the capabilities of the access point.
+     *
+     * @return Ieee80211AccessPointCapabilities
+     */
     virtual Ieee80211AccessPointCapabilities
     GetCapabilities() override;
-
-    std::string InterfaceName;
-    bool IsEnabled{ false };
 };
 
+/**
+ * @brief IAccessPointControllerFactory implementation for testing purposes.
+ */
 struct AccessPointControllerFactoryTest final :
     public Microsoft::Net::Wifi::IAccessPointControllerFactory
 {
+    AccessPointTest *AccessPoint{ nullptr };
+
+    /**
+     * @brief Construct a new AccessPointControllerFactoryTest object with no AccessPointTest parent/owner. This may
+     * only be used for cases where the constructed object won't actually be used (eg. unit tests for other components
+     * that require an IAccessPointControllerFactory, but the test doesn't trigger any functionality to use it).
+     *
+     * This should be contrained to testing creation/destruction of other objects that use this only.
+     */
+    AccessPointControllerFactoryTest() = default;
+
+    /**
+     * @brief Construct a new AccessPointControllerFactoryTest object. The owner of this object must ensure that the passed AccessPointTest remains valid for the lifetime of this object.
+     *
+     * @param accessPoint The access point to create controllers for.
+     */
+    AccessPointControllerFactoryTest(AccessPointTest *accessPoint);
+
+    /**
+     * @brief Create a new instance that can control the access point.
+     *
+     * @param interfaceName The name of the interface. If this factory was created with an AccessPointTest, this must
+     * match the interface name of the AccessPoint the object or else a std::runtime_error will be thrown.  was created
+     * @return std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController>
+     */
     std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController>
     Create(std::string_view interfaceName) override;
 };

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointManagerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointManagerTest.hxx
@@ -1,0 +1,42 @@
+
+#ifndef ACCESS_POINT_MANAGER_TEST
+#define ACCESS_POINT_MANAGER_TEST
+
+#include <memory>
+
+#include <microsoft/net/wifi/AccessPointManager.hxx>
+#include <microsoft/net/wifi/IAccessPoint.hxx>
+
+namespace Microsoft::Net::Wifi::Test
+{
+/**
+ * @brief AccessPointManager to be used in tests, allowing access to protected methods to add/remove known access
+ * points.
+ */
+struct AccessPointManagerTest :
+    public Microsoft::Net::Wifi::AccessPointManager
+{
+    /**
+     * @brief Construct a new AccessPointManagerTest object.
+     */
+    AccessPointManagerTest() = default;
+
+    /**
+     * @brief Adds a new access point.
+     *
+     * @param accessPoint The access point to add.
+     */
+    void
+    AddAccessPoint(std::shared_ptr<IAccessPoint> accessPoint) override;
+
+    /**
+     * @brief Removes an existing access point from use.
+     *
+     * @param accessPoint The access point to remove.
+     */
+    void
+    RemoveAccessPoint(std::shared_ptr<IAccessPoint> accessPoint) override;
+};
+} // namespace Microsoft::Net::Wifi::Test
+
+#endif // ACCESS_POINT_MANAGER_TEST

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -11,13 +11,39 @@
 
 namespace Microsoft::Net::Wifi::Test
 {
+/**
+ * @brief IAccessPoint implementation for testing purposes.
+ *
+ * This implementation has public members for each configurable setting, allowing consumers to read and change them at
+ * will. This is intended to be used by test code only.
+ */
 struct AccessPointTest final :
     public IAccessPoint
 {
+    std::string InterfaceName;
+    Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities Capabilities;
+    bool IsEnabled{ false };
+
+    /**
+     * @brief Construct a new AccessPointTest object with the given interface name and default capabilities.
+     *
+     * @param interfaceName The interface name to use for the access point.
+     */
     AccessPointTest(std::string_view interfaceName);
 
+    /**
+     * @brief Construct a new AccessPointTest object with the given interface name and capabilities.
+     *
+     * @param interfaceName The interface name to use for the access point.
+     * @param capabilities The capabilities to use for the access point.
+     */
     AccessPointTest(std::string_view interfaceName, Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities capabilities);
 
+    /**
+     * @brief Get the interface name of the access point.
+     *
+     * @return std::string_view
+     */
     virtual std::string_view
     GetInterfaceName() const noexcept override;
 
@@ -28,9 +54,6 @@ struct AccessPointTest final :
      */
     virtual std::unique_ptr<IAccessPointController>
     CreateController() override;
-
-    std::string InterfaceName;
-    Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities Capabilities;
 };
 
 /**
@@ -59,7 +82,7 @@ struct AccessPointFactoryTest :
      *
      * @param interface The interface to create the AccessPoint for. This can be
      * any string and does not have to correspond to a real device interface.
-     * @param createArgs 
+     * @param createArgs Arguments to be passed to the access point during creation.
      *
      * @return std::shared_ptr<IAccessPoint>
      */

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -6,6 +6,8 @@
 #include <string_view>
 
 #include <microsoft/net/wifi/IAccessPoint.hxx>
+#include <microsoft/net/wifi/Ieee80211.hxx>
+#include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
 
 namespace Microsoft::Net::Wifi::Test
 {
@@ -13,6 +15,8 @@ struct AccessPointTest final :
     public IAccessPoint
 {
     AccessPointTest(std::string_view interfaceName);
+
+    AccessPointTest(std::string_view interfaceName, Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities capabilities);
 
     virtual std::string_view
     GetInterfaceName() const noexcept override;
@@ -26,6 +30,7 @@ struct AccessPointTest final :
     CreateController() override;
 
     std::string InterfaceName;
+    Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities Capabilities;
 };
 
 /**

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -45,7 +45,7 @@ struct AccessPointTest final :
      * @return std::string_view
      */
     virtual std::string_view
-    GetInterfaceName() const noexcept override;
+    GetInterfaceName() const override;
 
     /**
      * @brief Create a new instance that can control the access point.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow tests to create fake/simulated access points to validate functionality that requires the existence of access points.

### Technical Details

* Add `AccessPointManagerTest` class which inherits from `AccessPointManager` but exposes the `AddAccessPoint` and `RemoveAccessPoint` functions, allowing tests to add/remove access points at will.
* Extend `AccessPointTest` to contain public members tracking configurable properties, including capabilities and enablement status.
* Update `AccessPointControllerTest` to take a `AccessPointTest` and use this instance to implement the `IAccessPointController` interface, reflecting all of the property values from it.
* Add documentation to test classes.

### Test Results

* All unit tests pass.

### Reviewer Focus

* Consider whether any additional functionality is needed to use these updated classes now for API validation.

### Future Work

* The test implementations will need to be updated as APIs are implemented and extended.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
