### PR TITLE
Improve AccessPointManager::GetAccessPoint

### DIFF
--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -30,6 +30,7 @@ enum WifiAccessPointOperationStatusCode
     WifiAccessPointOperationStatusCodeAccessPointInvalid = 3;
     WifiAccessPointOperationStatusCodeAccessPointNotEnabled = 4;
     WifiAccessPointOperationStatusCodeOperationNotSupported = 5;
+    WifiAccessPointOperationStatusCodeInternalError = 6;
 }
 
 message WifiAccessPointOperationStatus

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -352,7 +352,7 @@ NetRemoteAccessPointResultItemIsInvalid(const Microsoft::Net::Remote::Wifi::Wifi
 
 /**
  * @brief Handle a failure for a request that referecnes an access point.
- * 
+ *
  * @tparam RequestT The request type. This must contain an access point id (trait).
  * @tparam ResultT The result type. This must contain an access point id and a status (traits).
  * @param request A reference to the request.
@@ -360,7 +360,7 @@ NetRemoteAccessPointResultItemIsInvalid(const Microsoft::Net::Remote::Wifi::Wifi
  * @param code The error code to set in the result message.
  * @param message The error message to set in the result message.
  * @param grpcStatus The status to be returned to the client.
- * @return ::grpc::Status 
+ * @return ::grpc::Status
  */
 template <
     typename RequestT,
@@ -384,13 +384,13 @@ HandleFailure(RequestT& request, ResultT& result, WifiAccessPointOperationStatus
 
 /**
  * @brief Attempt to obtain an IAccessPintController instance for the access point in the specified request message.
- * 
+ *
  * @tparam RequestT The request type. This must contain an access point id (trait).
  * @tparam ResultT The result type. This must contain an access point id and a status (traits).
  * @param request A reference to the request.
  * @param result A reference to the result.
- * @param accessPointManager 
- * @return std::shared_ptr<IAccessPointController> 
+ * @param accessPointManager
+ * @return std::shared_ptr<IAccessPointController>
  */
 template <
     typename RequestT,

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -12,9 +12,12 @@
 
 using namespace Microsoft::Net::Remote::Service;
 
+using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus;
+using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode;
 using Microsoft::Net::Wifi::AccessPointControllerException;
 using Microsoft::Net::Wifi::AccessPointManager;
 using Microsoft::Net::Wifi::IAccessPoint;
+using Microsoft::Net::Wifi::IAccessPointController;
 
 NetRemoteService::NetRemoteService(std::shared_ptr<AccessPointManager> accessPointManager) :
     m_accessPointManager(std::move(accessPointManager))
@@ -325,7 +328,7 @@ IAccessPointToNetRemoteAccessPointResultItem(IAccessPoint& accessPoint)
 }
 
 Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResultItem
-IAccessPointWeakToNetRemoteAccessPointResultItem(std::weak_ptr<Microsoft::Net::Wifi::IAccessPoint>& accessPointWeak)
+IAccessPointWeakToNetRemoteAccessPointResultItem(std::weak_ptr<IAccessPoint>& accessPointWeak)
 {
     using Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResultItem;
 
@@ -341,23 +344,86 @@ IAccessPointWeakToNetRemoteAccessPointResultItem(std::weak_ptr<Microsoft::Net::W
     return item;
 }
 
-std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController>
-IAccessPointWeakToAccessPointController(std::weak_ptr<Microsoft::Net::Wifi::IAccessPoint>& accessPointWeak)
-{
-    auto accessPoint = accessPointWeak.lock();
-    if (accessPoint != nullptr) {
-        return accessPoint->CreateController();
-    } else {
-        LOGE << "Failed to retrieve access point as it is no longer valid";
-    }
-
-    return nullptr;
-}
-
 bool
 NetRemoteAccessPointResultItemIsInvalid(const Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResultItem& item)
 {
     return (item.accesspointid() == AccessPointIdInvalid);
+}
+
+/**
+ * @brief Handle a failure for a request that referecnes an access point.
+ * 
+ * @tparam RequestT The request type. This must contain an access point id (trait).
+ * @tparam ResultT The result type. This must contain an access point id and a status (traits).
+ * @param request A reference to the request.
+ * @param result A reference to the result.
+ * @param code The error code to set in the result message.
+ * @param message The error message to set in the result message.
+ * @param grpcStatus The status to be returned to the client.
+ * @return ::grpc::Status 
+ */
+template <
+    typename RequestT,
+    typename ResultT>
+::grpc::Status
+HandleFailure(RequestT& request, ResultT& result, WifiAccessPointOperationStatusCode code, std::string_view message, ::grpc::Status grpcStatus = ::grpc::Status::OK)
+{
+    LOGE << message;
+
+    // Populate status.
+    WifiAccessPointOperationStatus status{};
+    status.set_code(code);
+    status.set_message(std::string(message));
+
+    // Populate result fields expected on error conditions.
+    result->set_accesspointid(request->accesspointid());
+    *result->mutable_status() = std::move(status);
+
+    return grpcStatus;
+}
+
+/**
+ * @brief Attempt to obtain an IAccessPintController instance for the access point in the specified request message.
+ * 
+ * @tparam RequestT The request type. This must contain an access point id (trait).
+ * @tparam ResultT The result type. This must contain an access point id and a status (traits).
+ * @param request A reference to the request.
+ * @param result A reference to the result.
+ * @param accessPointManager 
+ * @return std::shared_ptr<IAccessPointController> 
+ */
+template <
+    typename RequestT,
+    typename ResultT>
+std::shared_ptr<IAccessPointController>
+TryGetAccessPointController(RequestT& request, ResultT& result, std::shared_ptr<AccessPointManager>& accessPointManager)
+{
+    const auto& accessPointId = request->accesspointid();
+
+    // Find the requested AP.
+    auto accessPointOpt = accessPointManager->GetAccessPoint(accessPointId);
+    if (!accessPointOpt.has_value()) {
+        LOGW << std::format("Access point {} not found", accessPointId);
+        HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointInvalid, std::format("Access point {} not found", accessPointId));
+        return nullptr;
+    }
+
+    // Attempt to promote the weak reference to a strong reference.
+    auto accessPointWeak{ accessPointOpt.value() };
+    auto accessPoint = accessPointWeak.lock();
+    if (accessPoint == nullptr) {
+        HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointInvalid, std::format("Access point {} is no longer valid", accessPointId));
+        return nullptr;
+    }
+
+    // Create a controller for this access point.
+    auto accessPointController = accessPoint->CreateController();
+    if (accessPointController == nullptr) {
+        HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInternalError, std::format("Failed to create controller for access point {}", accessPointId));
+        return nullptr;
+    }
+
+    return accessPointController;
 }
 } // namespace detail
 
