### PR TITLE
Add API to set Wi-Fi frequency bands 

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,6 +9,7 @@
         "ms-vscode-remote.vscode-remote-extensionpack",
         "coolbear.systemd-unit-file",
         "redhat.vscode-yaml",
-        "vadimcn.vscode-lldb"
+        "vadimcn.vscode-lldb",
+        "zxh404.vscode-proto3"
     ]
 }

--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -12,4 +12,5 @@ service NetRemote
     rpc WifiAccessPointEnable (Microsoft.Net.Remote.Wifi.WifiAccessPointEnableRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointEnableResult);
     rpc WifiAccessPointDisable (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableResult);
     rpc WifiAccessPointSetPhyType (Microsoft.Net.Remote.Wifi.WifiAccessPointSetPhyTypeRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetPhyTypeResult);
+    rpc WifiAccessPointSetFrequencyBands (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsResult);
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -74,3 +74,15 @@ message WifiAccessPointSetPhyTypeResult
     string AccessPointId = 1;
     WifiAccessPointOperationStatus Status = 2;
 }
+
+message WifiAccessPointSetFrequencyBandsRequest
+{
+    string AccessPointId = 1;
+    repeated Microsoft.Net.Wifi.Dot11FrequencyBand FrequencyBands = 2;
+}
+
+message WifiAccessPointSetFrequencyBandsResult
+{
+    string AccessPointId = 1;
+    WifiAccessPointOperationStatus Status = 2;
+}

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -196,17 +196,31 @@ Dot11FrequencyBand
 IeeeDot11FrequencyBandToNetRemoteDot11FrequencyBand(Ieee80211FrequencyBand ieeeDot11FrequencyBand)
 {
     switch (ieeeDot11FrequencyBand) {
-    case Ieee80211FrequencyBand::Unknown:
-        return Dot11FrequencyBand::Dot11FrequencyBandUnknown;
     case Ieee80211FrequencyBand::TwoPointFourGHz:
         return Dot11FrequencyBand::Dot11FrequencyBandTwoPoint4GHz;
     case Ieee80211FrequencyBand::FiveGHz:
         return Dot11FrequencyBand::Dot11FrequencyBandFiveGHz;
     case Ieee80211FrequencyBand::SixGHz:
         return Dot11FrequencyBand::Dot11FrequencyBandSixGHz;
+    default:
+        return Dot11FrequencyBand::Dot11FrequencyBandUnknown;
     }
+}
 
-    return Dot11FrequencyBand::Dot11FrequencyBandUnknown;
+Ieee80211FrequencyBand
+NetRemoteDot11FrequencyBandToIeee80211FrequencyBand(Dot11FrequencyBand dot11FrequencyBand)
+{
+    switch (dot11FrequencyBand) {
+    case Dot11FrequencyBand::Dot11FrequencyBand2_4GHz:
+        return Ieee80211FrequencyBand::TwoPointFourGHz;
+    case Dot11FrequencyBand::Dot11FrequencyBand5_0GHz:
+        return Ieee80211FrequencyBand::FiveGHz;
+    case Dot11FrequencyBand::Dot11FrequencyBand6_0GHz:
+        return Ieee80211FrequencyBand::SixGHz;
+    case Dot11FrequencyBand::Dot11FrequencyBandUnknown:
+    default:
+        return Ieee80211FrequencyBand::Unknown;
+    }
 }
 
 using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
@@ -602,21 +616,7 @@ GetFrequencyBands(const WifiAccessPointSetFrequencyBandsRequest& request)
     return bands;
 }
 
-Ieee80211FrequencyBand
-NetRemoteFrequencyBandToIeee80211FrequencyBand(Dot11FrequencyBand dot11FrequencyBand)
-{
-    switch (dot11FrequencyBand) {
-    case Dot11FrequencyBand::Dot11FrequencyBand2_4GHz:
-        return Ieee80211FrequencyBand::TwoPointFourGHz;
-    case Dot11FrequencyBand::Dot11FrequencyBand5_0GHz:
-        return Ieee80211FrequencyBand::FiveGHz;
-    case Dot11FrequencyBand::Dot11FrequencyBand6_0GHz:
-        return Ieee80211FrequencyBand::SixGHz;
-    case Dot11FrequencyBand::Dot11FrequencyBandUnknown:
-    default:
-        return Ieee80211FrequencyBand::Unknown;
-    }
-}
+
 } // namespace detail
 
 /* static */
