### PR TITLE
Organize CMake presets

### DIFF
--- a/.github/actions/build-with-host/action.yml
+++ b/.github/actions/build-with-host/action.yml
@@ -57,7 +57,7 @@ runs:
     shell: pwsh
 
   - name: CMake Build
-    run: cmake --build --preset ${{ inputs.preset-name }} --config ${{ inputs.build-type }}
+    run: cmake --build --preset build-${{ inputs.preset-name }} --config ${{ inputs.build-type }}
     shell: pwsh
 
   - name: CMake Test (ctest)
@@ -67,12 +67,12 @@ runs:
 
   - name: CMake Install
     if: inputs.install == 'true'
-    run: cmake --build --preset ${{ inputs.preset-name }} --target install --config ${{ inputs.build-type }}
+    run: cmake --build --preset build-${{ inputs.preset-name }} --target install --config ${{ inputs.build-type }}
     shell: pwsh
 
   - name: CMake Package (cpack)
     if: inputs.package == 'true'
-    run: cpack --preset ${{ inputs.preset-name }} -C ${{ inputs.build-type }}
+    run: cpack --preset package-${{ inputs.preset-name }} -C ${{ inputs.build-type }}
     shell: pwsh
 
   - name: Publish Artifacts

--- a/.github/actions/build-with-selfhost/action.yml
+++ b/.github/actions/build-with-selfhost/action.yml
@@ -41,7 +41,7 @@ runs:
     shell: bash
 
   - name: CMake Build
-    run: cmake --build --preset ${{ inputs.preset-name }} --config ${{ inputs.build-type }}
+    run: cmake --build --preset build-${{ inputs.preset-name }} --config ${{ inputs.build-type }}
     shell: bash
 
   - name: CMake Test (ctest)
@@ -51,12 +51,12 @@ runs:
 
   - name: CMake Install
     if: inputs.install == 'true'
-    run: cmake --build --preset ${{ inputs.preset-name }} --target install --config ${{ inputs.build-type }}
+    run: cmake --build --preset build-${{ inputs.preset-name }} --target install --config ${{ inputs.build-type }}
     shell: bash
 
   - name: CMake Package (cpack)
     if: inputs.package == 'true'
-    run: cpack --preset ${{ inputs.preset-name }} -C ${{ inputs.build-type }}
+    run: cpack --preset package-${{ inputs.preset-name }} -C ${{ inputs.build-type }}
     shell: bash
 
   - name: Publish Artifacts

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -295,7 +295,7 @@
         },
         {
             "name": "build-dev-linux",
-            "displayName": "Development Build",
+            "displayName": "Development",
             "description": "Build the project for development on Linux",
             "configurePreset": "dev-linux",
             "inherits": [
@@ -304,7 +304,7 @@
         },
         {
             "name": "build-dev-windows",
-            "displayName": "Development Build",
+            "displayName": "Development",
             "description": "Build the project for development on Windows",
             "configurePreset": "dev-windows",
             "inherits": [
@@ -312,8 +312,17 @@
             ]
         },
         {
+            "name": "build-dev-windows-arm64",
+            "displayName": "Development",
+            "description": "Build the project for development on Windows (ARM64)",
+            "configurePreset": "dev-windows-arm64",
+            "inherits": [
+                "build-dev"
+            ]
+        },
+        {
             "name": "build-release-linux",
-            "displayName": "Release Build",
+            "displayName": "Release",
             "description": "Build the project for release on Linux",
             "configurePreset": "release-linux",
             "inherits": [
@@ -322,9 +331,18 @@
         },
         {
             "name": "build-release-windows",
-            "displayName": "Release Build",
+            "displayName": "Release",
             "description": "Build the project for release on Windows",
             "configurePreset": "release-windows",
+            "inherits": [
+                "build-release"
+            ]
+        },
+        {
+            "name": "build-release-windows-arm64",
+            "displayName": "Release (ARM64)",
+            "description": "Build the project for release on Windows (ARM64)",
+            "configurePreset": "release-windows-arm64",
             "inherits": [
                 "build-release"
             ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -43,7 +43,6 @@
                 "CMAKE_GENERATOR": "Ninja Multi-Config"
             }
         },
-
         {
             "name": "out-of-source-build",
             "hidden": true,
@@ -58,7 +57,6 @@
             "displayName": "Out of source install",
             "installDir": "${sourceParentDir}/${sourceDirName}-cmake/install/${presetName}"
         },
-
         {
             "name": "in-source-build",
             "hidden": true,
@@ -73,7 +71,6 @@
             "description": "Configure to install inside the source tree",
             "installDir": "${sourceDir}/install/${presetName}"
         },
-
         {
             "name": "packaging",
             "hidden": true,
@@ -98,7 +95,6 @@
                 "packaging"
             ]
         },
-
         {
             "name": "packaging-linux",
             "hidden": true,
@@ -123,7 +119,6 @@
                 "CPACK_GENERATOR": "ZIP"
             }
         },
