### PR TITLE
Add consistent logging for API functions

### DIFF
--- a/src/common/service/CMakeLists.txt
+++ b/src/common/service/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(${PROJECT_NAME}-service
         ${PROJECT_NAME}-protocol
         wifi-apmanager
     PRIVATE
+        logging-utils
         plog::plog
 )
 

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include <format>
 #include <iterator>
-#include <memory>
 #include <optional>
 #include <source_location>
 #include <sstream>
@@ -16,7 +15,6 @@
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <plog/Log.h>
-#include <plog/Severity.h>
 
 using namespace Microsoft::Net::Remote::Service;
 

--- a/src/common/shared/logging/CMakeLists.txt
+++ b/src/common/shared/logging/CMakeLists.txt
@@ -7,15 +7,25 @@ set(LOGUTILS_DIR_PUBLIC_INCLUDE_PREFIX ${LOGUTILS_DIR_PUBLIC_INCLUDE}/${LOGUTILS
 
 target_sources(logging-utils
     PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/FunctionTracer.cxx
         ${CMAKE_CURRENT_LIST_DIR}/LogUtils.cxx
     PUBLIC
     FILE_SET HEADERS
     BASE_DIRS ${LOGUTILS_DIR_PUBLIC_INCLUDE}
     FILES
+        ${LOGUTILS_DIR_PUBLIC_INCLUDE_PREFIX}/FunctionTracer.hxx
         ${LOGUTILS_DIR_PUBLIC_INCLUDE_PREFIX}/LogUtils.hxx
 )
 
 target_link_libraries(logging-utils 
     PUBLIC 
         plog::plog
+)
+
+install(
+    TARGETS logging-utils
+    EXPORT ${PROJECT_NAME}
+    COMPONENT dev
+    FILE_SET HEADERS
+    PUBLIC_HEADER DESTINATION "${NETREMOTE_DIR_INSTALL_PUBLIC_HEADER_BASE}/${LOGUTILS_DIR_PUBLIC_INCLUDE_SUFFIX}"
 )

--- a/src/common/shared/logging/FunctionTracer.cxx
+++ b/src/common/shared/logging/FunctionTracer.cxx
@@ -1,0 +1,112 @@
+
+#include <format>
+#include <sstream>
+
+#include <logging/FunctionTracer.hxx>
+#include <plog/Log.h>
+
+using namespace logging;
+
+namespace detail
+{
+std::string
+BuildValueList(const std::vector<std::pair<std::string, std::string>>& values, std::string_view prefix, std::string_view keyValueSeparator = "=", std::string_view delimeter = ", ")
+{
+    if (std::empty(values)) {
+        return {};
+    }
+
+    std::ostringstream valueListBuilder;
+    valueListBuilder << prefix;
+    for (std::size_t i = 0; i < std::size(values); i++) {
+        const auto& [name, value] = values[i];
+        if (i > 0) {
+            valueListBuilder << delimeter;
+        }
+        valueListBuilder << name << keyValueSeparator << value << "'";
+    }
+
+    return valueListBuilder.str();
+}
+} // namespace detail
+
+FunctionTracer::FunctionTracer(std::string logPrefix, std::vector<std::pair<std::string, std::string>> arguments, bool deferEnter, std::source_location location) :
+    m_logPrefix(std::move(logPrefix)),
+    m_location(std::move(location)),
+    m_functionName(m_location.function_name()),
+    m_arguments(std::move(arguments))
+{
+    // Attempt to parse the function name, removing the return type, namespace prefixes, and arguments.
+    const auto openingBracketPos = m_functionName.find_first_of('(');
+    if (openingBracketPos != m_functionName.npos) {
+        m_functionName.remove_suffix(m_functionName.size() - openingBracketPos);
+    }
+
+    const auto lastColonPos = m_functionName.find_last_of(':');
+    if (lastColonPos != m_functionName.npos) {
+        m_functionName.remove_prefix(lastColonPos + 1);
+    }
+
+    if (!deferEnter) {
+        Enter();
+    }
+}
+
+FunctionTracer::~FunctionTracer()
+{
+    Exit();
+}
+
+void
+FunctionTracer::Enter()
+{
+    if (m_entered) {
+        return;
+    }
+
+    m_entered = true;
+    auto arguments = detail::BuildValueList(m_arguments, " with arguments ");
+    LOGI << std::format("{} +{}{}", m_logPrefix, m_functionName, arguments);
+}
+
+void
+FunctionTracer::Exit()
+{
+    if (m_exited) {
+        return;
+    }
+
+    auto returnValues = detail::BuildValueList(m_returnValues, " returning ");
+    PLOG(m_exitLogSeverity) << std::format("{} -{}{}", m_logPrefix, m_functionName, returnValues);
+    m_exited = true;
+}
+
+void
+FunctionTracer::AddArgument(std::string name, std::string value)
+{
+    m_arguments.emplace_back(std::move(name), std::move(value));
+}
+
+void
+FunctionTracer::AddReturnValue(std::string name, std::string value)
+{
+    m_returnValues.emplace_back(std::move(name), std::move(value));
+}
+
+void
+FunctionTracer::SetSucceeded() noexcept
+{
+    m_exitLogSeverity = plog::Severity::info;
+}
+
+void
+FunctionTracer::SetFailed() noexcept
+{
+    m_exitLogSeverity = plog::Severity::error;
+}
+
+void
+FunctionTracer::SetExitLogSeverity(plog::Severity severity) noexcept
+{
+    m_exitLogSeverity = severity;
+}

--- a/src/common/shared/logging/FunctionTracer.cxx
+++ b/src/common/shared/logging/FunctionTracer.cxx
@@ -12,6 +12,8 @@ namespace detail
 std::string
 BuildValueList(const std::vector<std::pair<std::string, std::string>>& values, std::string_view prefix, std::string_view keyValueSeparator = "=", std::string_view delimeter = ", ")
 {
+    static constexpr auto ValueWrapperCharacter = '\'';
+
     if (std::empty(values)) {
         return {};
     }
@@ -23,7 +25,7 @@ BuildValueList(const std::vector<std::pair<std::string, std::string>>& values, s
         if (i > 0) {
             valueListBuilder << delimeter;
         }
-        valueListBuilder << name << keyValueSeparator << value << "'";
+        valueListBuilder << name << keyValueSeparator <<  ValueWrapperCharacter << value << ValueWrapperCharacter;
     }
 
     return valueListBuilder.str();

--- a/src/common/shared/logging/include/logging/FunctionTracer.hxx
+++ b/src/common/shared/logging/include/logging/FunctionTracer.hxx
@@ -1,0 +1,57 @@
+
+#ifndef FUNCTION_TRACER_HXX
+#define FUNCTION_TRACER_HXX
+
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <plog/Severity.h>
+
+namespace logging
+{
+/**
+ * @brief Traces a function's entry and exit, logging the arguments and return values.
+ */
+struct FunctionTracer
+{
+    FunctionTracer(std::string logPrefix = {}, std::vector<std::pair<std::string, std::string>> arguments = {}, bool deferEnter = false, std::source_location location = std::source_location::current());
+
+    virtual ~FunctionTracer();
+
+    void
+    Enter();
+
+    void
+    Exit();
+
+    void
+    AddArgument(std::string name, std::string value);
+
+    void
+    AddReturnValue(std::string name, std::string value);
+
+    void
+    SetSucceeded() noexcept;
+
+    void
+    SetFailed() noexcept;
+
+    void
+    SetExitLogSeverity(plog::Severity severity) noexcept;
+
+private:
+    std::string m_logPrefix;
+    std::source_location m_location;
+    std::string_view m_functionName;
+    std::vector<std::pair<std::string, std::string>> m_arguments;
+    std::vector<std::pair<std::string, std::string>> m_returnValues;
+    bool m_entered{ false };
+    bool m_exited{ false };
+    plog::Severity m_exitLogSeverity{ plog::Severity::info };
+};
+} // namespace logging
+
+#endif // FUNCTION_TRACER_HXX

--- a/src/common/shared/logging/include/logging/FunctionTracer.hxx
+++ b/src/common/shared/logging/include/logging/FunctionTracer.hxx
@@ -21,24 +21,53 @@ struct FunctionTracer
 
     virtual ~FunctionTracer();
 
+    /**
+     * @brief Print the function entry log message.
+     */
     void
     Enter();
 
+    /**
+     * @brief Print the function exit log message.
+     */
     void
     Exit();
 
+    /**
+     * @brief Add an argument to the function tracer. This value will be printed in the entry log message.
+     *
+     * @param name The name of the argument.
+     * @param value The value of the argument.
+     */
     void
     AddArgument(std::string name, std::string value);
 
+    /**
+     * @brief Add a return value to the function tracer. This value will be printed in the exit log message.
+     *
+     * @param name The name of the return value.
+     * @param value The value of the return value.
+     */
     void
     AddReturnValue(std::string name, std::string value);
 
+    /**
+     * @brief Mark that the function has succeeded. This will set the log verbosity to info.
+     */
     void
     SetSucceeded() noexcept;
 
+    /**
+     * @brief Mark that the function has failed. This will set the log verbosity to error.
+     */
     void
     SetFailed() noexcept;
 
+    /**
+     * @brief Manually set the log severity for the exit log message. This overrides the SetSucceeded and SetFailed methods.
+     *
+     * @param severity The log severity to use when printing the exit log message.
+     */
     void
     SetExitLogSeverity(plog::Severity severity) noexcept;
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(${PROJECT_NAME}-test-unit)
 
 target_sources(${PROJECT_NAME}-test-unit
     PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/Main.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteCommon.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteServer.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteServiceClient.cxx
@@ -17,9 +18,10 @@ target_sources(${PROJECT_NAME}-test-unit
 target_link_libraries(${PROJECT_NAME}-test-unit
     PRIVATE
         ${PROJECT_NAME}-server
-        Catch2::Catch2WithMain
+        Catch2::Catch2
         gRPC::grpc++
         magic_enum::magic_enum
+        plog::plog
         wifi-test-helpers
 )
 

--- a/tests/unit/Main.cxx
+++ b/tests/unit/Main.cxx
@@ -1,0 +1,16 @@
+
+#include <catch2/catch_session.hpp>
+#include <plog/Appenders/ColorConsoleAppender.h>
+#include <plog/Formatters/MessageOnlyFormatter.h>
+#include <plog/Init.h>
+#include <plog/Log.h>
+
+int
+main(int argc, char* argv[])
+{
+    static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
+
+    plog::init(plog::verbose, &colorConsoleAppender);
+
+    return Catch::Session().run(argc, argv);
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure API invocations are logged consistently.

### Technical Details

* Add new utility class `FunctionTracer` to trace a function's entry and exit, optionally allowing printing of input arguments and return values.
* Implement Netremote-API specific tracers for base API functions and Wi-Fi API functions.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
