### PR TITLE
Expand HostapdStatus structure with IEEE 802.11 protocols N, AC, and AX.

### DIFF
--- a/src/linux/wpa-controller/CMakeLists.txt
+++ b/src/linux/wpa-controller/CMakeLists.txt
@@ -20,6 +20,8 @@ target_sources(wpa-controller
         WpaKeyValuePair.cxx
         WpaResponse.cxx
         WpaResponseParser.cxx
+        WpaParsingUtilities.hxx
+        WpaParsingUtilities.cxx
     PUBLIC
     FILE_SET HEADERS
     BASE_DIRS ${WPA_CONTROLLER_PUBLIC_INCLUDE}
@@ -45,4 +47,5 @@ target_link_libraries(wpa-controller
         notstd
     PRIVATE
         magic_enum::magic_enum
+        plog::plog
 )

--- a/src/linux/wpa-controller/WpaCommandStatus.cxx
+++ b/src/linux/wpa-controller/WpaCommandStatus.cxx
@@ -1,4 +1,5 @@
 
+#include <plog/Log.h>
 #include <Wpa/ProtocolHostapd.hxx>
 #include <Wpa/ProtocolWpa.hxx>
 #include <Wpa/WpaCommandStatus.hxx>
@@ -19,11 +20,8 @@ WpaStatusResponseParser::WpaStatusResponseParser(const WpaCommand* command, std:
     WpaResponseParser(command, responsePayload, {
         { ProtocolHostapd::ResponseStatusPropertyKeyState, WpaValuePresence::Required },
         { ProtocolHostapd::ResponseStatusPropertyKeyIeee80211N, WpaValuePresence::Required },
-        { ProtocolHostapd::ResponseStatusPropertyKeyDisable11N, WpaValuePresence::Required },
         { ProtocolHostapd::ResponseStatusPropertyKeyIeee80211AC, WpaValuePresence::Required },
-        { ProtocolHostapd::ResponseStatusPropertyKeyDisableAC, WpaValuePresence::Required },
         { ProtocolHostapd::ResponseStatusPropertyKeyIeee80211AX, WpaValuePresence::Required },
-        { ProtocolHostapd::ResponseStatusPropertyKeyDisableAX, WpaValuePresence::Required }
     })
 // clang-format on
 {

--- a/src/linux/wpa-controller/WpaCommandStatus.cxx
+++ b/src/linux/wpa-controller/WpaCommandStatus.cxx
@@ -4,6 +4,8 @@
 #include <Wpa/WpaCommandStatus.hxx>
 #include <Wpa/WpaResponseStatus.hxx>
 
+#include "WpaParsingUtilities.hxx"
+
 using namespace Wpa;
 
 std::unique_ptr<WpaResponseParser>
@@ -16,6 +18,12 @@ WpaCommandStatus::CreateResponseParser(const WpaCommand* command, std::string_vi
 WpaStatusResponseParser::WpaStatusResponseParser(const WpaCommand* command, std::string_view responsePayload) :
     WpaResponseParser(command, responsePayload, {
         { ProtocolHostapd::ResponseStatusPropertyKeyState, WpaValuePresence::Required },
+        { ProtocolHostapd::ResponseStatusPropertyKeyIeee80211N, WpaValuePresence::Required },
+        { ProtocolHostapd::ResponseStatusPropertyKeyDisable11N, WpaValuePresence::Required },
+        { ProtocolHostapd::ResponseStatusPropertyKeyIeee80211AC, WpaValuePresence::Required },
+        { ProtocolHostapd::ResponseStatusPropertyKeyDisableAC, WpaValuePresence::Required },
+        { ProtocolHostapd::ResponseStatusPropertyKeyIeee80211AX, WpaValuePresence::Required },
+        { ProtocolHostapd::ResponseStatusPropertyKeyDisableAX, WpaValuePresence::Required }
     })
 // clang-format on
 {
@@ -24,13 +32,40 @@ WpaStatusResponseParser::WpaStatusResponseParser(const WpaCommand* command, std:
 std::shared_ptr<WpaResponse>
 WpaStatusResponseParser::ParsePayload()
 {
+    using namespace Wpa::Parsing;
+
     const auto properties = GetProperties();
     const auto response = std::make_shared<WpaResponseStatus>();
+    auto& status = response->Status;
 
     for (const auto& [key, value] : properties) {
         if (key == ProtocolHostapd::ResponseStatusPropertyKeyState) {
-            response->Status.State = HostapdInterfaceStateFromString(value);
+            status.State = HostapdInterfaceStateFromString(value);
+        } else if (key == ProtocolHostapd::ResponseStatusPropertyKeyIeee80211N) {
+            ParseInt(value, status.Ieee80211n);
+        } else if (key == ProtocolHostapd::ResponseStatusPropertyKeyDisable11N) {
+            ParseInt(value, status.Disable11n);
+        } else if (key == ProtocolHostapd::ResponseStatusPropertyKeyIeee80211AC) {
+            ParseInt(value, status.Ieee80211ac);
+        } else if (key == ProtocolHostapd::ResponseStatusPropertyKeyDisableAC) {
+            ParseInt(value, status.Disable11ac);
+        } else if (key == ProtocolHostapd::ResponseStatusPropertyKeyIeee80211AX) {
+            ParseInt(value, status.Ieee80211ax);
+        } else if (key == ProtocolHostapd::ResponseStatusPropertyKeyDisableAX) {
+            ParseInt(value, status.Disable11ax);
         }
+    }
+
+    if (!!status.Ieee80211n) {
+        // TODO: parse attributes that are preset when this value is set.
+    }
+
+    if (!!status.Ieee80211ac) {
+        // TODO: parse attributes that are preset when this value is set.
+    }
+
+    if (!!status.Ieee80211ax) {
+        // TODO: parse attributes that are preset when this value is set.
     }
 
     return response;

--- a/src/linux/wpa-controller/WpaController.cxx
+++ b/src/linux/wpa-controller/WpaController.cxx
@@ -2,10 +2,10 @@
 #include <array>
 #include <cstddef>
 #include <format>
-#include <iostream>
 #include <mutex>
 
 #include <magic_enum.hpp>
+#include <plog/Log.h>
 #include <wpa_ctrl.h>
 
 #include <Wpa/WpaController.hxx>
@@ -63,7 +63,7 @@ WpaController::GetCommandControlSocket()
     const auto controlSocketPath = m_controlSocketPath / m_interfaceName;
     struct wpa_ctrl* controlSocket = wpa_ctrl_open(controlSocketPath.c_str());
     if (controlSocket == nullptr) {
-        std::cerr << std::format("Failed to open control socket for {} interface at {}.", m_interfaceName, controlSocketPath.c_str()) << std::endl;
+        LOGE << std::format("Failed to open control socket for {} interface at {}.\n", m_interfaceName, controlSocketPath.c_str());
         return nullptr;
     }
 
@@ -78,7 +78,7 @@ WpaController::SendCommand(const WpaCommand& command)
     // Obtain a control socket connection to send the command over.
     struct wpa_ctrl* controlSocket = GetCommandControlSocket();
     if (controlSocket == nullptr) {
-        std::cerr << std::format("Failed to get control socket for {}.", m_interfaceName) << std::endl;
+        LOGE << std::format("Failed to get control socket for {}.\n", m_interfaceName);
         return nullptr;
     }
 
@@ -93,13 +93,13 @@ WpaController::SendCommand(const WpaCommand& command)
         return command.ParseResponse(responsePayload);
     }
     case -1:
-        std::cerr << std::format("Failed to send or receive command to {} interface.", m_interfaceName) << std::endl;
+        LOGE << std::format("Failed to send or receive command to {} interface.\n", m_interfaceName);
         return nullptr;
     case -2:
-        std::cerr << std::format("Sending command to {} interface timed out.", m_interfaceName) << std::endl;
+        LOGE << std::format("Sending command to {} interface timed out.\n", m_interfaceName);
         return nullptr;
     default:
-        std::cerr << std::format("Unknown error sending command to {} interface (ret={}).", m_interfaceName, ret) << std::endl;
+        LOGE << std::format("Unknown error sending command to {} interface (ret={}).\n", m_interfaceName, ret);
         return nullptr;
     }
 }

--- a/src/linux/wpa-controller/WpaKeyValuePair.cxx
+++ b/src/linux/wpa-controller/WpaKeyValuePair.cxx
@@ -2,6 +2,7 @@
 #include <format>
 #include <stdexcept>
 
+#include <plog/Log.h>
 #include <Wpa/WpaKeyValuePair.hxx>
 
 using namespace Wpa;
@@ -15,7 +16,15 @@ WpaKeyValuePair::TryParseValue(std::string_view input)
         const auto keyPosition = input.find(Key);
         if (keyPosition != input.npos) {
             // Assign the starting position of the value, advancing past the key.
-            Value = std::data(input) + keyPosition + std::size(Key);
+            input = input.substr(keyPosition + std::size(Key));
+
+            // Find the end of the line, marking the end of the value string.
+            const auto eolPosition = input.find('\n');
+            if (eolPosition != input.npos) {
+                Value = input.substr(0, eolPosition);
+            } else {
+                LOGW << std::format("Failed to parse value for key: {} (missing eol)", Key);
+            }
         }
     }
 

--- a/src/linux/wpa-controller/WpaParsingUtilities.cxx
+++ b/src/linux/wpa-controller/WpaParsingUtilities.cxx
@@ -1,0 +1,22 @@
+
+#include <charconv>
+#include <format>
+
+#include <plog/Log.h>
+
+#include "WpaParsingUtilities.hxx"
+
+namespace Wpa::Parsing
+{
+bool
+ParseInt(std::string_view value, int& valueInt) noexcept
+{
+    const auto [ptr, ec] = std::from_chars(std::data(value), std::data(value) + std::size(value), valueInt);
+    if (ec != std::errc() || ptr != std::data(value) + std::size(value)) {
+        LOGE << std::format("Failed to parse integer value: '{}'", value);
+        return false;
+    }
+
+    return true;
+}
+} // namespace Wpa::Parsing

--- a/src/linux/wpa-controller/WpaParsingUtilities.hxx
+++ b/src/linux/wpa-controller/WpaParsingUtilities.hxx
@@ -1,0 +1,22 @@
+
+#ifndef WPA_PARSING_UTILITIES_HXX
+#define WPA_PARSING_UTILITIES_HXX
+
+#include <string_view>
+
+namespace Wpa::Parsing
+{
+/**
+ * @brief Parse a string into an integer.
+ * 
+ * @param value The string to parse.
+ * @param valueInt The integer to store the result in.
+ * @return true 
+ * @return false 
+ */
+bool
+ParseInt(std::string_view value, int& valueInt) noexcept;
+
+} // namespace Wpa::Parsing
+
+#endif // WPA_PARSING_UTILITIES_HXX

--- a/src/linux/wpa-controller/WpaResponseParser.cxx
+++ b/src/linux/wpa-controller/WpaResponseParser.cxx
@@ -2,6 +2,7 @@
 #include <format>
 #include <iostream>
 
+#include <plog/Log.h>
 #include <Wpa/WpaResponseParser.hxx>
 
 using namespace Wpa;
@@ -47,7 +48,7 @@ WpaResponseParser::TryParseProperties()
             propertyToParseIterator = m_propertiesToParse.erase(propertyToParseIterator);
             continue;
         } else if (propertyToParse.IsRequired) {
-            std::cerr << std::format("Failed to parse required property: {}", propertyToParse.Key) << std::endl;
+            LOGE << std::format("Failed to parse required property: {}\nPayload {}\n", propertyToParse.Key, ResponsePayload);
             return false;
         } else {
             ++propertyToParseIterator;

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -96,9 +96,12 @@ struct HostapdStatus
     // int EdmgEnable{ 0 };
     // uint8_t EdmgChannel{ 0 };
     // int SecondaryChannel{ 0 };
-    // int Ieee80211n{ 0 };
-    // int Ieee80211ac{ 0 };
-    // int Ieee80211ax{ 0 };
+    int Ieee80211n{ 0 };
+    int Ieee80211ac{ 0 };
+    int Ieee80211ax{ 0 };
+    int Disable11n{ 0 };
+    int Disable11ac{ 0 };
+    int Disable11ax{ 0 };
     // int Ieee80211be{ 0 };
     // uint16_t BeaconInterval{ 0 };
     // int DtimPeriod{ 0 };
@@ -200,17 +203,37 @@ struct ProtocolHostapd :
     static constexpr auto PropertyHwModeValueAD = "ad";
     static constexpr auto PropertyHwModeValueAny = "any";
 
-    static constexpr auto PropertyNameIeee80211N = "ieee80211n";
-    static constexpr auto PropertyNameDisable11N = "disable_11n";
-    static constexpr auto PropertyNameIeee80211AC = "ieee80211ac";
-    static constexpr auto PropertyNameDisable11AC = "disable_11ac";
-    static constexpr auto PropertyNameIeee80211AX = "ieee80211ax";
-    static constexpr auto PropertyNameDisable11AX = "disable_11ax";
+#define HOSTAPD_PROPERTY_KEY_VALUE_DELIMETER "="
+#define HOSTAPD_PROPERTY_NAME_IEEE80211N     "ieee80211n"
+#define HOSTAPD_PROPERTY_NAME_DISABLE11N     "disable_11n"
+#define HOSTAPD_PROPERTY_NAME_IEEE80211AC    "ieee80211ac"
+#define HOSTAPD_PROPERTY_NAME_DISABLE11AC    "disable_11ac"
+#define HOSTAPD_PROPERTY_NAME_IEEE80211AX    "ieee80211ax"
+#define HOSTAPD_PROPERTY_NAME_DISABLE11AX    "disable_11ax"
+#define HOSTAPD_PROPERTY_NAME_STATE          "state"
+
+// Helper macro to create a hostapd configuration file key with value delimiter.
+#define HOSTAPD_DELIMITED_KEY(name) name HOSTAPD_PROPERTY_KEY_VALUE_DELIMETER
+
+    static constexpr auto ProperyKeyValueNameDelimeter = HOSTAPD_PROPERTY_KEY_VALUE_DELIMETER;
+    static constexpr auto PropertyNameIeee80211N = HOSTAPD_PROPERTY_NAME_IEEE80211N;
+    static constexpr auto PropertyNameDisable11N = HOSTAPD_PROPERTY_NAME_DISABLE11N;
+    static constexpr auto PropertyNameIeee80211AC = HOSTAPD_PROPERTY_NAME_IEEE80211AC;
+    static constexpr auto PropertyNameDisable11AC = HOSTAPD_PROPERTY_NAME_DISABLE11AC;
+    static constexpr auto PropertyNameIeee80211AX = HOSTAPD_PROPERTY_NAME_IEEE80211AX;
+    static constexpr auto PropertyNameDisable11AX = HOSTAPD_PROPERTY_NAME_DISABLE11AX;
     static constexpr auto PropertyNameWmmEnabled = "wmm_enabled";
 
     // Response properties for the "STATUS" command.
     // Note: all properties must be terminated with the key-value delimeter (=).
-    static constexpr auto ResponseStatusPropertyKeyState = "state=";
+    static constexpr auto PropertyNameState = HOSTAPD_PROPERTY_NAME_STATE;
+    static constexpr auto ResponseStatusPropertyKeyState = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_STATE);
+    static constexpr auto ResponseStatusPropertyKeyIeee80211N = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_IEEE80211N);
+    static constexpr auto ResponseStatusPropertyKeyDisable11N = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_DISABLE11N);
+    static constexpr auto ResponseStatusPropertyKeyIeee80211AC = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_IEEE80211AC);
+    static constexpr auto ResponseStatusPropertyKeyDisableAC = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_DISABLE11AC);
+    static constexpr auto ResponseStatusPropertyKeyIeee80211AX = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_IEEE80211AX);
+    static constexpr auto ResponseStatusPropertyKeyDisableAX = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_DISABLE11AX);
 };
 
 /**

--- a/tests/unit/linux/wpa-controller/CMakeLists.txt
+++ b/tests/unit/linux/wpa-controller/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(wpa-controller-test-unit
         detail/WifiVirtualDeviceManager.cxx
         detail/WpaDaemonCatch2EventListener.cxx
         detail/WpaDaemonManager.cxx
+        Main.cxx
         TestHostapd.cxx
         TestWpaController.cxx
 )
@@ -17,8 +18,9 @@ target_include_directories(wpa-controller-test-unit
 
 target_link_libraries(wpa-controller-test-unit
     PRIVATE
-        Catch2::Catch2WithMain
+        Catch2::Catch2
         magic_enum::magic_enum
+        plog::plog
         strings
         wpa-controller
 )

--- a/tests/unit/linux/wpa-controller/Main.cxx
+++ b/tests/unit/linux/wpa-controller/Main.cxx
@@ -1,0 +1,15 @@
+
+#include <catch2/catch_session.hpp>
+#include <plog/Appenders/ColorConsoleAppender.h>
+#include <plog/Formatters/MessageOnlyFormatter.h>
+#include <plog/Init.h>
+#include <plog/Log.h>
+
+int main(int argc, char* argv[])
+{
+    static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
+
+    plog::init(plog::verbose, &colorConsoleAppender);
+
+    return Catch::Session().run(argc, argv);
+}

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -120,6 +120,40 @@ TEST_CASE("Send command: GetStatus() (root)", "[wpa][hostapd][client][remote]")
         ieee80211nValueUpdated = hostapd.GetStatus().Ieee80211n;
         REQUIRE(ieee80211nValueUpdated == ieee80211nValueExpected);
     }
+
+    SECTION("GetStatus() reflects changes in IEEE 802.11ac state")
+    {
+        using namespace Wpa::Test;
+
+        const auto ieee80211acInitial = hostapd.GetStatus().Ieee80211ac;
+
+        auto ieee80211acValueExpected = !!ieee80211acInitial;
+        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AC, GetPropertyEnablementValue(ieee80211acValueExpected)));
+        auto ieee80211acValueUpdated = hostapd.GetStatus().Ieee80211ac;
+        REQUIRE(ieee80211acValueUpdated == ieee80211acValueExpected);
+
+        ieee80211acValueExpected = !!ieee80211acValueUpdated;
+        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AC, GetPropertyEnablementValue(ieee80211acValueExpected)));
+        ieee80211acValueUpdated = hostapd.GetStatus().Ieee80211ac;
+        REQUIRE(ieee80211acValueUpdated == ieee80211acValueExpected);
+    }
+
+    SECTION("GetStatus() reflects changes in IEEE 802.11ax state")
+    {
+        using namespace Wpa::Test;
+
+        const auto ieee80211axInitial = hostapd.GetStatus().Ieee80211ax;
+
+        auto ieee80211axValueExpected = !!ieee80211axInitial;
+        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AX, GetPropertyEnablementValue(ieee80211axValueExpected)));
+        auto ieee80211axValueUpdated = hostapd.GetStatus().Ieee80211ax;
+        REQUIRE(ieee80211axValueUpdated == ieee80211axValueExpected);
+
+        ieee80211axValueExpected = !!ieee80211axValueUpdated;
+        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AX, GetPropertyEnablementValue(ieee80211axValueExpected)));
+        ieee80211axValueUpdated = hostapd.GetStatus().Ieee80211ax;
+        REQUIRE(ieee80211axValueUpdated == ieee80211axValueExpected);
+    }
 }
 
 TEST_CASE("Send GetProperty() command (root)", "[wpa][hostapd][client][remote]")

--- a/tests/unit/linux/wpa-controller/detail/WpaDaemonManager.cxx
+++ b/tests/unit/linux/wpa-controller/detail/WpaDaemonManager.cxx
@@ -3,11 +3,12 @@
 #include <filesystem>
 #include <format>
 #include <fstream>
-#include <iostream>
 #include <sstream>
 
 #include "WpaDaemonManager.hxx"
+
 #include <magic_enum.hpp>
+#include <plog/Log.h>
 #include <signal.h>
 
 namespace detail
@@ -69,7 +70,7 @@ WpaDaemonManager::FindDaemonBinary(Wpa::WpaType wpaType, std::filesystem::path s
 
     const auto daemon = Wpa::GetWpaTypeDaemonBinaryName(wpaType);
 
-    std::cout << std::format("Searching for hostapd daemon binary '{}' in '{}'\n", daemon, searchPath.c_str());
+    LOGI << std::format("Searching for hostapd daemon binary '{}' in '{}'\n", daemon, searchPath.c_str());
 
     for (const auto& directoryEntry : std::filesystem::recursive_directory_iterator(searchPath)) {
         if (directoryEntry.is_regular_file() && directoryEntry.path().filename() == daemon) {
@@ -103,7 +104,7 @@ WpaDaemonManager::CreateAndWriteDefaultConfigurationFile(Wpa::WpaType wpaType, s
     daemonConfigurationFile.flush();
     daemonConfigurationFile.close();
 
-    std::cout << std::format("Created default configuration file for wpa '{}' daemon at {}\n", daemon, daemonConfigurationFilePath.c_str());
+    LOGI << std::format("Created default configuration file for wpa '{}' daemon at {}\n", daemon, daemonConfigurationFilePath.c_str());
     return daemonConfigurationFilePath;
 }
 
@@ -126,19 +127,19 @@ WpaDaemonManager::Start(Wpa::WpaType wpaType, std::string_view interfaceName, co
     // -P -> write pid to file
     // -i -> interface name
     const auto daemonStartCommand = std::format("{} -B -P {} -i {} {} {} {}", daemonFilePath.c_str(), pidFilePath.c_str(), interfaceName, extraCommandLineArguments, configurationFileArgumentPrefix, configurationFilePath.c_str());
-    std::cout << std::format("Starting wpa daemon with command '{}'\n", daemonStartCommand);
+    LOGI << std::format("Starting wpa daemon with command '{}'\n", daemonStartCommand);
 
     int ret = std::system(daemonStartCommand.c_str());
     if (ret == -1) {
         ret = WEXITSTATUS(ret);
-        std::cerr << std::format("Failed to start wpa '{}' daemon, ret={}\n", daemon, ret);
+        LOGE << std::format("Failed to start wpa '{}' daemon, ret={}\n", daemon, ret);
         return std::nullopt;
     }
 
     // Open the pid file on the running daemon.
     std::ifstream pidFile{ pidFilePath };
     if (!pidFile.is_open()) {
-        std::cerr << std::format("Failed to open pid file for wpa '{}' daemon\n", daemon);
+        LOGE << std::format("Failed to open pid file for wpa '{}' daemon\n", daemon);
         return std::nullopt;
     }
 
@@ -148,11 +149,11 @@ WpaDaemonManager::Start(Wpa::WpaType wpaType, std::string_view interfaceName, co
     pidFileContents << pidFile.rdbuf();
     pidFileContents >> pid;
     if (pid == 0 || pidFileContents.fail()) {
-        std::cerr << std::format("Failed to read pid file {} for wpa '{}' daemon\n", pidFilePath.c_str(), daemon);
+        LOGE << std::format("Failed to read pid file {} for wpa '{}' daemon\n", pidFilePath.c_str(), daemon);
         return std::nullopt;
     }
 
-    std::cout << std::format("Started wpa '{}' daemon with pid {}\n", daemon, pid);
+    LOGI << std::format("Started wpa '{}' daemon with pid {}\n", daemon, pid);
 
     // Return a handle to the daemon instance.
     return WpaDaemonInstanceHandle{
@@ -167,13 +168,13 @@ WpaDaemonManager::StartDefault(Wpa::WpaType wpaType, std::string_view interfaceN
 {
     auto configurationFilePath = CreateAndWriteDefaultConfigurationFile(wpaType, interfaceName);
     if (configurationFilePath.empty()) {
-        std::cerr << std::format("Failed to create default configuration file for wpa '{}' daemon\n", Wpa::GetWpaTypeDaemonBinaryName(wpaType));
+        LOGE << std::format("Failed to create default configuration file for wpa '{}' daemon\n", Wpa::GetWpaTypeDaemonBinaryName(wpaType));
         return std::nullopt;
     }
 
     auto daemonFilePath = FindDaemonBinary(wpaType);
     if (daemonFilePath.empty()) {
-        std::cerr << std::format("Failed to find wpa '{}' daemon binary\n", magic_enum::enum_name(wpaType));
+        LOGE << std::format("Failed to find wpa '{}' daemon binary\n", magic_enum::enum_name(wpaType));
         return std::nullopt;
     }
 
@@ -187,12 +188,12 @@ WpaDaemonManager::Stop(const WpaDaemonInstanceHandle& instanceHandle)
     // Kill the process associated with the daemon instance.
     int ret = kill(instanceHandle.Pid, SIGTERM);
     if (ret != 0) {
-        std::cerr << std::format("Failed to stop wpa '{}' daemon, ret={}\n", magic_enum::enum_name(instanceHandle.WpaType), ret);
+        LOGE << std::format("Failed to stop wpa '{}' daemon, ret={}\n", magic_enum::enum_name(instanceHandle.WpaType), ret);
         return false;
     }
 
     const auto daemon = Wpa::GetWpaTypeDaemonBinaryName(instanceHandle.WpaType);
-    std::cout << std::format("Stopped wpa '{}' daemon with pid {}\n", daemon, instanceHandle.Pid);
+    LOGI << std::format("Stopped wpa '{}' daemon with pid {}\n", daemon, instanceHandle.Pid);
 
     return true;
 }

--- a/tests/unit/linux/wpa-controller/detail/WpaDaemonManager.hxx
+++ b/tests/unit/linux/wpa-controller/detail/WpaDaemonManager.hxx
@@ -13,7 +13,7 @@
 #include <Wpa/WpaCore.hxx>
 
 /**
- * @brief Handle referencing an running wpa daemon instance.
+ * @brief Handle referencing a running wpa daemon instance.
  */
 struct WpaDaemonInstanceHandle
 {
@@ -36,6 +36,15 @@ struct WpaDaemonManager
      * @brief The default path to the daemon control socket, if not specified.
      */
     static constexpr auto ControlSocketPathBase{ "/run/" };
+
+    /**
+     * @brief Attempts to find the binary for the specified wpa daemon type.
+     *
+     * @param wpaType The type of wpa daemon to find the binary for.
+     * @return std::filesystem::path The path to the daemon binary, if found. Otherwise, an empty path.
+     */
+    static std::filesystem::path
+    FindDaemonBinary(Wpa::WpaType wpaType, std::filesystem::path searchPath = std::filesystem::current_path());
 
     /**
      * @brief Create and write a default configuration file to disk for the
@@ -65,12 +74,13 @@ struct WpaDaemonManager
      *
      * @param wpaType The type of wpa daemon to start.
      * @param interfaceName The wlan interface for the daemon to use.
+     * @param daemonFilePath The path to the daemon binary, including the daemon name.
      * @param configurationFilePath The path to the daemon configuration file.
      * @param extraCommandLineArguments The command line arguments to be passed to the daemon binary.
      * @return std::optional<WpaDaemonInstanceHandle>
      */
     static std::optional<WpaDaemonInstanceHandle>
-    Start(Wpa::WpaType wpaType, std::string_view interfaceName, const std::filesystem::path& configurationFilePath, std::string_view extraCommandLineArguments = "");
+    Start(Wpa::WpaType wpaType, std::string_view interfaceName, const std::filesystem::path& daemonFilePath, const std::filesystem::path& configurationFilePath, std::string_view extraCommandLineArguments = "");
 
     /**
      * @brief Stop a running instance of the specified wpa daemon.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Enable obtaining 802.11 protocol support from hostapd.

### Technical Details

* Modify `HostapdStatus` to include fields for 802.11 N, AC, and AX support.
* Add parsing code for above fields from the hostapd `"STATUS"` command.
* Improve top-level wpa parsing code to terminate the value portion of the key-value pair at the newline position.
* Add logging support to `wpa-controller-test-unit` and replace `std::c*` instances with corresponding plog `LOG*`.
* Add generic wpa parsing utilities.
* Modify `WpaDaemonManager` to require daemon binary filesystem path.

### Test Results

* `wpa_controller-test-unit` run under `sudo` (expected) passes.

### Reviewer Focus

* None

### Future Work

* Parsing for 802.11 dependent properties still needs to be done. This information is not currently used so is deferred to a future PR when needed.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
