### PR TITLE
Add read action and write security event permissions to all build workflows

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -5,6 +5,10 @@ on: workflow_dispatch
 
 jobs:
   build:
+    name: build linux
+    permissions:
+      actions: read
+      security-events: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -17,6 +17,10 @@ on:
 
 jobs:
   build:
+    name: build windows
+    permissions:
+      actions: read
+      security-events: write
     runs-on: windows-latest
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,9 @@ on:
 jobs:
   build:
     name: cmake build
+    permissions:
+      actions: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,6 +21,9 @@ on:
 jobs:
   build-validation:
     name: Build Validation
+    permissions:
+      actions: read
+      security-events: write
     uses: ./.github/workflows/build.yml
     with:
       build-types: "[ 'Debug' ]"


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Ensure CodeQL can upload results. This is required due to a recent change in the microsoft Github org where the `GITHUB_TOKEN` default permissions were changed to be read-only.

### Technical Details

* Add the following permissions block allowing read of actions and write of security events to each build workflow job:
```yml
    permissions:
      actions: read
      security-events: write
```

### Test Results

* TBD

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
