### PR TITLE
Remove OpenSSL dependency from gRPC with vcpkg overlay port

### DIFF
--- a/packaging/vcpkg/ports/grpc/00001-fix-uwp.patch
+++ b/packaging/vcpkg/ports/grpc/00001-fix-uwp.patch
@@ -1,0 +1,73 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 25990a5d8a..4bec4e1e72 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -219,6 +219,9 @@ if(UNIX)
+ endif()
+ if(WIN32)
+   set(_gRPC_PLATFORM_WINDOWS ON)
++  if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
++    set(_gRPC_PLATFORM_UWP ON)
++  endif()
+ endif()
+ 
+  # Use C11 standard
+@@ -263,6 +266,9 @@ if(MSVC)
+   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4267")
+   # TODO(jtattermusch): needed to build boringssl with VS2017, revisit later
+   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4987 /wd4774 /wd4819 /wd4996 /wd4619")
++  if(_gRPC_PLATFORM_UWP)
++    add_definitions(-DGRPC_ARES=0)
++  endif()
+   # Silences thousands of trucation warnings
+   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4503")
+   # Tell MSVC to build grpc using utf-8
+@@ -430,6 +436,10 @@ file(MAKE_DIRECTORY ${_gRPC_PROTO_GENS_DIR})
+ #     ``.proto`` files
+ #
+ function(protobuf_generate_grpc_cpp)
++  if(_gRPC_PLATFORM_UWP)
++    return()
++  endif()
++
+   if(NOT ARGN)
+     message(SEND_ERROR "Error: PROTOBUF_GENERATE_GRPC_CPP() called without any proto files")
+     return()
+@@ -552,6 +562,7 @@ if (gRPC_BUILD_GRPC_RUBY_PLUGIN)
+   list(APPEND _gRPC_PLUGIN_LIST grpc_ruby_plugin)
+ endif ()
+ 
++if(NOT _gRPC_PLATFORM_UWP)
+ add_custom_target(plugins
+   DEPENDS ${_gRPC_PLUGIN_LIST}
+ )
+@@ -567,6 +578,7 @@ add_custom_target(tools_cxx
+ 
+ add_custom_target(tools
+   DEPENDS tools_c tools_cxx)
++endif()
+ 
+ protobuf_generate_grpc_cpp_with_import_path_correction(
+   src/proto/grpc/channelz/channelz.proto src/proto/grpc/channelz/channelz.proto
+diff --git a/src/core/lib/security/credentials/alts/check_gcp_environment_windows.cc b/src/core/lib/security/credentials/alts/check_gcp_environment_windows.cc
+index 5d2bdc14de..e9870c2656 100644
+--- a/src/core/lib/security/credentials/alts/check_gcp_environment_windows.cc
++++ b/src/core/lib/security/credentials/alts/check_gcp_environment_windows.cc
+@@ -39,6 +39,7 @@ bool check_bios_data(const char*) { return false; }
+ bool check_windows_registry_product_name(HKEY root_key,
+                                          const char* reg_key_path,
+                                          const char* reg_key_name) {
++#if !defined(WINAPI_FAMILY) || WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP
+   const size_t kProductNameBufferSize = 256;
+   char const expected_substr[] = "Google";
+ 
+@@ -71,6 +72,9 @@ bool check_windows_registry_product_name(HKEY root_key,
+   }
+ 
+   return strstr(buffer, expected_substr) != nullptr;
++#else
++  return false;
++#endif
+ }
+ 
+ }  // namespace internal

--- a/packaging/vcpkg/ports/grpc/00002-static-linking-in-linux.patch
+++ b/packaging/vcpkg/ports/grpc/00002-static-linking-in-linux.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8f78306f77..e09f8fcc1e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -211,6 +211,11 @@ if (NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
+ endif()
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+ 
++if (gRPC_STATIC_LINKING AND NOT _gRPC_PLATFORM_WINDOWS)
++  # Force to static link
++  set(CMAKE_EXE_LINKER_FLAGS "-Bstatic")
++endif()
++
+ if(MSVC)
+   include(cmake/msvc_static_runtime.cmake)
+   add_definitions(-D_WIN32_WINNT=0x600 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)

--- a/packaging/vcpkg/ports/grpc/00003-undef-base64-macro.patch
+++ b/packaging/vcpkg/ports/grpc/00003-undef-base64-macro.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/lib/transport/transport.cc b/src/core/lib/transport/transport.cc
+index 5d74ec2..89494b5 100644
+--- a/src/core/lib/transport/transport.cc
++++ b/src/core/lib/transport/transport.cc
+@@ -77,6 +77,8 @@ void grpc_stream_ref_init(grpc_stream_refcount* refcount, int /*initial_refs*/,
+                                                              : nullptr);
+ }
+ 
++#undef move64
++
+ static void move64bits(uint64_t* from, uint64_t* to) {
+   *to += *from;
+   *from = 0;

--- a/packaging/vcpkg/ports/grpc/00004-link-gdi32-on-windows.patch
+++ b/packaging/vcpkg/ports/grpc/00004-link-gdi32-on-windows.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 25990a5d8a..8a632d2289 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -404,7 +404,7 @@ if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/xds)
+ endif()
+ 
+ if(WIN32)
+-  set(_gRPC_BASELIB_LIBRARIES ws2_32 crypt32)
++  set(_gRPC_BASELIB_LIBRARIES wsock32 ws2_32 crypt32 gdi32)
+ endif()
+ 
+ # Create directory for proto source files

--- a/packaging/vcpkg/ports/grpc/00005-fix-uwp-error.patch
+++ b/packaging/vcpkg/ports/grpc/00005-fix-uwp-error.patch
@@ -1,0 +1,47 @@
+diff --git a/src/core/ext/transport/chttp2/transport/hpack_parser.cc b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+index b0d3a6465b..5c48f1aa30 100644
+--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
++++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+@@ -1037,7 +1037,7 @@ class HPackParser::Parser {
+ 
+  private:
+   void GPR_ATTRIBUTE_NOINLINE LogHeader(const HPackTable::Memento& memento) {
+-    const char* type;
++    const char* type = nullptr;
+     switch (log_info_.type) {
+       case LogInfo::kHeaders:
+         type = "HDR";
+diff --git a/src/core/lib/slice/slice.cc b/src/core/lib/slice/slice.cc
+index 898a62823c..6b31cdc082 100644
+--- a/src/core/lib/slice/slice.cc
++++ b/src/core/lib/slice/slice.cc
+@@ -188,6 +188,7 @@ grpc_slice grpc_slice_from_moved_buffer(grpc_core::UniquePtr<char> p,
+                                         size_t len) {
+   uint8_t* ptr = reinterpret_cast<uint8_t*>(p.get());
+   grpc_slice slice;
++  memset(&slice, 0, sizeof(grpc_slice));
+   if (len <= sizeof(slice.data.inlined.bytes)) {
+     slice.refcount = nullptr;
+     slice.data.inlined.length = len;
+@@ -206,7 +207,7 @@ grpc_slice grpc_slice_from_moved_string(grpc_core::UniquePtr<char> p) {
+ }
+ 
+ grpc_slice grpc_slice_from_cpp_string(std::string str) {
+-  grpc_slice slice;
++  grpc_slice slice = { 0 };
+   if (str.size() <= sizeof(slice.data.inlined.bytes)) {
+     slice.refcount = nullptr;
+     slice.data.inlined.length = str.size();
+diff --git a/src/core/lib/surface/server.cc b/src/core/lib/surface/server.cc
+index 141b16e345..89d9d6dafd 100644
+--- a/src/core/lib/surface/server.cc
++++ b/src/core/lib/surface/server.cc
+@@ -902,7 +902,7 @@ grpc_call_error Server::QueueRequestedCall(size_t cq_idx, RequestedCall* rc) {
+     FailCall(cq_idx, rc, GRPC_ERROR_CREATE("Server Shutdown"));
+     return GRPC_CALL_OK;
+   }
+-  RequestMatcherInterface* rm;
++  RequestMatcherInterface* rm = nullptr;
+   switch (rc->type) {
+     case RequestedCall::Type::BATCH_CALL:
+       rm = unregistered_request_matcher_.get();

--- a/packaging/vcpkg/ports/grpc/00009-use-system-upb.patch
+++ b/packaging/vcpkg/ports/grpc/00009-use-system-upb.patch
@@ -1,0 +1,91 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 23098aa578..a8e8bc274b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -85,6 +85,9 @@ set_property(CACHE gRPC_SSL_PROVIDER PROPERTY STRINGS "module" "package")
+ set(gRPC_PROTOBUF_PROVIDER "module" CACHE STRING "Provider of protobuf library")
+ set_property(CACHE gRPC_PROTOBUF_PROVIDER PROPERTY STRINGS "module" "package")
+
++set(gRPC_UPB_PROVIDER "module" CACHE STRING "Provider of upb library")
++set_property(CACHE gRPC_UPB_PROVIDER PROPERTY STRINGS "module" "package")
++
+ set(gRPC_PROTOBUF_PACKAGE_TYPE "" CACHE STRING "Algorithm for searching protobuf package")
+ set_property(CACHE gRPC_PROTOBUF_PACKAGE_TYPE PROPERTY STRINGS "CONFIG" "MODULE")
+
+@@ -1631,6 +1634,7 @@ target_link_libraries(gpr
+   absl::time
+   absl::optional
+   absl::variant
++  ${_gRPC_UPB_LIBRARIES}
+ )
+ if(_gRPC_PLATFORM_ANDROID)
+   target_link_libraries(gpr
+@@ -2435,7 +2439,6 @@ target_link_libraries(grpc
+   gpr
+   ${_gRPC_SSL_LIBRARIES}
+   address_sorting
+-  upb
+ )
+ if(_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
+   target_link_libraries(grpc "-framework CoreFoundation")
+@@ -2979,7 +2982,6 @@ target_link_libraries(grpc_unsecure
+   absl::utility
+   gpr
+   address_sorting
+-  upb
+ )
+ if(_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
+   target_link_libraries(grpc_unsecure "-framework CoreFoundation")
+@@ -4251,6 +4253,7 @@ endif()
+
+ endif()
+
++if (gRPC_UPB_PROVIDER STREQUAL "module")
+ add_library(upb
+   third_party/upb/third_party/utf8_range/naive.c
+   third_party/upb/third_party/utf8_range/range2-neon.c
+@@ -4319,7 +4322,7 @@ if(gRPC_INSTALL)
+     ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
+   )
+ endif()
+-
++endif()
+
+ if(gRPC_BUILD_TESTS)
+
+diff --git a/cmake/gRPCConfig.cmake.in b/cmake/gRPCConfig.cmake.in
+index 3623f4aa5e..df6ced560e 100644
+--- a/cmake/gRPCConfig.cmake.in
++++ b/cmake/gRPCConfig.cmake.in
+@@ -8,6 +8,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules)
+ @_gRPC_FIND_CARES@
+ @_gRPC_FIND_ABSL@
+ @_gRPC_FIND_RE2@
++@_gRPC_FIND_UPB@
+
+ # Targets
+ include(${CMAKE_CURRENT_LIST_DIR}/gRPCTargets.cmake)
+diff --git a/cmake/upb.cmake b/cmake/upb.cmake
+index f2a0e508c3..09751f5ef0 100644
+--- a/cmake/upb.cmake
++++ b/cmake/upb.cmake
+@@ -12,9 +12,19 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
++set(_gRPC_UPB_GRPC_GENERATED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/core/ext/upb-generated" "${CMAKE_CURRENT_SOURCE_DIR}/src/core/ext/upbdefs-generated")
++if (gRPC_UPB_PROVIDER STREQUAL "module")
++
+ set(UPB_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/upb)
+
+ set(_gRPC_UPB_INCLUDE_DIR "${UPB_ROOT_DIR}")
+ set(_gRPC_UPB_GRPC_GENERATED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/core/ext/upb-generated" "${CMAKE_CURRENT_SOURCE_DIR}/src/core/ext/upbdefs-generated")
+
+ set(_gRPC_UPB_LIBRARIES upb)
++
++elseif(gRPC_UPB_PROVIDER STREQUAL "package")
++    find_package(upb CONFIG REQUIRED)
++    set(_gRPC_UPB_LIBRARIES upb::fastdecode upb::json upb::upb upb::utf8_range upb::textformat upb::reflection upb::descriptor_upb_proto)
++    set(_gRPC_UPB_INCLUDE_DIR)
++    set(_gRPC_FIND_UPB "if(NOT upb_FOUND)\n  find_package(upb CONFIG REQUIRED)\nendif()")
++endif()

--- a/packaging/vcpkg/ports/grpc/00012-fix-use-cxx17.patch
+++ b/packaging/vcpkg/ports/grpc/00012-fix-use-cxx17.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 25990a5d8a..ba8df92858 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -326,6 +326,11 @@ include(cmake/xxhash.cmake)
+ include(cmake/zlib.cmake)
+ include(cmake/download_archive.cmake)
+
++if (ABSL_USE_CXX17)
++    message(STATUS "Found absl uses CXX17, enable CXX17 feature.")
++    set(CMAKE_CXX_STANDARD 17)
++endif()
++
+ # Setup external proto library at third_party/envoy-api with 2 download URLs
+ if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/envoy-api)
+   # Download the archive via HTTP, validate the checksum, and extract to third_party/envoy-api.

--- a/packaging/vcpkg/ports/grpc/00014-pkgconfig-upbdefs.patch
+++ b/packaging/vcpkg/ports/grpc/00014-pkgconfig-upbdefs.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 48019cce95..1eda700ae8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23186,7 +23186,7 @@ generate_pkgconfig(
+   "high performance general RPC framework"
+   "${gRPC_CORE_VERSION}"
+   "gpr openssl absl_any_invocable absl_base absl_bind_front absl_cleanup absl_cord absl_core_headers absl_flat_hash_map absl_flat_hash_set absl_function_ref absl_hash absl_inlined_vector absl_memory absl_optional absl_random_random absl_span absl_status absl_statusor absl_str_format absl_strings absl_synchronization absl_time absl_type_traits absl_utility absl_variant"
+-  "-lgrpc -laddress_sorting -lre2 -lupb -lcares -lz"
++  "-lgrpc -laddress_sorting -lre2 -lupb_textformat -lupb_mini_table -lupb -lupb_collections -lupb_reflection -lupb_extension_registry -lupb_json -lupb_fastdecode -lupb_utf8_range -ldescriptor_upb_proto -lcares -lz"
+   ""
+   "grpc.pc")
+ 

--- a/packaging/vcpkg/ports/grpc/00015-disable-download-archive.patch
+++ b/packaging/vcpkg/ports/grpc/00015-disable-download-archive.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/download_archive.cmake b/cmake/download_archive.cmake
+index 820aafafb7..a59b785c7e 100644
+--- a/cmake/download_archive.cmake
++++ b/cmake/download_archive.cmake
+@@ -19,6 +19,7 @@ file(MAKE_DIRECTORY ${_download_archive_TEMPORARY_DIR})
+ # Note that strip_prefix strips the directory path prefix of the extracted
+ # archive content, and it may strip multiple directories.
+ function(download_archive destination url hash strip_prefix)
++  return()
+   # Fetch and validate
+   set(_TEMPORARY_FILE ${_download_archive_TEMPORARY_DIR}/${strip_prefix}.tar.gz)
+   message(STATUS "Downloading from ${url}, if failed, please try configuring again")

--- a/packaging/vcpkg/ports/grpc/gRPCTargets-vcpkg-tools.cmake
+++ b/packaging/vcpkg/ports/grpc/gRPCTargets-vcpkg-tools.cmake
@@ -1,0 +1,10 @@
+file(GLOB GRPC_PLUGINS "${_IMPORT_PREFIX}/../@HOST_TRIPLET@/tools/grpc/grpc_*_plugin*")
+
+foreach(PLUGIN ${GRPC_PLUGINS})
+  get_filename_component(PLUGIN_NAME "${PLUGIN}" NAME_WE)
+  add_executable(gRPC::${PLUGIN_NAME} IMPORTED)
+  set_property(TARGET gRPC::${PLUGIN_NAME} APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+  set_target_properties(gRPC::${PLUGIN_NAME} PROPERTIES
+    IMPORTED_LOCATION_RELEASE "${PLUGIN}"
+  )
+endforeach()

--- a/packaging/vcpkg/ports/grpc/portfile.cmake
+++ b/packaging/vcpkg/ports/grpc/portfile.cmake
@@ -1,0 +1,98 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO grpc/grpc
+    REF v1.51.1
+    SHA512 1bc8e7a5a15b2dca88527d111cde398b0dc1921bbc945c6df8225b4225b8ac0b43155bcf743230ce7b5962d1ab948e9363229c98a879b1befc7a939a290fb888
+    HEAD_REF master
+    PATCHES
+        00001-fix-uwp.patch
+        00002-static-linking-in-linux.patch
+        00003-undef-base64-macro.patch
+        00004-link-gdi32-on-windows.patch
+        00005-fix-uwp-error.patch
+        00009-use-system-upb.patch
+        snprintf.patch
+        00012-fix-use-cxx17.patch
+        00014-pkgconfig-upbdefs.patch
+        00015-disable-download-archive.patch
+)
+
+if(NOT TARGET_TRIPLET STREQUAL HOST_TRIPLET)
+    vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/grpc")
+endif()
+
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" gRPC_MSVC_STATIC_RUNTIME)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" gRPC_STATIC_LINKING)
+
+if(VCPKG_TARGET_IS_UWP)
+    set(cares_CARES_PROVIDER OFF)
+else()
+    set(cares_CARES_PROVIDER "package")
+endif()
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        codegen gRPC_BUILD_CODEGEN
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
+        -DgRPC_INSTALL=ON
+        -DgRPC_BUILD_TESTS=OFF
+        -DgRPC_STATIC_LINKING=${gRPC_STATIC_LINKING}
+        -DgRPC_MSVC_STATIC_RUNTIME=${gRPC_MSVC_STATIC_RUNTIME}
+        -DgRPC_ZLIB_PROVIDER=package
+        -DgRPC_SSL_PROVIDER=package
+        -DgRPC_PROTOBUF_PROVIDER=package
+        -DgRPC_ABSL_PROVIDER=package
+        -DgRPC_UPB_PROVIDER=package
+        -DgRPC_RE2_PROVIDER=package
+        -DgRPC_PROTOBUF_PACKAGE_TYPE=CONFIG
+        -DgRPC_CARES_PROVIDER=${cares_CARES_PROVIDER}
+        -DgRPC_BENCHMARK_PROVIDER=none
+        -DgRPC_INSTALL_BINDIR:STRING=bin
+        -DgRPC_INSTALL_LIBDIR:STRING=lib
+        -DgRPC_INSTALL_INCLUDEDIR:STRING=include
+        -DgRPC_INSTALL_CMAKEDIR:STRING=share/grpc
+        "-D_gRPC_PROTOBUF_PROTOC_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf/protoc${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+        "-DProtobuf_PROTOC_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/protobuf/protoc${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+    MAYBE_UNUSED_VARIABLES
+        gRPC_MSVC_STATIC_RUNTIME
+)
+
+vcpkg_cmake_install(ADD_BIN_TO_PATH)
+
+vcpkg_cmake_config_fixup()
+
+if (gRPC_BUILD_CODEGEN)
+    vcpkg_copy_tools(
+        AUTO_CLEAN
+        TOOL_NAMES
+            grpc_php_plugin
+            grpc_python_plugin
+            grpc_node_plugin
+            grpc_objective_c_plugin
+            grpc_csharp_plugin
+            grpc_cpp_plugin
+            grpc_ruby_plugin
+    )
+else()
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/gRPCTargets-vcpkg-tools.cmake" "${CURRENT_PACKAGES_DIR}/share/grpc/gRPCTargets-vcpkg-tools.cmake" @ONLY)
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share" "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_copy_pdbs()
+if (VCPKG_TARGET_IS_WINDOWS)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+else()
+    vcpkg_fixup_pkgconfig()
+endif()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/packaging/vcpkg/ports/grpc/portfile.cmake
+++ b/packaging/vcpkg/ports/grpc/portfile.cmake
@@ -48,7 +48,7 @@ vcpkg_cmake_configure(
         -DgRPC_STATIC_LINKING=${gRPC_STATIC_LINKING}
         -DgRPC_MSVC_STATIC_RUNTIME=${gRPC_MSVC_STATIC_RUNTIME}
         -DgRPC_ZLIB_PROVIDER=package
-        -DgRPC_SSL_PROVIDER=package
+        -DgRPC_SSL_PROVIDER=
         -DgRPC_PROTOBUF_PROVIDER=package
         -DgRPC_ABSL_PROVIDER=package
         -DgRPC_UPB_PROVIDER=package

--- a/packaging/vcpkg/ports/grpc/snprintf.patch
+++ b/packaging/vcpkg/ports/grpc/snprintf.patch
@@ -1,0 +1,12 @@
+diff --git a/src/core/tsi/alts/crypt/aes_gcm.cc b/src/core/tsi/alts/crypt/aes_gcm.cc
+index b761224..88a3d6b 100644
+--- a/src/core/tsi/alts/crypt/aes_gcm.cc
++++ b/src/core/tsi/alts/crypt/aes_gcm.cc
+@@ -19,6 +19,7 @@
+ #include <grpc/support/port_platform.h>
+ 
+ #include <string.h>
++#include <cstdio>
+ 
+ #include <openssl/bio.h>
+ #include <openssl/buffer.h>

--- a/packaging/vcpkg/ports/grpc/vcpkg-cmake-wrapper.cmake
+++ b/packaging/vcpkg/ports/grpc/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,2 @@
+list(REMOVE_AT ARGS 0)
+_find_package(gRPC ${ARGS}) # Shouldn't this be fixed downstream instead of using a Wrapper?

--- a/packaging/vcpkg/ports/grpc/vcpkg.json
+++ b/packaging/vcpkg/ports/grpc/vcpkg.json
@@ -1,0 +1,48 @@
+{
+  "name": "grpc",
+  "version-semver": "1.51.1",
+  "port-version": 1,
+  "description": "An RPC library and framework",
+  "homepage": "https://github.com/grpc/grpc",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "abseil",
+    {
+      "name": "c-ares",
+      "platform": "!uwp"
+    },
+    {
+      "name": "grpc",
+      "host": true,
+      "features": [
+        "codegen"
+      ]
+    },
+    "openssl",
+    "protobuf",
+    {
+      "name": "protobuf",
+      "host": true
+    },
+    "re2",
+    "upb",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ],
+  "features": {
+    "absl-sync": {
+      "description": "Deprecated."
+    },
+    "codegen": {
+      "description": "Build code generator machinery",
+      "supports": "!uwp"
+    }
+  }
+}

--- a/packaging/vcpkg/ports/grpc/vcpkg.json
+++ b/packaging/vcpkg/ports/grpc/vcpkg.json
@@ -18,7 +18,6 @@
         "codegen"
       ]
     },
-    "openssl",
     "protobuf",
     {
       "name": "protobuf",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
+  "default-registry": {
+    "kind": "git",
+    "baseline": "76a79d990dcb2e30e964322cda912db3fe395c33",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://aka.ms/vcpkg-ce-default",
+      "name": "microsoft"
+    }
+  ],
+  "overlay-ports": [
+    "./packaging/vcpkg/ports"
+  ]
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Try to avoid pulling in OpenSSL via vcpkg.

### Technical Details

* Add overlay port for gRPC using `vcpkg-configuration.json`.
* Remove `openssl` from gRPC `vcpkg.json` dependency list.
* Set `DgRPC_SSL_PROVIDER` to an empty string.

### Test Results

* TBD

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
