### PR TITLE
Update .deb package generation to follow Linux Filesystem Hierarchy Standard (FHS) guidelines

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,16 +28,16 @@
             "hidden": true,
             "displayName": "Out of source build",
             "description": "Configure to build outside of the source tree",
-            "binaryDir": "${sourceParentDir}/${sourceDirName}-cmake/out/build/${presetName}",
-            "installDir": "${sourceParentDir}/${sourceDirName}-cmake/out/install/${presetName}"
+            "binaryDir": "${sourceParentDir}/${sourceDirName}-cmake/build/${presetName}",
+            "installDir": "${sourceParentDir}/${sourceDirName}-cmake/install/${presetName}"
         },
         {
             "name": "in-source-build",
             "hidden": true,
             "displayName": "In source build",
             "description": "Configure to build inside the source tree",
-            "binaryDir": "${sourceDir}/out/build/${presetName}",
-            "installDir": "${sourceDir}/out/install/${presetName}"
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "installDir": "${sourceDir}/install/${presetName}"
         },
         {
             "name": "linux-base",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,7 +28,13 @@
             "hidden": true,
             "displayName": "Out of source build",
             "description": "Configure to build outside of the source tree",
-            "binaryDir": "${sourceParentDir}/${sourceDirName}-cmake/build/${presetName}",
+            "binaryDir": "${sourceParentDir}/${sourceDirName}-cmake/build/${presetName}"
+        },
+        {
+            "name": "out-of-source-install",
+            "hidden": true,
+            "description": "Configure to install outside of the source tree",
+            "displayName": "Out of source install",
             "installDir": "${sourceParentDir}/${sourceDirName}-cmake/install/${presetName}"
         },
         {
@@ -36,7 +42,13 @@
             "hidden": true,
             "displayName": "In source build",
             "description": "Configure to build inside the source tree",
-            "binaryDir": "${sourceDir}/build/${presetName}",
+            "binaryDir": "${sourceDir}/build/${presetName}"
+        },
+        {
+            "name": "in-source-install",
+            "hidden": true,
+            "displayName": "In source install",
+            "description": "Configure to install inside the source tree",
             "installDir": "${sourceDir}/install/${presetName}"
         },
         {
@@ -61,7 +73,8 @@
             "displayName": "Development (base)",
             "description": "Base options for all development presets",
             "inherits": [
-                "out-of-source-build"
+                "out-of-source-build",
+                "out-of-source-install"
             ]
         },
         {
@@ -109,8 +122,11 @@
             "name": "release-base",
             "hidden": true,
             "inherits": [
-                "in-source-build"
-            ]
+                "out-of-source-build"
+            ],
+            "cacheVariables": {
+                "CMAKE_INSTALL_PREFIX": "/usr/local"
+            }
         },
         {
             "name": "release-linux",
@@ -144,7 +160,6 @@
             "hidden": true,
             "configuration": "Debug"
         },