-
         {
             "name": "packaging-linux-dev",
             "hidden": true,
@@ -145,7 +140,6 @@
                 "packaging-windows"
             ]
         },
-
         {
             "name": "packaging-linux-release",
             "hidden": true,
@@ -167,7 +161,6 @@
                 "packaging-windows"
             ]
         },
-
         {
             "name": "dev",
             "hidden": true,
@@ -190,7 +183,6 @@
                 "packaging-release"
             ]
         },
-
         {
             "name": "dev-linux",
             "displayName": "Development",
@@ -220,7 +212,6 @@
                 "windows-arm64"
             ]
         },
-
         {
             "name": "release-linux",
             "displayName": "Release",
@@ -283,7 +274,6 @@
             "description": "Build the project with MinSizeRel configuration",
             "configuration": "MinSizeRel"
         },
-
         {
             "name": "build-dev",
             "hidden": true,
@@ -302,7 +292,6 @@
                 "cfg-release-with-debuginfo"
             ]
         },
-
         {
             "name": "build-dev-linux",
             "displayName": "Development Build",
@@ -321,7 +310,6 @@
                 "build-dev"
             ]
         },
-
         {
             "name": "build-release-linux",
             "displayName": "Release Build",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -209,7 +209,6 @@
             "description": "Base options for release on all platforms",
             "inherits": [
                 "out-of-source-build",
-                "out-of-source-install",
                 "packaging-release"
             ]
         },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -108,18 +108,6 @@
             }
         },
         {
-            "name": "packaging-windows",
-            "hidden": true,
-            "displayName": "Packaging Windows (base)",
-            "inherits": [
-                "windows",
-                "packaging"
-            ],
-            "cacheVariables": {
-                "CPACK_GENERATOR": "ZIP"
-            }
-        },
-        {
             "name": "packaging-linux-dev",
             "hidden": true,
             "displayName": "Packaging Linux (development)",
@@ -132,15 +120,6 @@
             }
         },
         {
-            "name": "packaging-windows-dev",
-            "hidden": true,
-            "displayName": "Packaging Windows (development)",
-            "description": "Packaging for development inner-loop on Windows",
-            "inherits": [
-                "packaging-windows"
-            ]
-        },
-        {
             "name": "packaging-linux-release",
             "hidden": true,
             "displayName": "Packaging Linux (release)",
@@ -151,6 +130,27 @@
             "cacheVariables": {
                 "CPACK_SET_DESTDIR": "ON"
             }
+        },
+        {
+            "name": "packaging-windows",
+            "hidden": true,
+            "displayName": "Packaging Windows (base)",
+            "inherits": [
+                "windows",
+                "packaging"
+            ],
+            "cacheVariables": {
+                "CPACK_GENERATOR": "ZIP"
+            }
+        },
+        {
+            "name": "packaging-windows-dev",
+            "hidden": true,
+            "displayName": "Packaging Windows (development)",
+            "description": "Packaging for development inner-loop on Windows",
+            "inherits": [
+                "packaging-windows"
+            ]
         },
         {
             "name": "packaging-windows-release",
@@ -173,17 +173,6 @@
             ]
         },
         {
-            "name": "release",
-            "hidden": true,
-            "displayName": "Release (base)",
-            "description": "Base options for release on all platforms",
-            "inherits": [
-                "out-of-source-build",
-                "out-of-source-install",
-                "packaging-release"
-            ]
-        },
-        {
             "name": "dev-linux",
             "displayName": "Development",
             "description": "Development inner-loop on Linux",
@@ -193,6 +182,7 @@
                 "packaging-linux-dev"
             ]
         },