@@ -387,8 +453,6 @@ NetRemoteService::WifiEnumerateAccessPoints([[maybe_unused]] ::grpc::ServerConte
     return grpc::Status::OK;
 }
 
-using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus;
-using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode;
 using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
 using Microsoft::Net::Wifi::Dot11CipherSuite;
 using Microsoft::Net::Wifi::Dot11PhyType;
@@ -456,10 +520,9 @@ NetRemoteService::WifiAccessPointSetPhyType([[maybe_unused]] ::grpc::ServerConte
     }
 
     // Create an AP controller for the requested AP.
-    auto accessPointWeak = m_accessPointManager->GetAccessPoint(request->accesspointid());
-    auto accessPointController = detail::IAccessPointWeakToAccessPointController(accessPointWeak);
-    if (!accessPointController) {
-        return handleFailure(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointInvalid, std::format("Failed to create controller for access point {}", request->accesspointid()));
+    auto accessPointController = detail::TryGetAccessPointController(request, response, m_accessPointManager);
+    if (accessPointController == nullptr) {
+        return grpc::Status::OK;
     }
 
     // Convert PHY type to Ieee80211 protocol.

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -31,6 +31,108 @@ NetRemoteService::GetAccessPointManager() noexcept
 
 namespace detail
 {
+/**
+ * @brief Handle a failure for a request that referecnes an access point.
+ *
+ * @tparam RequestT The request type. This must contain an access point id (trait).
+ * @tparam ResultT The result type. This must contain an access point id and a status (traits).
+ * @param request A reference to the request.
+ * @param result A reference to the result.
+ * @param code The error code to set in the result message.
+ * @param message The error message to set in the result message.
+ * @param grpcStatus The status to be returned to the client.
+ * @return ::grpc::Status
+ */
+template <
+    typename RequestT,
+    typename ResultT>
+::grpc::Status
+HandleFailure(RequestT& request, ResultT& result, WifiAccessPointOperationStatusCode code, std::string_view message, ::grpc::Status grpcStatus = ::grpc::Status::OK)
+{
+    LOGE << message;
+
+    // Populate status.
+    WifiAccessPointOperationStatus status{};
+    status.set_code(code);
+    status.set_message(std::string(message));
+
+    // Populate result fields expected on error conditions.
+    result->set_accesspointid(request->accesspointid());
+    *result->mutable_status() = std::move(status);
+
+    return grpcStatus;
+}
+
+/**
+ * @brief Attempt to obtain an IAccessPoint instance for the access point in the specified request message.
+ *
+ * @tparam RequestT The request type. This must contain an access point id (trait).
+ * @tparam ResultT The result type. This must contain an access point id and a status (traits).
+ * @param request A reference to the request.
+ * @param result A reference to the result.
+ * @param accessPointManager
+ * @return std::shared_ptr<IAccessPoint>
+ */
+template <
+    typename RequestT,
+    typename ResultT>
+std::shared_ptr<IAccessPoint>
+TryGetAccessPoint(RequestT& request, ResultT& result, std::shared_ptr<AccessPointManager>& accessPointManager)
+{
+    const auto& accessPointId = request->accesspointid();
+
+    // Find the requested AP.
+    auto accessPointOpt = accessPointManager->GetAccessPoint(accessPointId);
+    if (!accessPointOpt.has_value()) {
+        HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointInvalid, std::format("Access point {} not found", accessPointId));
+        return nullptr;
+    }
+
+    // Attempt to promote the weak reference to a strong reference.
+    auto accessPointWeak{ accessPointOpt.value() };
+    auto accessPoint = accessPointWeak.lock();
+    if (accessPoint == nullptr) {
+        HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointInvalid, std::format("Access point {} is no longer valid", accessPointId));
+        return nullptr;
+    }
+
+    return accessPoint;
+}
+
+/**
+ * @brief Attempt to obtain an IAccessPointController instance for the access point in the specified request message.
+ *
+ * @tparam RequestT The request type. This must contain an access point id (trait).
+ * @tparam ResultT The result type. This must contain an access point id and a status (traits).
+ * @param request A reference to the request.
+ * @param result A reference to the result.
+ * @param accessPointManager
+ * @return std::shared_ptr<IAccessPointController>
+ */
+template <
+    typename RequestT,
+    typename ResultT>
+std::shared_ptr<IAccessPointController>
+TryGetAccessPointController(RequestT& request, ResultT& result, std::shared_ptr<AccessPointManager>& accessPointManager)
+{
+    const auto& accessPointId = request->accesspointid();
+
+    // Find the requested AP.
+    auto accessPoint = TryGetAccessPoint(request, result, accessPointManager);
+    if (accessPoint == nullptr) {
+        return nullptr;
+    }
+
+    // Create a controller for this access point.
+    auto accessPointController = accessPoint->CreateController();
+    if (accessPointController == nullptr) {
+        HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInternalError, std::format("Failed to create controller for access point {}", accessPointId));
+        return nullptr;
+    }
+
+    return accessPointController;
+}
+
 using Microsoft::Net::Wifi::Dot11PhyType;
 using Microsoft::Net::Wifi::Ieee80211Protocol;
 