@@ -657,7 +657,7 @@ NetRemoteService::WifiAccessPointSetFrequencyBands([[maybe_unused]] ::grpc::Serv
     // Convert dot11 bands to ieee80211 bands.
     const auto& frequencyBands = detail::GetFrequencyBands(*request);
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> ieeeFrequencyBands(static_cast<std::size_t>(std::size(frequencyBands)));
-    std::ranges::transform(frequencyBands, std::begin(ieeeFrequencyBands), detail::NetRemoteFrequencyBandToIeee80211FrequencyBand);
+    std::ranges::transform(frequencyBands, std::begin(ieeeFrequencyBands), detail::NetRemoteDot11FrequencyBandToIeee80211FrequencyBand);
 
     // Obtain capabilities of the access point.
     Ieee80211AccessPointCapabilities accessPointCapabilities{};

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -619,6 +619,7 @@ NetRemoteFrequencyBandToIeee80211FrequencyBand(Dot11FrequencyBand dot11Frequency
 }
 } // namespace detail
 
+/* static */
 bool
 NetRemoteService::ValidateWifiSetFrequencyBandsRequest(const WifiAccessPointSetFrequencyBandsRequest* request, WifiAccessPointSetFrequencyBandsResult* result)
 {
@@ -693,6 +694,7 @@ NetRemoteService::WifiAccessPointSetFrequencyBands([[maybe_unused]] ::grpc::Serv
     return grpc::Status::OK;
 }
 
+/* static */
 bool
 NetRemoteService::ValidateWifiAccessPointEnableRequest(const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, WifiAccessPointOperationStatus& status)
 {

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -564,7 +564,7 @@ NetRemoteService::WifiAccessPointSetPhyType([[maybe_unused]] ::grpc::ServerConte
         }
     } catch (const AccessPointControllerException& apce) {
         LOGE << std::format("Failed to get capabilities for access point {} ({})", request->accesspointid(), apce.what());
-        return handleFailure(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeOperationNotSupported, std::format("Failed to get capabilities for access point {}", request->accesspointid()));
+        return handleFailure(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInternalError, std::format("Failed to get capabilities for access point {}", request->accesspointid()));
     }
 
     // Set the Ieee80211 protocol.
@@ -573,7 +573,7 @@ NetRemoteService::WifiAccessPointSetPhyType([[maybe_unused]] ::grpc::ServerConte
             return handleFailure(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeOperationNotSupported, std::format("Failed to set PHY type for access point {}", request->accesspointid()));
         }
     } catch (const AccessPointControllerException& apce) {
-        return handleFailure(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeOperationNotSupported, std::format("Failed to set PHY type for access point {} ({})", request->accesspointid(), apce.what()));
+        return handleFailure(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInternalError, std::format("Failed to set PHY type for access point {} ({})", request->accesspointid(), apce.what()));
     }
 
     status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -44,9 +44,15 @@ private:
     virtual ::grpc::Status
     WifiAccessPointSetPhyType(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetPhyTypeRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetPhyTypeResult* response) override;
 
+    virtual ::grpc::Status
+    WifiAccessPointSetFrequencyBands(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsResult* response) override;
+
 protected:
     bool
     ValidateWifiAccessPointEnableRequest(const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus& status);
+
+    bool
+    ValidateWifiSetFrequencyBandsRequest(const ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsResult* result);
 
 private:
     std::shared_ptr<Microsoft::Net::Wifi::AccessPointManager> m_accessPointManager;

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -48,10 +48,10 @@ private:
     WifiAccessPointSetFrequencyBands(::grpc::ServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsResult* response) override;
 
 protected:
-    bool
+    static bool
     ValidateWifiAccessPointEnableRequest(const ::Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus& status);
 
-    bool
+    static bool
     ValidateWifiSetFrequencyBandsRequest(const ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest* request, ::Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsResult* result);
 
 private:

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -72,6 +72,16 @@ struct IAccessPointController
      */
     virtual bool
     SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol) = 0;