+
         {
             "name": "dev-windows",
             "displayName": "Development",
@@ -210,6 +200,17 @@
             "inherits": [
                 "dev-windows",
                 "windows-arm64"
+            ]
+        },
+        {
+            "name": "release",
+            "hidden": true,
+            "displayName": "Release (base)",
+            "description": "Base options for release on all platforms",
+            "inherits": [
+                "out-of-source-build",
+                "out-of-source-install",
+                "packaging-release"
             ]
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,6 +19,7 @@
         },
         {
             "name": "windows-arm64",
+            "hidden": true,
             "displayName": "Windows ARM64",
             "description": "Base options for all Windows ARM64 builds",
             "inherits": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,23 +6,44 @@
     },
     "configurePresets": [
         {
-            "name": "os-windows",
+            "name": "windows",
             "hidden": true,
             "condition": {
                 "type": "equals",
                 "lhs": "${hostSystemName}",
                 "rhs": "Windows"
+            },
+            "cacheVariables": {
+                "CMAKE_GENERATOR": "Visual Studio 17 2022"
             }
         },
         {
-            "name": "os-linux",
+            "name": "windows-arm64",
+            "displayName": "Windows ARM64",
+            "description": "Base options for all Windows ARM64 builds",
+            "inherits": [
+                "windows"
+            ],
+            "architecture": {
+                "value": "ARM64",
+                "strategy": "set"
+            }
+        },
+        {
+            "name": "linux",
             "hidden": true,
             "condition": {
                 "type": "equals",
                 "lhs": "${hostSystemName}",
                 "rhs": "Linux"
+            },
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER": "/usr/bin/clang++-17",
+                "CMAKE_C_COMPILER": "/usr/bin/clang-17",
+                "CMAKE_GENERATOR": "Ninja Multi-Config"
             }
         },
+
         {
             "name": "out-of-source-build",
             "hidden": true,
@@ -37,6 +58,7 @@
             "displayName": "Out of source install",
             "installDir": "${sourceParentDir}/${sourceDirName}-cmake/install/${presetName}"
         },
+
         {
             "name": "in-source-build",
             "hidden": true,
@@ -51,185 +73,271 @@
             "description": "Configure to install inside the source tree",
             "installDir": "${sourceDir}/install/${presetName}"
         },
+
         {
-            "name": "linux-base",
+            "name": "packaging",
             "hidden": true,
+            "displayName": "Packaging (base)",
+            "description": "Base options for all packaging presets"
+        },
+        {
+            "name": "packaging-dev",
+            "hidden": true,
+            "displayName": "Packaging (development)",
+            "description": "Development packaging for inner-loop",
+            "inherits": [
+                "packaging"
+            ]
+        },
+        {
+            "name": "packaging-release",
+            "hidden": true,
+            "displayName": "Packaging (release)",
+            "description": "Release packaging for inner-loop",
+            "inherits": [
+                "packaging"
+            ]
+        },
+
+        {
+            "name": "packaging-linux",
+            "hidden": true,
+            "displayName": "Packaging Linux (base)",
+            "inherits": [
+                "linux",
+                "packaging"
+            ],
             "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "/usr/bin/clang++-17",
-                "CMAKE_C_COMPILER": "/usr/bin/clang-17",
-                "CMAKE_GENERATOR": "Ninja Multi-Config"
+                "CPACK_PACKAGING_INSTALL_PREFIX": "/usr/local"
             }
         },
         {
-            "name": "windows-base",
+            "name": "packaging-windows",
             "hidden": true,
+            "displayName": "Packaging Windows (base)",
+            "inherits": [
+                "windows",
+                "packaging"
+            ],
             "cacheVariables": {
-                "CMAKE_GENERATOR": "Visual Studio 17 2022"
+                "CPACK_GENERATOR": "ZIP"
             }
         },
