### PR TITLE
Enable building a .deb for Linux installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,12 @@ set(VCPKG_TARGET ${VCPKG_TARGET_DEVELOPMENT} CACHE STRING "vcpkg target: either 
 set(VCPKG_SUBMODULE_ROOT ${CMAKE_CURRENT_LIST_DIR}/vcpkg CACHE PATH "Location of vcpkg submodule root")
 vcpkg_configure(SUBMODULE_ROOT ${VCPKG_SUBMODULE_ROOT})
 
+find_package(Git REQUIRED)
+include(version)
+
 project(netremote
   LANGUAGES CXX
-  VERSION 0.0.1
+  VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
 )
 
 # Conditional inclusion of OS-dependent source trees.
@@ -71,7 +74,6 @@ find_package(Threads REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 find_package(CLI11 CONFIG REQUIRED)
 find_package(plog CONFIG REQUIRED)
-find_package(Git REQUIRED)
 
 # Enable POSITION_INDEPENDENT_CODE variable to control passing PIE flags to the linker.
 if (POLICY CMP0083)

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,0 +1,26 @@
+
+# Default version values in case we can't get them from git.
+set(VERSION_MAJOR 0)
+set(VERSION_MINOR 1)
+set(VERSION_PATCH 0)
+
+execute_process(
+  COMMAND "${GIT_EXECUTABLE}" describe --tags --abbrev=0
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  RESULT_VARIABLE GIT_DESCRIBE_RESULT
+  OUTPUT_VARIABLE GIT_DESCRIBE_OUTPUT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if (GIT_DESCRIBE_RESULT EQUAL 0)
+  if (GIT_DESCRIBE_OUTPUT MATCHES "^v([0-9]+)[.]([0-9]+)[.]([0-9]+)[.]*")
+    set(VERSION_MAJOR ${CMAKE_MATCH_1})
+    set(VERSION_MINOR ${CMAKE_MATCH_2})
+    set(VERSION_PATCH ${CMAKE_MATCH_3})
+    message(STATUS "Detected version from latest git tag: ${GIT_DESCRIBE_OUTPUT}")
+  else()
+    message(WARNING "Failed to get version from git: ${GIT_DESCRIBE_RESULT}; falling back to hard-coded version")
+  endif()
+endif()
+
+message(STATUS "Configuring netremote version v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -2,3 +2,7 @@
 if (NOT NETREMOTE_VCPKG_BUILD_FOR_PORT)
   add_subdirectory(vcpkg)
 endif()
+
+if (BUILD_FOR_LINUX)
+  add_subdirectory(deb)
+endif()

--- a/packaging/deb/CMakeLists.txt
+++ b/packaging/deb/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Common CPack configuration for all packages.
 set(CPACK_PACKAGE_DESCRIPTION "A framework for remotely controlling network componments such as wi-fi access points.")
 set(CPACK_COMPONENTS_GROUPING ONE_PER_GROUP)
+set(CPACK_PACKAGING_INSTALL_PREFIX "/")
 
 # .deb specific configuration.
 set(CPACK_GENERATOR "DEB")

--- a/packaging/deb/CMakeLists.txt
+++ b/packaging/deb/CMakeLists.txt
@@ -1,0 +1,14 @@
+
+# Common CPack configuration for all packages.
+set(CPACK_PACKAGE_DESCRIPTION "A framework for remotely controlling network componments such as wi-fi access points.")
+set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)
+
+# .deb specific configuration.
+set(CPACK_GENERATOR "DEB")
+set(CPACK_DEB_COMPONENT_INSTALL ON)
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "netremoteowners@microsoft.com")
+set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/microsoft/netremote")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+set(CPACK_COMPONENTS_ALL netremote-server)
+
+include(CPack)

--- a/packaging/deb/CMakeLists.txt
+++ b/packaging/deb/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # Common CPack configuration for all packages.
-set(CPACK_PACKAGE_DESCRIPTION "A framework for remotely controlling network componments such as wi-fi access points.")
+set(CPACK_PACKAGE_DESCRIPTION "A framework for remotely controlling network components such as wi-fi access points.")
 set(CPACK_COMPONENTS_GROUPING ONE_PER_GROUP)
 set(CPACK_PACKAGING_INSTALL_PREFIX "/")
 

--- a/packaging/deb/CMakeLists.txt
+++ b/packaging/deb/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 # Common CPack configuration for all packages.
 set(CPACK_PACKAGE_DESCRIPTION "A framework for remotely controlling network componments such as wi-fi access points.")
-set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)
+set(CPACK_COMPONENTS_GROUPING ONE_PER_GROUP)
 
 # .deb specific configuration.
 set(CPACK_GENERATOR "DEB")
@@ -9,6 +9,7 @@ set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "netremoteowners@microsoft.com")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/microsoft/netremote")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
-set(CPACK_COMPONENTS_ALL netremote-server)
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_COMPONENTS_ALL server)
 
 include(CPack)