+
+    /**
+     * @brief Set the frquency bands the access point should enable.
+     *
+     * @param frequencyBands The frequency bands to be set.
+     * @return true
+     * @return false
+     */
+    virtual bool
+    SetFrquencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) = 0;
 };
 
 /**

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -81,7 +81,7 @@ struct IAccessPointController
      * @return false
      */
     virtual bool
-    SetFrquencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) = 0;
+    SetFrequencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) = 0;
 };
 
 /**

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -200,6 +200,13 @@ AccessPointControllerLinux::SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol 
     return isOk && m_hostapd.Reload();
 }
 
+bool
+AccessPointControllerLinux::SetFrquencyBands([[maybe_unused]] std::vector<Ieee80211FrequencyBand> frequencyBands)
+{
+    // TODO:
+    return false;
+}
+
 std::unique_ptr<IAccessPointController>
 AccessPointControllerLinuxFactory::Create(std::string_view interfaceName)
 {

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -226,7 +226,7 @@ AccessPointControllerLinux::SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol 
 }
 
 bool
-AccessPointControllerLinux::SetFrquencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands)
+AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands)
 {
     // Ensure at least one band is requested.
     if (std::empty(frequencyBands)) {

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -3,10 +3,11 @@
 #define ACCESS_POINT_CONTROLLER_LINUX_HXX
 
 #include <string_view>
+#include <vector>
 
 #include <Wpa/Hostapd.hxx>
-#include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/AccessPointController.hxx>
+#include <microsoft/net/wifi/Ieee80211.hxx>
 
 namespace Microsoft::Net::Wifi
 {
@@ -53,6 +54,16 @@ struct AccessPointControllerLinux :
      */
     virtual bool
     SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol) override;
+
+    /**
+     * @brief Set the frquency bands the access point should enable.
+     *
+     * @param frequencyBands The frequency bands to be set.
+     * @return true
+     * @return false
+     */
+    virtual bool
+    SetFrquencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) override;
 
 private:
     Wpa::Hostapd m_hostapd;

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -63,7 +63,7 @@ struct AccessPointControllerLinux :
      * @return false
      */
     virtual bool
-    SetFrquencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) override;
+    SetFrequencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) override;
 
 private:
     Wpa::Hostapd m_hostapd;

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -19,6 +19,7 @@
 namespace Microsoft::Net::Remote::Test
 {
 constexpr auto AllProtocols = magic_enum::enum_values<Microsoft::Net::Wifi::Ieee80211Protocol>();
+constexpr auto AllBands = magic_enum::enum_values<Microsoft::Net::Wifi::Ieee80211FrequencyBand>();
 } // namespace Microsoft::Net::Remote::Test
 
 using Microsoft::Net::Remote::Test::RemoteServiceAddressHttp;