+
         {
-            "name": "dev-packaging-base",
+            "name": "packaging-linux-dev",
             "hidden": true,
-            "displayName": "Development (packaging base)",
+            "displayName": "Packaging Linux (development)",
+            "description": "Packaging for development inner-loop on Linux",
+            "inherits": [
+                "packaging-linux"
+            ],
             "cacheVariables": {
-                "CPACK_PACKAGING_INSTALL_PREFIX": "/usr/local",
                 "CPACK_SET_DESTDIR": "OFF"
             }
         },
         {
-            "name": "release-packaging-base",
+            "name": "packaging-windows-dev",
             "hidden": true,
-            "displayName": "Release (packaging base)",
+            "displayName": "Packaging Windows (development)",
+            "description": "Packaging for development inner-loop on Windows",
+            "inherits": [
+                "packaging-windows"
+            ]
+        },
+
+        {
+            "name": "packaging-linux-release",
+            "hidden": true,
+            "displayName": "Packaging Linux (release)",
+            "description": "Packaging for release on Linux",
+            "inherits": [
+                "packaging-linux"
+            ],
             "cacheVariables": {
-                "CPACK_PACKAGING_INSTALL_PREFIX": "/usr/local",
                 "CPACK_SET_DESTDIR": "ON"
             }
         },
         {
-            "name": "dev-base",
+            "name": "packaging-windows-release",
             "hidden": true,
-            "displayName": "Development (base)",
-            "description": "Base options for all development presets",
+            "displayName": "Packaging Windows (release)",
+            "description": "Packaging for release on Windows",
             "inherits": [
-                "out-of-source-build",
-                "out-of-source-install",
-                "dev-packaging-base"
+                "packaging-windows"
             ]
         },
+
         {
             "name": "dev",
             "hidden": true,
-            "displayName": "Development",
-            "description": "Development build for inner-loop",
+            "displayName": "Development (base)",
+            "description": "Base options for development inner-loop on all platforms",
             "inherits": [
-                "dev-base"
+                "out-of-source-build",
+                "out-of-source-install",
+                "packaging-dev"
             ]
         },
         {
+            "name": "release",
+            "hidden": true,
+            "displayName": "Release (base)",
+            "description": "Base options for release on all platforms",
+            "inherits": [
+                "out-of-source-build",
+                "out-of-source-install",
+                "packaging-release"
+            ]
+        },
+
+        {
             "name": "dev-linux",
             "displayName": "Development",
-            "description": "Development build for inner-loop on Linux",
+            "description": "Development inner-loop on Linux",
             "inherits": [
-                "os-linux",
-                "linux-base",
-                "dev"
+                "dev",
+                "linux",
+                "packaging-linux-dev"
             ]
         },
         {
             "name": "dev-windows",
             "displayName": "Development",
-            "description": "Development build for inner-loop on Windows",
+            "description": "Development inner-loop on Windows",
             "inherits": [
-                "os-windows",
-                "windows-base",
-                "dev"
+                "dev",
+                "windows",
+                "packaging-windows-dev"
             ]
         },
         {
             "name": "dev-windows-arm64",
             "displayName": "Development (ARM64)",
-            "description": "Development build for inner-loop on Windows ARM64",
-            "inherits":[
-                "dev-windows"
-            ],
-            "architecture": {
-                "value": "ARM64",
-                "strategy": "set"
-            }
-        },
-        {
-            "name": "release-base",
-            "hidden": true,
+            "description": "Development inner-loop on Windows ARM64",
             "inherits": [
-                "out-of-source-build",
-                "release-packaging-base"
+                "dev-windows",
+                "windows-arm64"
+            ]
+        },
+
+        {
+            "name": "release-linux",
+            "displayName": "Release",
+            "description": "Release for Linux",
+            "inherits": [
+                "release",
+                "linux",
+                "packaging-linux-release"
             ],
             "cacheVariables": {
                 "CMAKE_INSTALL_PREFIX": "/usr/local"
             }
         },
         {
-            "name": "release-linux",
-            "inherits":[
-                "os-linux",
-                "linux-base",
-                "release-base"
+            "name": "release-windows",
+            "displayName": "Release",
+            "description": "Release for Windows",
+            "inherits": [
+                "release",
+                "windows",
+                "packaging-windows-release"
             ]
         },
         {
-            "name": "release-windows",
-            "inherits":[
-                "os-windows",
-                "windows-base",
-                "release-base"
+            "name": "release-windows-arm64",
+            "displayName": "Release (ARM64)",
+            "description": "Release for Windows ARM64",
+            "inherits": [
+                "release-windows",
+                "windows-arm64"
             ]
         }
     ],
     "buildPresets": [
         {
-            "name": "dev-linux",
-            "configurePreset": "dev-linux",
-            "configuration": "Debug"
-        },
-        {
-            "name": "dev-windows",
-            "configurePreset": "dev-windows"
-        },
-        {
             "name": "cfg-debug",
             "hidden": true,
+            "displayName": "Build (Debug)",
+            "description": "Build the project with Debug configuration",
             "configuration": "Debug"
         },
         {
             "name": "cfg-release",
             "hidden": true,
+            "displayName": "Build (Release)",
+            "description": "Build the project with Release configuration",
             "configuration": "Release"
         },
         {
-            "name": "cfg-release-with-debug",
+            "name": "cfg-release-with-debuginfo",
             "hidden": true,
+            "displayName": "Build (RelWithDebInfo)",
+            "description": "Build the project with RelWithDebInfo configuration",
             "configuration": "RelWithDebInfo"
         },
         {
-            "name": "release-linux-debug",
-            "configurePreset": "release-linux",
+            "name": "cfg-release-with-minsizerel",
+            "hidden": true,
+            "displayName": "Build (MinSizeRel)",
+            "description": "Build the project with MinSizeRel configuration",
+            "configuration": "MinSizeRel"
+        },
+
+        {
+            "name": "build-dev",
+            "hidden": true,
+            "displayName": "Development Build (base)",
+            "description": "Base options for development builds on all platforms",
             "inherits": [
                 "cfg-debug"
             ]
         },
         {
-            "name": "release-linux-release",
+            "name": "build-release",
+            "hidden": true,
+            "displayName": "Release Build (base)",
+            "description": "Base options for release builds on all platforms",
+            "inherits": [
+                "cfg-release-with-debuginfo"
+            ]
+        },
+
+        {
+            "name": "build-dev-linux",
+            "displayName": "Development Build",
+            "description": "Build the project for development on Linux",
+            "configurePreset": "dev-linux",
+            "inherits": [
+                "build-dev"
+            ]
+        },
+        {
+            "name": "build-dev-windows",
+            "displayName": "Development Build",
+            "description": "Build the project for development on Windows",
+            "configurePreset": "dev-windows",
+            "inherits": [
+                "build-dev"
+            ]
+        },
+
+        {
+            "name": "build-release-linux",
+            "displayName": "Release Build",
+            "description": "Build the project for release on Linux",
             "configurePreset": "release-linux",
             "inherits": [
-                "cfg-release"
+                "build-release"
             ]
         },
         {
-            "name": "release-linux-release-with-debug",
-            "configurePreset": "release-linux",
-            "inherits": [
-                "cfg-release-with-debug"
-            ]
-        },
-        {
-            "name": "release-windows-debug",
+            "name": "build-release-windows",
+            "displayName": "Release Build",
+            "description": "Build the project for release on Windows",
             "configurePreset": "release-windows",
             "inherits": [
-                "cfg-debug"
-            ]
-        },
-        {
-            "name": "release-windows-release",
-            "configurePreset": "release-windows",
-            "inherits": [
-                "cfg-release"
-            ]
-        },
-        {
-            "name": "release-windows-release-with-debug",
-            "configurePreset": "release-windows",
-            "inherits": [
-                "cfg-release-with-debug"
+                "build-release"
             ]
         }
     ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -364,5 +364,31 @@
                 "test-common"
             ]
         }