@@ -348,82 +450,6 @@ bool
 NetRemoteAccessPointResultItemIsInvalid(const Microsoft::Net::Remote::Wifi::WifiEnumerateAccessPointsResultItem& item)
 {
     return (item.accesspointid() == AccessPointIdInvalid);
-}
-
-/**
- * @brief Handle a failure for a request that referecnes an access point.
- *
- * @tparam RequestT The request type. This must contain an access point id (trait).
- * @tparam ResultT The result type. This must contain an access point id and a status (traits).
- * @param request A reference to the request.
- * @param result A reference to the result.
- * @param code The error code to set in the result message.
- * @param message The error message to set in the result message.
- * @param grpcStatus The status to be returned to the client.
- * @return ::grpc::Status
- */
-template <
-    typename RequestT,
-    typename ResultT>
-::grpc::Status
-HandleFailure(RequestT& request, ResultT& result, WifiAccessPointOperationStatusCode code, std::string_view message, ::grpc::Status grpcStatus = ::grpc::Status::OK)
-{
-    LOGE << message;
-
-    // Populate status.
-    WifiAccessPointOperationStatus status{};
-    status.set_code(code);
-    status.set_message(std::string(message));
-
-    // Populate result fields expected on error conditions.
-    result->set_accesspointid(request->accesspointid());
-    *result->mutable_status() = std::move(status);
-
-    return grpcStatus;
-}
-
-/**
- * @brief Attempt to obtain an IAccessPintController instance for the access point in the specified request message.
- *
- * @tparam RequestT The request type. This must contain an access point id (trait).
- * @tparam ResultT The result type. This must contain an access point id and a status (traits).
- * @param request A reference to the request.
- * @param result A reference to the result.
- * @param accessPointManager
- * @return std::shared_ptr<IAccessPointController>
- */
-template <
-    typename RequestT,
-    typename ResultT>
-std::shared_ptr<IAccessPointController>
-TryGetAccessPointController(RequestT& request, ResultT& result, std::shared_ptr<AccessPointManager>& accessPointManager)
-{
-    const auto& accessPointId = request->accesspointid();
-
-    // Find the requested AP.
-    auto accessPointOpt = accessPointManager->GetAccessPoint(accessPointId);
-    if (!accessPointOpt.has_value()) {
-        LOGW << std::format("Access point {} not found", accessPointId);
-        HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointInvalid, std::format("Access point {} not found", accessPointId));
-        return nullptr;
-    }
-
-    // Attempt to promote the weak reference to a strong reference.
-    auto accessPointWeak{ accessPointOpt.value() };
-    auto accessPoint = accessPointWeak.lock();
-    if (accessPoint == nullptr) {
-        HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointInvalid, std::format("Access point {} is no longer valid", accessPointId));
-        return nullptr;
-    }
-
-    // Create a controller for this access point.
-    auto accessPointController = accessPoint->CreateController();
-    if (accessPointController == nullptr) {
-        HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInternalError, std::format("Failed to create controller for access point {}", accessPointId));
-        return nullptr;
-    }
-
-    return accessPointController;
 }
 } // namespace detail
 