@@ -166,5 +167,149 @@ TEST_CASE("WifiAccessPointSetPhyType API", "[basic][rpc][client][remote]")
         REQUIRE(setPhyTypeResult.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
         REQUIRE(setPhyTypeResult.status().message().empty());
         REQUIRE(setPhyTypeResult.status().has_details() == false);
+    }
+}
+
+TEST_CASE("WifiAccessPointSetFrequencyBands API", "[basic][rpc][client][remote]")
+{
+    using namespace Microsoft::Net::Remote;
+    using namespace Microsoft::Net::Remote::Service;
+    using namespace Microsoft::Net::Remote::Test;
+    using namespace Microsoft::Net::Remote::Wifi;
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    constexpr auto InterfaceNameAllBands{ "TestWifiAccessPointSetFrequencyBandsAll" };
+    constexpr auto InterfaceNameBand2_4{ "TestWifiAccessPointSetFrequencyBands2_4" };
+    constexpr auto InterfaceNameBand5_0{ "TestWifiAccessPointSetFrequencyBands5_0" };
+    constexpr auto InterfaceNameBand6_0{ "TestWifiAccessPointSetFrequencyBands6_0" };
+
+    auto apManagerTest = std::make_shared<AccessPointManagerTest>();
+
+    Ieee80211AccessPointCapabilities apCapabilitiesBandsAll{
+        .FrequencyBands{ std::cbegin(AllBands), std::cend(AllBands) }
+    };
+    Ieee80211AccessPointCapabilities apCapabilitiesBands2_4{
+        .FrequencyBands{ Ieee80211FrequencyBand::TwoPointFourGHz }
+    };
+    Ieee80211AccessPointCapabilities apCapabilitiesBands5_0{
+        .FrequencyBands{ Ieee80211FrequencyBand::FiveGHz }
+    };
+    Ieee80211AccessPointCapabilities apCapabilitiesBands6_0{
+        .FrequencyBands{ Ieee80211FrequencyBand::SixGHz }
+    };
+
+    auto apTestBandsAll = std::make_shared<AccessPointTest>(InterfaceNameAllBands, std::move(apCapabilitiesBandsAll));
+    auto apTestBands2_4 = std::make_shared<AccessPointTest>(InterfaceNameBand2_4, std::move(apCapabilitiesBands2_4));
+    auto apTestBands5_0 = std::make_shared<AccessPointTest>(InterfaceNameBand5_0, std::move(apCapabilitiesBands5_0));
+    auto apTestBands6_0 = std::make_shared<AccessPointTest>(InterfaceNameBand6_0, std::move(apCapabilitiesBands6_0));
+
+    apManagerTest->AddAccessPoint(apTestBandsAll);
+    apManagerTest->AddAccessPoint(apTestBands2_4);
+    apManagerTest->AddAccessPoint(apTestBands5_0);
+    apManagerTest->AddAccessPoint(apTestBands6_0);
+
+    NetRemoteServerConfiguration Configuration{
+        .ServerAddress = RemoteServiceAddressHttp,
+        .AccessPointManager = apManagerTest,
+    };
+
+    NetRemoteServer server{ Configuration };
+    server.Run();
+
+    auto channel = grpc::CreateChannel(RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());
+    auto client = NetRemote::NewStub(channel);
+
+    SECTION("Can be called")
+    {
+        WifiAccessPointSetFrequencyBandsRequest request{};
+        request.set_accesspointid(InterfaceNameAllBands);
+        request.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
+        request.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
+
+        grpc::ClientContext clientContext{};
+        WifiAccessPointSetFrequencyBandsResult result{};
+        auto status = client->WifiAccessPointSetFrequencyBands(&clientContext, request, &result);
+        REQUIRE(status.ok());
+        REQUIRE(result.accesspointid() == request.accesspointid());
+        REQUIRE(result.has_status());
+        REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
+    }
+
+    SECTION("Empty frequency bands returns an error")
+    {
+        WifiAccessPointSetFrequencyBandsRequest request{};
+        request.set_accesspointid(InterfaceNameAllBands);
+
+        grpc::ClientContext clientContext{};
+        WifiAccessPointSetFrequencyBandsResult result{};
+        auto status = client->WifiAccessPointSetFrequencyBands(&clientContext, request, &result);
+        REQUIRE(status.ok());
+        REQUIRE(result.accesspointid() == request.accesspointid());
+        REQUIRE(result.has_status());
+        REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+    }
+
+    SECTION("Invalid frequency band returns an error")
+    {
+        WifiAccessPointSetFrequencyBandsRequest request{};
+        request.set_accesspointid(InterfaceNameAllBands);
+        request.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBandUnknown);
+
+        grpc::ClientContext clientContext{};
+        WifiAccessPointSetFrequencyBandsResult result{};
+        auto status = client->WifiAccessPointSetFrequencyBands(&clientContext, request, &result);
+        REQUIRE(status.ok());
+        REQUIRE(result.accesspointid() == request.accesspointid());
+        REQUIRE(result.has_status());
+        REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+    }
+
+    SECTION("Invalid frequency band with other valid bands returns an error")
+    {
+        WifiAccessPointSetFrequencyBandsRequest request{};
+        request.set_accesspointid(InterfaceNameAllBands);
+        request.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBandUnknown);
+        request.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
+
+        grpc::ClientContext clientContext{};
+        WifiAccessPointSetFrequencyBandsResult result{};
+        auto status = client->WifiAccessPointSetFrequencyBands(&clientContext, request, &result);
+        REQUIRE(status.ok());
+        REQUIRE(result.accesspointid() == request.accesspointid());
+        REQUIRE(result.has_status());
+        REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+    }
+
+    SECTION("Unsupported frequency band returns an error")
+    {
+        WifiAccessPointSetFrequencyBandsRequest request{};
+        request.set_accesspointid(InterfaceNameBand2_4);
+        request.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
+
+        grpc::ClientContext clientContext{};
+        WifiAccessPointSetFrequencyBandsResult result{};
+        auto status = client->WifiAccessPointSetFrequencyBands(&clientContext, request, &result);
+        REQUIRE(status.ok());
+        REQUIRE(result.accesspointid() == request.accesspointid());
+        REQUIRE(result.has_status());
+        REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeOperationNotSupported);
+    }
+
+    SECTION("Enabling multiple bands works")
+    {
+        WifiAccessPointSetFrequencyBandsRequest request{};
+        request.set_accesspointid(InterfaceNameAllBands);
+        request.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
+        request.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
+        request.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand6_0GHz);
+
+        grpc::ClientContext clientContext{};
+        WifiAccessPointSetFrequencyBandsResult result{};
+        auto status = client->WifiAccessPointSetFrequencyBands(&clientContext, request, &result);
+        REQUIRE(status.ok());
+        REQUIRE(result.accesspointid() == request.accesspointid());
+        REQUIRE(result.has_status());
+        REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
     }
 }

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -130,7 +130,6 @@ TEST_CASE("WifiAccessPointSetPhyType API", "[basic][rpc][client][remote]")
     using namespace Microsoft::Net::Wifi;
     using namespace Microsoft::Net::Wifi::Test;
 