+    ],
+    "packagePresets": [
+        {
+            "name": "packaging-dev",
+            "configurePreset": "packaging-dev"
+        },
+        {
+            "name": "packaging-release",
+            "configurePreset": "packaging-release"
+        },
+        {
+            "name": "packaging-dev-linux",
+            "configurePreset": "dev-linux"
+        },
+        {
+            "name": "packaging-release-linux",
+            "configurePreset": "release-linux"
+        },
+        {
+            "name": "packaging-dev-windows",
+            "configurePreset": "dev-windows"
+        },
+        {
+            "name": "packaging-release-windows",
+            "configurePreset": "release-windows"
+        }
     ]
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure CMake presets are consistently named.
* Ensure CMake presets are consistently styled.
* Ensure CMake presets can be used for development loop and release cycle.

### Technical Details

* De-duplicate `<preset>-base` and `<preset>`, leaving for the latter ones in place for base settings.
* Group presets for each OS together so they're easier to find.
* Move compiler options to top-level OS presets.

### Test Results

* Executed CMake `configure`, `build`, and `install` targets for `Development` and `Release` targets on Linux.
* Executed `cpack -C <configuration=Debug|RelWithDebInfo>` for `Development` `Release` targets, and verified the created `.deb` package had the correct paths and files.

### Reviewer Focus

* None

### Future Work

* None
 
### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