--- a/src/common/wifi/apmanager/AccessPointManager.cxx
+++ b/src/common/wifi/apmanager/AccessPointManager.cxx
@@ -56,7 +56,7 @@ AccessPointManager::RemoveAccessPoint(std::shared_ptr<IAccessPoint> accessPoint)
     m_accessPoints.erase(accessPointToRemove);
 }
 
-std::weak_ptr<IAccessPoint>
+std::optional<std::weak_ptr<IAccessPoint>>
 AccessPointManager::GetAccessPoint(std::string_view interfaceName) const
 {
     const auto accessPointsLock = std::scoped_lock{ m_accessPointGate };

--- a/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
+++ b/src/common/wifi/apmanager/include/microsoft/net/wifi/AccessPointManager.hxx
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <vector>
 
@@ -55,9 +56,9 @@ public:
      * @brief Get the IAccessPoint object with the specified interface name.
      *
      * @param interfaceName The interface name of the access point to get.
-     * @return std::weak_ptr<IAccessPoint>
+     * @return std::optional<std::weak_ptr<IAccessPoint>> 
      */
-    std::weak_ptr<IAccessPoint>
+    std::optional<std::weak_ptr<IAccessPoint>>
     GetAccessPoint(std::string_view interfaceName) const;
 
     /**

--- a/tests/unit/wifi/apmanager/TestAccessPointManager.cxx
+++ b/tests/unit/wifi/apmanager/TestAccessPointManager.cxx
@@ -73,7 +73,8 @@ TEST_CASE("AccessPointManager persists access points reported by discovery agent
     {
         accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPointInterfaceName1);
 
-        auto accessPointRetrievedWeak{ accessPointManager->GetAccessPoint(accessPointInterfaceName1) };
+        auto accessPointRetrievedOpt{ accessPointManager->GetAccessPoint(accessPointInterfaceName1) };
+        auto accessPointRetrievedWeak{ accessPointRetrievedOpt.value() };
         auto accessPointRetrieved{ accessPointRetrievedWeak.lock() };
         REQUIRE(accessPointRetrieved != nullptr);
         REQUIRE(accessPointRetrieved->GetInterfaceName() == accessPointInterfaceName1);
@@ -98,7 +99,8 @@ TEST_CASE("AccessPointManager persists access points reported by discovery agent
         accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPointInterfaceName1);
         accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPointInterfaceName2);
 
-        auto accessPointRetrievedWeak{ accessPointManager->GetAccessPoint(accessPointInterfaceName1) };
+        auto accessPointRetrievedOpt{ accessPointManager->GetAccessPoint(accessPointInterfaceName1) };
+        auto accessPointRetrievedWeak{ accessPointRetrievedOpt.value() };
         auto accessPointRetrieved{ accessPointRetrievedWeak.lock() };
         REQUIRE(accessPointRetrieved != nullptr);
         REQUIRE(accessPointRetrieved->GetInterfaceName() == accessPointInterfaceName1);
@@ -137,19 +139,21 @@ TEST_CASE("AccessPointManager discards access points reported to have departed b
     SECTION("Access points reported to have departed are not accessible via GetAccessPoint()")
     {
         accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPointInterfaceName);
-        auto accessPointWeak{ accessPointManager->GetAccessPoint(accessPointInterfaceName) };
+        auto accessPointOpt{ accessPointManager->GetAccessPoint(accessPointInterfaceName) };
+        auto accessPointWeak{ accessPointOpt.value() };
         auto accessPoint{ accessPointWeak.lock() };
 
         accessPointDiscoveryAgentOperationsTestPtr->RemoveAccessPoint(accessPointInterfaceName);
         auto accessPointRetrieved{ accessPointManager->GetAccessPoint(accessPointInterfaceName) };
-        REQUIRE(accessPointRetrieved.expired());
+        REQUIRE(!accessPointRetrieved.has_value());
     }
 
     SECTION("Access points reported to have departed are not accessible via GetAllAccessPoints()")
     {
         accessPointDiscoveryAgentOperationsTestPtr->AddAccessPoint(accessPointInterfaceName);
 
-        auto accessPointWeak{ accessPointManager->GetAccessPoint(accessPointInterfaceName) };
+        auto accessPointOpt{ accessPointManager->GetAccessPoint(accessPointInterfaceName) };
+        auto accessPointWeak{ accessPointOpt.value() };
         auto accessPoint{ accessPointWeak.lock() };
 
         accessPointDiscoveryAgentOperationsTestPtr->RemoveAccessPoint(accessPointInterfaceName);


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the API can distinguish between a request that references an AP which does not exist, and one that was recently invalidated.

### Technical Details

* The existing `AccessPointManager::GetAccessPoint` function returns a `std::weak_ptr<IAccessPoint>`. When the specified access point cannot be found, an empty `weak_ptr` is returned, which will have `expired() == true`. Unfortunately, this is the same behavior that would be exhibited by a non-empty `weak_ptr` that had recently expired; thus, the caller can't distinguish between these two cases without using some helper code that uses `owner_before()` ordering to determine if the `weak_ptr` was empty or not, which is ugly and requires undue checking. The prototype itself should better allow distinguishing these two cases more naturally.
* Update `AccessPointManager::GetAccessPoint` to return a `std::optional<std::weak_ptr<IAccessPoint>>` which makes very clear that `!has_value()` means no such access point existed, and `.has_value() && .value().expired()` means the access point _was_ valid but recently expired. 
* Add an `InternalError` code to `WifiAccessPointOperationStatusCode` to use when intermediate operations being carried out by the API impl occur.
* Add helper function to populate an API result type with the details of an error condition.
* Add helper function to attempt to resolve an access point in an API request.
* Adapt existing helper function to create an `IAccessPointController` instance to use the new helper function to find an AP to make error reporting more consistent.

### Test Results

* Linux `apmanager` unit tests pass.

### Reviewer Focus

* None

### Future Work

* Update API result type name variables from `response` to `result.
* Add explicit request input validation functions for APIs that don't currently use them and switch them to using the `detail::HandleFailure` helper.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