-    constexpr auto SsidName{ "TestWifiAccessPointSetPhyType" };
     constexpr auto InterfaceName{ "TestWifiAccessPointSetPhyType" };
 
     auto apManagerTest = std::make_shared<AccessPointManagerTest>();
@@ -150,29 +149,6 @@ TEST_CASE("WifiAccessPointSetPhyType API", "[basic][rpc][client][remote]")
 
     auto channel = grpc::CreateChannel(RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());
     auto client = NetRemote::NewStub(channel);
-
-    Dot11AccessPointConfiguration apConfiguration{};
-    apConfiguration.mutable_ssid()->set_name(SsidName);
-    apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
-    apConfiguration.set_authenticationalgorithm(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);
-    apConfiguration.set_ciphersuite(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
-    apConfiguration.mutable_bands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
-    apConfiguration.mutable_bands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
-
-    WifiAccessPointEnableRequest request{};
-    request.set_accesspointid(InterfaceName);
-    *request.mutable_configuration() = std::move(apConfiguration);
-
-    WifiAccessPointEnableResult result{};
-    grpc::ClientContext clientContext{};
-
-    auto status = client->WifiAccessPointEnable(&clientContext, request, &result);
-    REQUIRE(status.ok());
-    REQUIRE(result.accesspointid() == request.accesspointid());
-    REQUIRE(result.has_status());
-    REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
-    REQUIRE(result.status().message().empty());
-    REQUIRE(result.status().has_details() == false);
 
     SECTION("Can be called")
     {

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -53,7 +53,7 @@ AccessPointControllerTest::SetProtocol(Ieee80211Protocol ieeeProtocol)
 }
 
 bool
-AccessPointControllerTest::SetFrquencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands)
+AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands)
 {
     if (AccessPoint == nullptr) {
         throw std::runtime_error("AccessPointControllerTest::SetIeeeProtocol called with null AccessPoint");

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -1,8 +1,12 @@
 
+#include <algorithm>
+#include <format>
 #include <stdexcept>
 
+#include <magic_enum.hpp>
 #include <microsoft/net/wifi/test/AccessPointControllerTest.hxx>
 #include <microsoft/net/wifi/test/AccessPointTest.hxx>
+#include <plog/Log.h>
 
 using namespace Microsoft::Net::Wifi;
 using namespace Microsoft::Net::Wifi::Test;
@@ -57,6 +61,13 @@ AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand>
 {
     if (AccessPoint == nullptr) {
         throw std::runtime_error("AccessPointControllerTest::SetIeeeProtocol called with null AccessPoint");
+    }
+
+    for (const auto &frequencyBandToSet : frequencyBands) {
+        if (std::ranges::find(AccessPoint->Capabilities.FrequencyBands, frequencyBandToSet) == std::cend(AccessPoint->Capabilities.FrequencyBands)) {
+            LOGE << std::format("AccessPointControllerTest::SetFrequencyBands called with unsupported frequency band {}", magic_enum::enum_name(frequencyBandToSet));
+            return false;
+        }
     }
 
     AccessPoint->FrequencyBands = std::move(frequencyBands);

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -42,7 +42,7 @@ AccessPointControllerTest::GetCapabilities()
 }
 
 bool
-AccessPointControllerTest::SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol)
+AccessPointControllerTest::SetProtocol(Ieee80211Protocol ieeeProtocol)
 {
     if (AccessPoint == nullptr) {
         throw std::runtime_error("AccessPointControllerTest::SetIeeeProtocol called with null AccessPoint");
@@ -50,6 +50,16 @@ AccessPointControllerTest::SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol i
 
     AccessPoint->Protocol = ieeeProtocol;
     return true;
+}
+
+bool
+AccessPointControllerTest::SetFrquencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands)
+{
+    if (AccessPoint == nullptr) {
+        throw std::runtime_error("AccessPointControllerTest::SetIeeeProtocol called with null AccessPoint");
+    }
+
+    AccessPoint->FrequencyBands = std::move(frequencyBands);
 }
 
 AccessPointControllerFactoryTest::AccessPointControllerFactoryTest(AccessPointTest *accessPoint) :

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -60,6 +60,7 @@ AccessPointControllerTest::SetFrquencyBands(std::vector<Ieee80211FrequencyBand> 
     }
 
     AccessPoint->FrequencyBands = std::move(frequencyBands);
+    return true;
 }
 
 AccessPointControllerFactoryTest::AccessPointControllerFactoryTest(AccessPointTest *accessPoint) :

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -58,23 +58,23 @@ struct AccessPointControllerTest final :
 
     /**
      * @brief Set the Ieee80211 protocol of the access point.
-     * 
+     *
      * @param ieeeProtocol The Ieee80211 protocol to be set
      * @return true
      * @return false
-    */
+     */
     virtual bool
     SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol) override;
 
     /**
      * @brief Set the frquency bands the access point should enable.
-     * 
+     *
      * @param frequencyBands The frequency bands to be set.
-     * @return true 
-     * @return false 
+     * @return true
+     * @return false
      */
     virtual bool