-
         {
             "name": "cfg-release",
             "hidden": true,

--- a/packaging/deb/CMakeLists.txt
+++ b/packaging/deb/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Common CPack configuration for all packages.
 set(CPACK_PACKAGE_DESCRIPTION "A framework for remotely controlling network components such as wi-fi access points.")
 set(CPACK_COMPONENTS_GROUPING ONE_PER_GROUP)
-set(CPACK_PACKAGING_INSTALL_PREFIX "/")
+set(CPACK_SET_DESTDIR ON)
 
 # .deb specific configuration.
 set(CPACK_GENERATOR "DEB")

--- a/packaging/deb/CMakeLists.txt
+++ b/packaging/deb/CMakeLists.txt
@@ -11,6 +11,9 @@ set(CPACK_DEBIAN_PACKAGE_MAINTAINER "netremoteowners@microsoft.com")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/microsoft/netremote")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
-set(CPACK_COMPONENTS_ALL server)
+set(CPACK_COMPONENTS_ALL
+    server 
+    hostapd
+)
 
 include(CPack)

--- a/src/linux/external/hostap/CMakeLists.txt
+++ b/src/linux/external/hostap/CMakeLists.txt
@@ -92,6 +92,7 @@ set(HOSTAPD_CLI_BIN
 install(
     FILES ${LIBWPA_CLIENT}
     TYPE LIB
+    COMPONENT hostapd
 )
 
 install(
@@ -100,10 +101,12 @@ install(
         ${HOSTAPD_CLI_BIN}
     DESTINATION
         ${CMAKE_INSTALL_SBINDIR}
+    COMPONENT hostapd
 )
 
 install(
     DIRECTORY DESTINATION ${CMAKE_INSTALL_FULL_RUNSTATEDIR}
+    COMPONENT hostapd
 )
 
 add_subdirectory(systemd)

--- a/src/linux/external/hostap/systemd/CMakeLists.txt
+++ b/src/linux/external/hostap/systemd/CMakeLists.txt
@@ -19,5 +19,5 @@ install(
 install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/hostapd@.service
-    DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/systemd/system
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/system
 )

--- a/src/linux/server/systemd/CMakeLists.txt
+++ b/src/linux/server/systemd/CMakeLists.txt
@@ -8,6 +8,6 @@ configure_file(
 install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/netremote-server.service
-    DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/systemd/system
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/system
     COMPONENT server
 )


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure `.deb` generation follows best practices as recommended by the [Linux Filesystem Hierarchy Standard (FHS)](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html).

### Technical Details

* Install systemd `.service` files to `CMAKE_INSTALL_LIBDIR` instead of `CMAKE_INSTALL_SYSCONFDIR` per systemd guidelines.
* Separate CMake build and install settings into respective base, hidden presets to allow better control of install and packaging behaviors and locations.
* Explicitly set `CMAKE_INSTALL_PREFIX=/usr/local` to avoid relying on default behavior.
* Enable CPack to use the value of `CMAKE_INSTALL_PREFIX` for `CPACK_PACKAGING_INSTALL_PREFIX`.
* Mark hostapd artifacts as installation component, and add this component to `CPACK_COMPONENTS_ALL`.
* Remove extra directory `out` from out-of-source builds to eliminate one level in the filesystem hierarchy. This means in-source and out-of-source directory structures aren't identical since in-source necessarily need a top-level directory to denote where all generated build configuration goes, but nothing currently relies on this, so does not introduce any issues and makes the inner development loop ever slightly more efficient.

### Test Results

* Built and installed project when using CMake configure preset `Development`. Verified files go to out-of-source location.
* Built, installed, and packaged with CPack when using CMake configure preset `release-linux` and build presets `release-linux-debug` and `release-linux-release`. Verified that two packages were created, one for each component (server, hostapd), and that package contents are as expected, per below output:

```bash
shadowfax@mrstux:~/src/microsoft/netremote-cmake/build/release-linux$ dpkg --contents netremote-server_0.0.1_amd64.deb
drwxrwxr-x root/root         0 2024-01-29 00:41 ./usr/
drwxrwxr-x root/root         0 2024-01-29 00:41 ./usr/local/
drwxrwxr-x root/root         0 2024-01-29 00:41 ./usr/local/bin/
-rwxr-xr-x root/root 134337128 2024-01-29 00:41 ./usr/local/bin/netremote-server
drwxrwxr-x root/root         0 2024-01-29 00:41 ./usr/local/lib/
drwxrwxr-x root/root         0 2024-01-29 00:41 ./usr/local/lib/systemd/
drwxrwxr-x root/root         0 2024-01-29 00:41 ./usr/local/lib/systemd/system/
-rw-r--r-- root/root       241 2024-01-29 00:22 ./usr/local/lib/systemd/system/netremote-server.service

shadowfax@mrstux:~/src/microsoft/netremote-cmake/build/release-linux$ dpkg --contents netremote-hostapd_0.0.1_amd64.deb
drwxrwxr-x root/root         0 2024-01-29 00:41 ./usr/
drwxrwxr-x root/root         0 2024-01-29 00:41 ./usr/local/
drwxrwxr-x root/root         0 2024-01-29 00:41 ./usr/local/lib/
-rw-r--r-- root/root    138480 2024-01-29 00:41 ./usr/local/lib/libwpa_client.so
drwxrwxr-x root/root         0 2024-01-29 00:41 ./usr/local/sbin/
-rwxr-xr-x root/root   8647456 2024-01-29 00:20 ./usr/local/sbin/hostapd
-rwxr-xr-x root/root    347840 2024-01-29 00:20 ./usr/local/sbin/hostapd_cli
drwxrwxr-x root/root         0 2024-01-29 00:41 ./usr/local/var/
drwxr-xr-x root/root         0 2024-01-29 00:41 ./usr/local/var/run/
```

### Reviewer Focus

* None

### Future Work

* Modify the created `.deb` to trigger `dh_systemd_enable`/`dh_systemd_start` and `dh_systemd_stop`/`dh_system_disable` from `debhelper` for the `postinst` and `postrm` package scripts as appropriate.
* Update GitHub build workflows to enable creating `.deb` packages and include them in artifact upload.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