--- a/src/linux/server/CMakeLists.txt
+++ b/src/linux/server/CMakeLists.txt
@@ -24,6 +24,7 @@ set_target_properties(${PROJECT_NAME}-server-linux
 install(
     TARGETS ${PROJECT_NAME}-server-linux
     EXPORT ${PROJECT_NAME}
+    COMPONENT ${PROJECT_NAME}-server
 )
 
 add_subdirectory(systemd)

--- a/src/linux/server/CMakeLists.txt
+++ b/src/linux/server/CMakeLists.txt
@@ -23,6 +23,7 @@ set_target_properties(${PROJECT_NAME}-server-linux
 
 install(
     TARGETS ${PROJECT_NAME}-server-linux
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
     EXPORT ${PROJECT_NAME}
     COMPONENT server
 )

--- a/src/linux/server/CMakeLists.txt
+++ b/src/linux/server/CMakeLists.txt
@@ -24,7 +24,7 @@ set_target_properties(${PROJECT_NAME}-server-linux
 install(
     TARGETS ${PROJECT_NAME}-server-linux
     EXPORT ${PROJECT_NAME}
-    COMPONENT ${PROJECT_NAME}-server
+    COMPONENT server
 )
 
 add_subdirectory(systemd)

--- a/src/linux/server/systemd/CMakeLists.txt
+++ b/src/linux/server/systemd/CMakeLists.txt
@@ -9,4 +9,5 @@ install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/netremote-server.service
     DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/systemd/system
+    COMPONENT server
 )


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow installation of a release package onto Linux distributions supporting `.deb` package format.

### Technical Details

* Add CPack support using the `DEB` generator to build a `.deb` package.
* Set project version for use in packaging and CMake internals from latest git tag.

### Test Results

Generated a `.deb` package for the debug configuration using cpack per below:

```bash
shadowfax@mrstux:~/src/microsoft/netremote-cmake/out/build/dev-linux$ cpack -C Debug
CPack: Create package using DEB
CPack: Install projects
CPack: - Install project: netremote [Debug]
CPack: -   Install component: server
CPack: Create package
CPackDeb: - Generating dependency list
CPack: - package: /home/shadowfax/src/microsoft/netremote-cmake/out/build/dev-linux/netremote-server_0.0.1_amd64.deb generated.
``` 

Which shows contents to be:
```bash
shadowfax@mrstux:~/src/microsoft/netremote-cmake/out/build/dev-linux$ dpkg --contents ./netremote-server_0.0.1_amd64.deb 
drwxrwxr-x root/root         0 2024-01-26 23:18 ./bin/
-rwxr-xr-x root/root 134337128 2024-01-26 23:18 ./bin/netremote-server
drwxrwxr-x root/root         0 2024-01-26 23:18 ./etc/
drwxrwxr-x root/root         0 2024-01-26 23:18 ./etc/systemd/
drwxrwxr-x root/root         0 2024-01-26 23:18 ./etc/systemd/system/
-rw-r--r-- root/root       298 2024-01-17 19:35 ./etc/systemd/system/netremote-server.service
```

### Reviewer Focus

* None

### Future Work

* The server binary is being installed to `/bin` instead of `/usr/bin`. While this will work, it should be fixed.

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