-    SetFrquencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) override;
+    SetFrequencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) override;
 };
 
 /**

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string_view>
+#include <vector>
 
 #include <microsoft/net/wifi/IAccessPointController.hxx>
 
@@ -64,6 +65,16 @@ struct AccessPointControllerTest final :
     */
     virtual bool
     SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol) override;
+
+    /**
+     * @brief Set the frquency bands the access point should enable.
+     * 
+     * @param frequencyBands The frequency bands to be set.
+     * @return true 
+     * @return false 
+     */
+    virtual bool
+    SetFrquencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) override;
 };
 
 /**

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string_view>
+#include <vector>
 
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
@@ -24,6 +25,7 @@ struct AccessPointTest final :
     Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities Capabilities;
     bool IsEnabled{ false };
     Microsoft::Net::Wifi::Ieee80211Protocol Protocol;
+    std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> FrequencyBands;
 
     /**
      * @brief Construct a new AccessPointTest object with the given interface name and default capabilities.


### PR DESCRIPTION
### **Note:** most of the work in this PR was done by @corbin-phipps in #121.

### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow configuration of Wi-Fi Access Point frequency bands.

### Technical Details

* Add protobuf+grpc API `WifiAccessPointSetFrequencyBands`.
* Update `WifiAccessPointSetPhyType` to return `InternalError` when unspecified access point operations fail.
* Make request validation helpers static.

### Test Results

* All unit tests pass on Linux.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
