### PR TITLE
Add hostapd systemd files as named install components.

### DIFF
--- a/src/linux/external/hostap/systemd/CMakeLists.txt
+++ b/src/linux/external/hostap/systemd/CMakeLists.txt
@@ -14,10 +14,12 @@ install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/hostapd.example.conf
     DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/hostapd
+    COMPONENT hostapd
 )
 
 install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/hostapd@.service
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/system
+    COMPONENT hostapd
 )


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure hostapd systemd service unit files are installed in the `.deb` package.

### Technical Details

* Add component name `hostapd` to the systemd unit files (`.service`, `hostapd.example.confg`), ensuring they are installed with the `hostapd` component `.deb` package.

### Test Results

* `cpack -C debug` then `sudo apt install ./netremote-hostapd_0.0.1_amd64.deb` and verified that `hostapd@.service` was installed to `/usr/local/lib/systemd/system` and `hostapd.example.conf` to `/usr/local/etc/hostapd`. 

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
