### PR TITLE
Enable setting access point ssid

### DIFF
--- a/src/common/wifi/core/AccessPointOperationStatus.cxx
+++ b/src/common/wifi/core/AccessPointOperationStatus.cxx
@@ -1,0 +1,16 @@
+
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
+
+using namespace Microsoft::Net::Wifi;
+
+/* static */
+AccessPointOperationStatus
+AccessPointOperationStatus::MakeSucceeded() noexcept
+{
+    return AccessPointOperationStatus{ AccessPointOperationStatusCode::Succeeded };
+}
+
+AccessPointOperationStatus::operator bool() const noexcept
+{
+    return (Code == AccessPointOperationStatusCode::Succeeded);
+}

--- a/src/common/wifi/core/CMakeLists.txt
+++ b/src/common/wifi/core/CMakeLists.txt
@@ -10,12 +10,14 @@ target_sources(wifi-core
         AccessPoint.cxx
         AccessPointController.cxx
         AccessPointControllerException.cxx
+        AccessPointOperationStatus.cxx
     PUBLIC
     FILE_SET HEADERS
     BASE_DIRS ${WIFI_CORE_PUBLIC_INCLUDE}
     FILES
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPoint.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPointController.hxx
+        ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPointOperationStatus.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/IAccessPoint.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/IAccessPointController.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/Ieee80211.hxx

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
@@ -52,7 +52,7 @@ struct AccessPointOperationStatus
     static AccessPointOperationStatus
     MakeSucceeded() noexcept;
 
-      /**
+    /**
      * @brief Implicit bool operator allowing AccessPointOperationStatus to be used directly in condition statements
      * (eg. if (status) // ...).
      *

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
@@ -16,6 +16,7 @@ enum class AccessPointOperationStatusCode {
     AccessPointInvalid,
     AccessPointNotEnabled,
     OperationNotSupported,
+    InternalError,
 };
 
 /**

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
@@ -1,0 +1,65 @@
+
+#ifndef ACCESS_POINT_OPERATION_STATUS_HXX
+#define ACCESS_POINT_OPERATION_STATUS_HXX
+
+#include <string>
+
+namespace Microsoft::Net::Wifi
+{
+/**
+ * @brief High-level status reported by various access point operations.
+ */
+enum class AccessPointOperationStatusCode {
+    Unknown,
+    Succeeded,
+    InvalidParameter,
+    AccessPointInvalid,
+    AccessPointNotEnabled,
+    OperationNotSupported,
+};
+
+/**
+ * @brief Coarse status of an access point operation.
+ */
+struct AccessPointOperationStatus
+{
+    AccessPointOperationStatusCode Code{ AccessPointOperationStatusCode::Unknown };
+    std::string Message;
+
+    AccessPointOperationStatus() = default;
+    virtual ~AccessPointOperationStatus() = default;
+
+    /**
+     * @brief Create an AccessPointOperationStatus with the given status code.
+     */
+    constexpr explicit AccessPointOperationStatus(AccessPointOperationStatusCode code) noexcept :
+        Code{ code }
+    {}
+
+    AccessPointOperationStatus(const AccessPointOperationStatus &) = default;
+    AccessPointOperationStatus(AccessPointOperationStatus &&) = default;
+    AccessPointOperationStatus &
+    operator=(const AccessPointOperationStatus &) = default;
+    AccessPointOperationStatus &
+    operator=(AccessPointOperationStatus &&) = default;
+
+    /**
+     * @brief Create an AccessPointOperationStatus describing an operation that succeeded.
+     *
+     * @return AccessPointOperationStatus
+     */
+    static AccessPointOperationStatus
+    MakeSucceeded() noexcept;
+
+      /**
+     * @brief Implicit bool operator allowing AccessPointOperationStatus to be used directly in condition statements
+     * (eg. if (status) // ...).
+     *
+     * @return true
+     * @return false
+     */
+    operator bool() const noexcept; // NOLINT(hicpp-explicit-conversions)
+};
+} // namespace Microsoft::Net::Wifi
+
+#endif // ACCESS_POINT_OPERATION_STATUS_HXX

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -8,6 +8,7 @@
 #include <string_view>
 #include <vector>
 
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
 
@@ -41,12 +42,14 @@ struct IAccessPointController
     virtual ~IAccessPointController() = default;
 
     /**
-     * Prevent copying and moving of IAccessPointController objects. 
+     * Prevent copying and moving of IAccessPointController objects.
      */
     IAccessPointController(const IAccessPointController&) = delete;
-    IAccessPointController& operator=(const IAccessPointController&) = delete;
+    IAccessPointController&
+    operator=(const IAccessPointController&) = delete;
     IAccessPointController(IAccessPointController&&) = delete;
-    IAccessPointController& operator=(IAccessPointController&&) = delete;
+    IAccessPointController&
+    operator=(IAccessPointController&&) = delete;
 
     /**
      * @brief Get the interface name associated with this controller.
@@ -98,10 +101,9 @@ struct IAccessPointController
      * @brief Set the SSID of the access point.
      * 
      * @param ssid The SSID to be set.
-     * @return true 
-     * @return false 
+     * @return AccessPointOperationStatus 
      */
-    virtual bool
+    virtual AccessPointOperationStatus
     SetSssid(std::string_view ssid) = 0;
 };
 
@@ -115,12 +117,14 @@ struct IAccessPointControllerFactory
     virtual ~IAccessPointControllerFactory() = default;
 
     /**
-     * Prevent copying and moving of IAccessPointControllerFactory objects. 
+     * Prevent copying and moving of IAccessPointControllerFactory objects.
      */
     IAccessPointControllerFactory(const IAccessPointControllerFactory&) = delete;
-    IAccessPointControllerFactory& operator=(const IAccessPointControllerFactory&) = delete;
+    IAccessPointControllerFactory&
+    operator=(const IAccessPointControllerFactory&) = delete;
     IAccessPointControllerFactory(IAccessPointControllerFactory&&) = delete;
-    IAccessPointControllerFactory& operator=(IAccessPointControllerFactory&&) = delete;
+    IAccessPointControllerFactory&
+    operator=(IAccessPointControllerFactory&&) = delete;
 
     /**
      * @brief Create a new IAccessPointController object.

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -93,6 +93,16 @@ struct IAccessPointController
      */
     virtual bool
     SetFrequencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) = 0;
+
+    /**
+     * @brief Set the SSID of the access point.
+     * 
+     * @param ssid The SSID to be set.
+     * @return true 
+     * @return false 
+     */
+    virtual bool
+    SetSssid(std::string_view ssid) = 0;
 };
 
 /**

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -2,9 +2,11 @@
 #ifndef IEEE_80211_HXX
 #define IEEE_80211_HXX
 
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <initializer_list>
+#include <string>
 
 #include <notstd/Utility.hxx>
 
@@ -266,6 +268,39 @@ enum class Ieee80211CipherSuite : uint32_t {
     UseGroup = MakeIeee80211Suite(Ieee80211CipherSuiteIdUseGroup),
     Wep104 = MakeIeee80211Suite(Ieee80211CipherSuiteIdWep104),
     Wep40 = MakeIeee80211Suite(Ieee80211CipherSuiteIdWep40),
+};
+
+/**
+ * @brief IEEE 802.11 BSS Types.
+ *
+ * Defined in IEEE 802.11-2020, Section 4.3.
+ */
+enum class Ieee80211BssType {
+    Unknown,
+    Infrastructure, // ESS
+    Independent,    // IBSS
+    Personal,       // PBSS
+    Mesh,           // MBSS
+};
+
+/**
+ * @brief Number of octets per BSSID.
+ */
+static constexpr auto BssidNumOctets = 6;
+
+/**
+ * @brief BSSID type.
+ */
+using Ieee80211Bssid = std::array<uint8_t, BssidNumOctets>;
+
+/**
+ * @brief Information about a BSS.
+ */
+struct Ieee80211Bss
+{
+    Ieee80211BssType Type;
+    Ieee80211Bssid Bssid;
+    std::string Ssid;
 };
 
 } // namespace Microsoft::Net::Wifi

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -7,6 +7,7 @@
 
 #include <microsoft/net/remote/protocol/NetRemoteWifi.pb.h>
 #include <microsoft/net/remote/protocol/WifiCore.pb.h>
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
 #include <microsoft/net/wifi/Ieee80211Dot11Adapters.hxx>
@@ -14,6 +15,49 @@
 
 namespace Microsoft::Net::Wifi
 {
+using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode;
+using Microsoft::Net::Wifi::AccessPointOperationStatusCode;
+
+WifiAccessPointOperationStatusCode
+ToDot11AccessPointOperationStatusCode(AccessPointOperationStatusCode& accessPointOperationStatusCode) noexcept
+{
+    switch (accessPointOperationStatusCode) {
+    case AccessPointOperationStatusCode::Succeeded:
+        return WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded;
+    case AccessPointOperationStatusCode::InvalidParameter:
+        return WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter;
+    case AccessPointOperationStatusCode::AccessPointInvalid:
+        return WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointInvalid;
+    case AccessPointOperationStatusCode::AccessPointNotEnabled:
+        return WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointNotEnabled;
+    case AccessPointOperationStatusCode::OperationNotSupported:
+        return WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeOperationNotSupported;
+    case AccessPointOperationStatusCode::Unknown:
+    default:
+        return WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeUnknown;
+    }
+}
+
+AccessPointOperationStatusCode
+FromDot11AccessPointOperationStatusCode(WifiAccessPointOperationStatusCode wifiAccessPointOperationStatusCode) noexcept
+{
+    switch (wifiAccessPointOperationStatusCode) {
+    case WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded:
+        return AccessPointOperationStatusCode::Succeeded;
+    case WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter:
+        return AccessPointOperationStatusCode::InvalidParameter;
+    case WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointInvalid:
+        return AccessPointOperationStatusCode::AccessPointInvalid;
+    case WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointNotEnabled:
+        return AccessPointOperationStatusCode::AccessPointNotEnabled;
+    case WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeOperationNotSupported:
+        return AccessPointOperationStatusCode::OperationNotSupported;
+    case WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeUnknown:
+    default:
+        return AccessPointOperationStatusCode::Unknown;
+    }
+}
+
 using Microsoft::Net::Wifi::Dot11PhyType;
 using Microsoft::Net::Wifi::Ieee80211Protocol;
 

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -32,6 +32,8 @@ ToDot11AccessPointOperationStatusCode(AccessPointOperationStatusCode& accessPoin
         return WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointNotEnabled;
     case AccessPointOperationStatusCode::OperationNotSupported:
         return WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeOperationNotSupported;
+    case AccessPointOperationStatusCode::InternalError:
+        return WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInternalError;
     case AccessPointOperationStatusCode::Unknown:
     default:
         return WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeUnknown;
@@ -52,6 +54,8 @@ FromDot11AccessPointOperationStatusCode(WifiAccessPointOperationStatusCode wifiA
         return AccessPointOperationStatusCode::AccessPointNotEnabled;
     case WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeOperationNotSupported:
         return AccessPointOperationStatusCode::OperationNotSupported;
+    case WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInternalError:
+        return AccessPointOperationStatusCode::InternalError;
     case WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeUnknown:
     default:
         return AccessPointOperationStatusCode::Unknown;

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -4,12 +4,32 @@
 
 #include <vector>
 
+#include <microsoft/net/remote/protocol/NetRemoteWifi.pb.h>
 #include <microsoft/net/remote/protocol/WifiCore.pb.h>
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
 
 namespace Microsoft::Net::Wifi
 {
+/**
+ * @brief Convert the specified WifiAccessPointOperationStatusCode to the equivalent AccessPointOperationStatus.
+ *
+ * @param accessPointOperationStatusCode The WifiAccessPointOperationStatusCode to convert.
+ * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode
+ */
+Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode
+ToDot11AccessPointOperationStatusCode(Microsoft::Net::Wifi::AccessPointOperationStatusCode& accessPointOperationStatusCode) noexcept;
+
+/**
+ * @brief Convert the specified AccessPointOperationStatus to the equivalent WifiAccessPointOperationStatusCode.
+ *
+ * @param wifiAccessPointOperationStatusCode The AccessPointOperationStatus to convert.
+ * @return Microsoft::Net::Wifi::AccessPointOperationStatusCode
+ */
+Microsoft::Net::Wifi::AccessPointOperationStatusCode
+FromDot11AccessPointOperationStatusCode(Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode wifiAccessPointOperationStatusCode) noexcept;
+
 /**
  * @brief Convert the specified Dot11PhyType to the equivalent IEEE 802.11 protocol.
  *

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -273,6 +273,13 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
     return true;
 }
 
+bool
+AccessPointControllerLinux::SetSssid([[maybe_unused]] std::string_view ssid)
+{
+    // TODO: implement
+    return false;
+}
+
 std::unique_ptr<IAccessPointController>
 AccessPointControllerLinuxFactory::Create(std::string_view interfaceName)
 {

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -16,6 +16,7 @@
 #include <microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx>
 #include <microsoft/net/wifi/AccessPointController.hxx>
 #include <microsoft/net/wifi/AccessPointControllerLinux.hxx>
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
 #include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
@@ -193,7 +194,7 @@ bool
 AccessPointControllerLinux::SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol)
 {
     bool isOk = false;
-    Wpa::HostapdHwMode hwMode = detail::IeeeProtocolToHostapdHwMode(ieeeProtocol);
+    const Wpa::HostapdHwMode hwMode = detail::IeeeProtocolToHostapdHwMode(ieeeProtocol);
 
     try {
         // Set the hostapd hw_mode property.
@@ -249,7 +250,7 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
     }
 
     std::string setBandArgumentAll = setBandArgumentBuilder.str();
-    std::string_view setBandArgument(std::data(setBandArgumentAll), std::size(setBandArgumentAll) - 1); // Remove trailing comma
+    const std::string_view setBandArgument(std::data(setBandArgumentAll), std::size(setBandArgumentAll) - 1); // Remove trailing comma
 
     bool isOk = false;
     try {
@@ -273,11 +274,18 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
     return true;
 }
 
-bool
+AccessPointOperationStatus
 AccessPointControllerLinux::SetSssid([[maybe_unused]] std::string_view ssid)
 {
+    // Ensure the ssid is not empty.
+    if (std::empty(ssid)) {
+        LOGE << std::format("Empty SSID specified for interface {}", GetInterfaceName());
+        return {}; // TODO
+    }
+
     // TODO: implement
-    return false;
+
+    return {}; // TOOD
 }
 
 std::unique_ptr<IAccessPointController>

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -73,6 +73,16 @@ struct AccessPointControllerLinux :
     bool
     SetFrequencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) override;
 
+    /**
+     * @brief Set the SSID of the access point.
+     * 
+     * @param ssid The SSID to be set.
+     * @return true 
+     * @return false 
+     */
+    bool
+    SetSssid(std::string_view ssid) override;
+
 private:
     Wpa::Hostapd m_hostapd;
 };

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -2,12 +2,16 @@
 #ifndef ACCESS_POINT_CONTROLLER_LINUX_HXX
 #define ACCESS_POINT_CONTROLLER_LINUX_HXX
 
+#include <memory>
 #include <string_view>
 #include <vector>
 
 #include <Wpa/Hostapd.hxx>
 #include <microsoft/net/wifi/AccessPointController.hxx>
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
+#include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
+#include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
 
 namespace Microsoft::Net::Wifi
 {
@@ -29,12 +33,14 @@ struct AccessPointControllerLinux :
     explicit AccessPointControllerLinux(std::string_view interfaceName);
 
     /**
-     * Prevent copying and moving of this object. 
+     * Prevent copying and moving of this object.
      */
     AccessPointControllerLinux(const AccessPointControllerLinux&) = delete;
-    AccessPointControllerLinux& operator=(const AccessPointControllerLinux&) = delete;
+    AccessPointControllerLinux&
+    operator=(const AccessPointControllerLinux&) = delete;
     AccessPointControllerLinux(AccessPointControllerLinux&&) = delete;
-    AccessPointControllerLinux& operator=(AccessPointControllerLinux&&) = delete;
+    AccessPointControllerLinux&
+    operator=(AccessPointControllerLinux&&) = delete;
 
     /**
      * @brief Get whether the access point is enabled.
@@ -75,12 +81,11 @@ struct AccessPointControllerLinux :
 
     /**
      * @brief Set the SSID of the access point.
-     * 
+     *
      * @param ssid The SSID to be set.
-     * @return true 
-     * @return false 
+     * @return AccessPointOperationStatus
      */
-    bool
+    AccessPointOperationStatus
     SetSssid(std::string_view ssid) override;
 
 private:
@@ -98,12 +103,14 @@ struct AccessPointControllerLinuxFactory :
     ~AccessPointControllerLinuxFactory() override = default;
 
     /**
-     * Prevent copying and moving of this object. 
+     * Prevent copying and moving of this object.
      */
     AccessPointControllerLinuxFactory(const AccessPointControllerLinuxFactory&) = delete;
-    AccessPointControllerLinuxFactory& operator=(const AccessPointControllerLinuxFactory&) = delete;
+    AccessPointControllerLinuxFactory&
+    operator=(const AccessPointControllerLinuxFactory&) = delete;
     AccessPointControllerLinuxFactory(AccessPointControllerLinuxFactory&&) = delete;
-    AccessPointControllerLinuxFactory& operator=(AccessPointControllerLinuxFactory&&) = delete;
+    AccessPointControllerLinuxFactory&
+    operator=(AccessPointControllerLinuxFactory&&) = delete;
 
     /**
      * @brief Create a new IAccessPointController object.

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -1,4 +1,5 @@
 
+#include <format>
 #include <string>
 #include <string_view>
 
@@ -96,6 +97,8 @@ Hostapd::GetProperty(std::string_view propertyName, std::string& propertyValue)
 bool
 Hostapd::SetProperty(std::string_view propertyName, std::string_view propertyValue)
 {
+    LOGD << std::format("Attempting to set hostapd property '{}'({}) to '{}'({})", propertyName, std::size(propertyName), propertyValue, std::size(propertyValue));
+
     const WpaCommandSet setCommand(propertyName, propertyValue);
     const auto response = m_controller.SendCommand(setCommand);
     if (!response) {

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -11,6 +11,7 @@
 #include <Wpa/WpaCommandStatus.hxx>
 #include <Wpa/WpaCore.hxx>
 #include <Wpa/WpaResponseStatus.hxx>
+#include <plog/Log.h>
 
 using namespace Wpa;
 
@@ -50,6 +51,27 @@ Hostapd::GetStatus()
     }
 
     return response->Status;
+}
+
+bool
+Hostapd::SetSsid(std::string_view ssid, bool reload)
+{
+    const bool ssidWasSet = SetProperty(ProtocolHostapd::PropertyNameSsid, ssid);
+    if (!ssidWasSet) {
+        throw HostapdException("Failed to set hostapd 'ssid' property");
+    }
+
+    if (!reload) {
+        LOGW << "Skipping hostapd reload after setting 'ssid' (requested)";
+        return true;
+    }
+
+    const bool configurationReloadSucceeded = Reload();
+    if (!configurationReloadSucceeded) {
+        throw HostapdException("Failed to reload hostapd configuration");
+    }
+
+    return true;
 }
 
 bool

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -61,7 +61,7 @@ Hostapd::GetProperty(std::string_view propertyName, std::string& propertyValue)
         throw HostapdException("Failed to send hostapd 'get' command");
     }
 
-    // Check Failed() and not IsOk() since the response will indicate failure
+    // Check Failed() instead of IsOk() since the response will indicate failure
     // with "FAIL", otherwise, the payload is the property value (not "OK").
     if (response->Failed()) {
         return false;

--- a/src/linux/wpa-controller/WpaCommandStatus.cxx
+++ b/src/linux/wpa-controller/WpaCommandStatus.cxx
@@ -59,15 +59,15 @@ WpaStatusResponseParser::ParsePayload()
     }
 
     if (!(status.Ieee80211n == 0)) {
-        // TODO: parse attributes that are preset when this value is set.
+        // TODO: parse attributes that are present when this value is set.
     }
 
     if (!(status.Ieee80211ac == 0)) {
-        // TODO: parse attributes that are preset when this value is set.
+        // TODO: parse attributes that are present when this value is set.
     }
 
     if (!(status.Ieee80211ax == 0)) {
-        // TODO: parse attributes that are preset when this value is set.
+        // TODO: parse attributes that are present when this value is set.
     }
 
     return response;

--- a/src/linux/wpa-controller/WpaKeyValuePair.cxx
+++ b/src/linux/wpa-controller/WpaKeyValuePair.cxx
@@ -16,13 +16,13 @@ WpaKeyValuePair::TryParseValue(std::string_view input)
     if (!Value.has_value()) {
         // Find the starting position of the key.
         const auto keyPosition = input.find(Key);
-        if (keyPosition != input.npos) {
+        if (keyPosition != std::string_view::npos) {
             // Assign the starting position of the value, advancing past the key.
             input = input.substr(keyPosition + std::size(Key));
 
             // Find the end of the line, marking the end of the value string.
             const auto eolPosition = input.find('\n');
-            if (eolPosition != input.npos) {
+            if (eolPosition != std::string_view::npos) {
                 Value = input.substr(0, eolPosition);
             } else {
                 LOGW << std::format("Failed to parse value for key: {} (missing eol)", Key);

--- a/src/linux/wpa-controller/WpaKeyValuePair.cxx
+++ b/src/linux/wpa-controller/WpaKeyValuePair.cxx
@@ -8,27 +8,3 @@
 #include <plog/Log.h>
 
 using namespace Wpa;
-
-std::optional<std::string_view>
-WpaKeyValuePair::TryParseValue(std::string_view input)
-{
-    // If not already parsed...
-    if (!Value.has_value()) {
-        // Find the starting position of the key.
-        const auto keyPosition = input.find(Key);
-        if (keyPosition != std::string_view::npos) {
-            // Assign the starting position of the value, advancing past the key.
-            input = input.substr(keyPosition + std::size(Key));
-
-            // Find the end of the line, marking the end of the value string.
-            const auto eolPosition = input.find('\n');
-            if (eolPosition != std::string_view::npos) {
-                Value = input.substr(0, eolPosition);
-            } else {
-                LOGW << std::format("Failed to parse value for key: {} (missing eol)", Key);
-            }
-        }
-    }
-
-    return Value;
-}

--- a/src/linux/wpa-controller/WpaResponseParser.cxx
+++ b/src/linux/wpa-controller/WpaResponseParser.cxx
@@ -1,10 +1,13 @@
 
 #include <format>
 #include <initializer_list>
+#include <iterator>
 #include <memory>
+#include <ranges>
 #include <string_view>
 #include <unordered_map>
 
+#include <Wpa/ProtocolWpa.hxx>
 #include <Wpa/WpaKeyValuePair.hxx>
 #include <Wpa/WpaResponse.hxx>
 #include <Wpa/WpaResponseParser.hxx>
@@ -53,8 +56,43 @@ WpaResponseParser::GetResponsePayload() const noexcept
 bool
 WpaResponseParser::TryParseProperties()
 {
+    // Convert a range to a string-view for pre-C++23 where std::string_view doesn't have a range constructor.
+    constexpr auto toStringView = [](auto&& sv) {
+        return std::string_view{ std::data(sv), std::size(sv) };
+    };
+
     if (std::empty(m_propertiesToParse)) {
         return true;
+    }
+
+    // Parse the payload into individual lines containing key value pairs.
+    auto lines = m_responsePayload | std::views::split(ProtocolWpa::KeyValueLineDelimeter) | std::views::transform(toStringView);
+
+    // Parse each line into a key-value pair, and populate a map with them.
+    std::unordered_map<std::string_view, std::string_view> properties;
+    for (const auto line : lines) {
+        auto keyValuePair = line | std::views::split(ProtocolWpa::KeyValueDelimiter) | std::views::transform(toStringView);
+        auto keyValuePairIterator = std::begin(keyValuePair);
+
+        if (keyValuePairIterator == std::end(keyValuePair)) {
+            LOGV << std::format("Skipping empty key value pair line '{}'", line);
+            continue;
+        }
+
+        // Ensure a delimited key and value were found.
+        const auto numElements = std::ranges::distance(keyValuePairIterator, std::end(keyValuePair));
+        if (numElements < 2) {
+            LOGW << std::format("Skipping key value pair line '{}' with less than 2 elements ({})", line, numElements);
+            continue;
+        }
+
+        // Parse out the key and value, ensuring the key is non-empty (empty values are allowed).
+        const auto key = *std::next(keyValuePairIterator, 0);
+        const auto value = *std::next(keyValuePairIterator, 1);
+        if (!std::empty(key)) {
+            properties[key] = value;
+            LOGV << std::format("[{}] {}={}", std::size(properties), key, value);
+        }
     }
 
     for (auto propertyToParseIterator = std::begin(m_propertiesToParse); propertyToParseIterator != std::end(m_propertiesToParse);) {

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -74,6 +74,16 @@ struct Hostapd :
     GetStatus() override;
 
     /**
+     * @brief Set the ssid of the access point.
+     *
+     * @param ssid The ssid to set.
+     * @return true
+     * @return false
+     */
+    bool
+    SetSsid(std::string_view ssid, bool reload = true);
+
+    /**
      * @brief Get a property value for the interface.
      *
      * @param propertyName The name of the property to retrieve.

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -201,6 +201,8 @@ struct ProtocolHostapd :
     static constexpr auto PropertyHwModeValueAD = "ad";
     static constexpr auto PropertyHwModeValueAny = "any";
 
+    static constexpr auto PropertyNameSsid = "ssid";
+
 // Macros below used to avoid repeating the same string literals in multiple places.
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define HOSTAPD_PROPERTY_KEY_VALUE_DELIMETER "="

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -212,20 +212,31 @@ struct ProtocolHostapd :
 #define HOSTAPD_PROPERTY_NAME_DISABLE11AC    "disable_11ac"
 #define HOSTAPD_PROPERTY_NAME_IEEE80211AX    "ieee80211ax"
 #define HOSTAPD_PROPERTY_NAME_DISABLE11AX    "disable_11ax"
+#define HOSTAPD_PROPERTY_NAME_WMM_ENABLED    "wmm_enabled"
 #define HOSTAPD_PROPERTY_NAME_STATE          "state"
+#define HOSTAPD_PROPERTY_NAME_BSS            "bss"
+#define HOSTAPD_PROPERTY_NAME_BSS_BSSID      "bssid"
+#define HOSTAPD_PROPERTY_NAME_BSS_SSID       "ssid"
+#define HOSTAPD_PROPERTY_NAME_BSS_NUM_STA    "num_sta"
 
 // Helper macro to create a hostapd configuration file key with value delimiter.
 #define HOSTAPD_DELIMITED_KEY(name) name HOSTAPD_PROPERTY_KEY_VALUE_DELIMETER
-    // NOLINTEND(cppcoreguidelines-macro-usage)
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
-    static constexpr auto ProperyKeyValueNameDelimeter = HOSTAPD_PROPERTY_KEY_VALUE_DELIMETER;
     static constexpr auto PropertyNameIeee80211N = HOSTAPD_PROPERTY_NAME_IEEE80211N;
     static constexpr auto PropertyNameDisable11N = HOSTAPD_PROPERTY_NAME_DISABLE11N;
     static constexpr auto PropertyNameIeee80211AC = HOSTAPD_PROPERTY_NAME_IEEE80211AC;
     static constexpr auto PropertyNameDisable11AC = HOSTAPD_PROPERTY_NAME_DISABLE11AC;
     static constexpr auto PropertyNameIeee80211AX = HOSTAPD_PROPERTY_NAME_IEEE80211AX;
     static constexpr auto PropertyNameDisable11AX = HOSTAPD_PROPERTY_NAME_DISABLE11AX;
-    static constexpr auto PropertyNameWmmEnabled = "wmm_enabled";
+    static constexpr auto PropertyNameWmmEnabled = HOSTAPD_PROPERTY_NAME_WMM_ENABLED;
+    static constexpr auto PropertyNameState = HOSTAPD_PROPERTY_NAME_STATE;
+
+    // Indexed property names for BSS entries in the "STATUS" response.
+    static constexpr auto PropertyNameBss = HOSTAPD_PROPERTY_NAME_BSS;
+    static constexpr auto PropertyNameBssBssid = HOSTAPD_PROPERTY_NAME_BSS_BSSID;
+    static constexpr auto PropertyNameBssSsid = HOSTAPD_PROPERTY_NAME_BSS_SSID;
+    static constexpr auto PropertyNameNumStations = HOSTAPD_PROPERTY_NAME_BSS_NUM_STA;
 
     // Response properties for the "STATUS" command.
     // Note: all properties must be terminated with the key-value delimeter (=).

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -203,51 +203,30 @@ struct ProtocolHostapd :
 
     static constexpr auto PropertyNameSsid = "ssid";
 
-// Macros below used to avoid repeating the same string literals in multiple places.
-// NOLINTBEGIN(cppcoreguidelines-macro-usage)
-#define HOSTAPD_PROPERTY_KEY_VALUE_DELIMETER "="
-#define HOSTAPD_PROPERTY_NAME_IEEE80211N     "ieee80211n"
-#define HOSTAPD_PROPERTY_NAME_DISABLE11N     "disable_11n"
-#define HOSTAPD_PROPERTY_NAME_IEEE80211AC    "ieee80211ac"
-#define HOSTAPD_PROPERTY_NAME_DISABLE11AC    "disable_11ac"
-#define HOSTAPD_PROPERTY_NAME_IEEE80211AX    "ieee80211ax"
-#define HOSTAPD_PROPERTY_NAME_DISABLE11AX    "disable_11ax"
-#define HOSTAPD_PROPERTY_NAME_WMM_ENABLED    "wmm_enabled"
-#define HOSTAPD_PROPERTY_NAME_STATE          "state"
-#define HOSTAPD_PROPERTY_NAME_BSS            "bss"
-#define HOSTAPD_PROPERTY_NAME_BSS_BSSID      "bssid"
-#define HOSTAPD_PROPERTY_NAME_BSS_SSID       "ssid"
-#define HOSTAPD_PROPERTY_NAME_BSS_NUM_STA    "num_sta"
-
-// Helper macro to create a hostapd configuration file key with value delimiter.
-#define HOSTAPD_DELIMITED_KEY(name) name HOSTAPD_PROPERTY_KEY_VALUE_DELIMETER
-// NOLINTEND(cppcoreguidelines-macro-usage)
-
-    static constexpr auto PropertyNameIeee80211N = HOSTAPD_PROPERTY_NAME_IEEE80211N;
-    static constexpr auto PropertyNameDisable11N = HOSTAPD_PROPERTY_NAME_DISABLE11N;
-    static constexpr auto PropertyNameIeee80211AC = HOSTAPD_PROPERTY_NAME_IEEE80211AC;
-    static constexpr auto PropertyNameDisable11AC = HOSTAPD_PROPERTY_NAME_DISABLE11AC;
-    static constexpr auto PropertyNameIeee80211AX = HOSTAPD_PROPERTY_NAME_IEEE80211AX;
-    static constexpr auto PropertyNameDisable11AX = HOSTAPD_PROPERTY_NAME_DISABLE11AX;
-    static constexpr auto PropertyNameWmmEnabled = HOSTAPD_PROPERTY_NAME_WMM_ENABLED;
-    static constexpr auto PropertyNameState = HOSTAPD_PROPERTY_NAME_STATE;
+    static constexpr auto PropertyNameIeee80211N = "ieee80211n";
+    static constexpr auto PropertyNameDisable11N = "disable_11n";
+    static constexpr auto PropertyNameIeee80211AC = "ieee80211ac";
+    static constexpr auto PropertyNameDisable11AC = "disable_11ac";
+    static constexpr auto PropertyNameIeee80211AX = "ieee80211ax";
+    static constexpr auto PropertyNameDisable11AX = "disable_11ax";
+    static constexpr auto PropertyNameWmmEnabled = "wmm_enabled";
+    static constexpr auto PropertyNameState = "state";
 
     // Indexed property names for BSS entries in the "STATUS" response.
-    static constexpr auto PropertyNameBss = HOSTAPD_PROPERTY_NAME_BSS;
-    static constexpr auto PropertyNameBssBssid = HOSTAPD_PROPERTY_NAME_BSS_BSSID;
-    static constexpr auto PropertyNameBssSsid = HOSTAPD_PROPERTY_NAME_BSS_SSID;
-    static constexpr auto PropertyNameNumStations = HOSTAPD_PROPERTY_NAME_BSS_NUM_STA;
+    static constexpr auto PropertyNameBss = "bss";
+    static constexpr auto PropertyNameBssBssid = "bssid";
+    static constexpr auto PropertyNameBssSsid = "ssid";
+    static constexpr auto PropertyNameBssNumStations = "num_sta";
 
     // Response properties for the "STATUS" command.
     // Note: all properties must be terminated with the key-value delimeter (=).
-    static constexpr auto PropertyNameState = HOSTAPD_PROPERTY_NAME_STATE;
-    static constexpr auto ResponseStatusPropertyKeyState = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_STATE);
-    static constexpr auto ResponseStatusPropertyKeyIeee80211N = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_IEEE80211N);
-    static constexpr auto ResponseStatusPropertyKeyDisable11N = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_DISABLE11N);
-    static constexpr auto ResponseStatusPropertyKeyIeee80211AC = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_IEEE80211AC);
-    static constexpr auto ResponseStatusPropertyKeyDisableAC = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_DISABLE11AC);
-    static constexpr auto ResponseStatusPropertyKeyIeee80211AX = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_IEEE80211AX);
-    static constexpr auto ResponseStatusPropertyKeyDisableAX = HOSTAPD_DELIMITED_KEY(HOSTAPD_PROPERTY_NAME_DISABLE11AX);
+    static constexpr auto ResponseStatusPropertyKeyState = PropertyNameState;
+    static constexpr auto ResponseStatusPropertyKeyIeee80211N = PropertyNameIeee80211N;
+    static constexpr auto ResponseStatusPropertyKeyDisable11N = PropertyNameDisable11N;
+    static constexpr auto ResponseStatusPropertyKeyIeee80211AC = PropertyNameIeee80211AC;
+    static constexpr auto ResponseStatusPropertyKeyDisableAC = PropertyNameDisable11AC;
+    static constexpr auto ResponseStatusPropertyKeyIeee80211AX = PropertyNameIeee80211AX;
+    static constexpr auto ResponseStatusPropertyKeyDisableAX = PropertyNameDisable11AX;
 };
 
 /**

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -5,6 +5,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <Wpa/ProtocolWpa.hxx>
 
@@ -49,6 +50,7 @@ struct BssInfo
     int NumStations{ 0 };
     std::string Bssid;
     std::string Interface;
+    std::string Ssid;
 
     // Present with:
     //  - CONFIG_IEEE80211BE compilation option
@@ -156,8 +158,8 @@ struct HostapdStatus
     // //  - The current operational mode supports the currently active frequency.
     // std::optional<unsigned> MaxTxPower;
 
-    // // Always present (but may be empty).
-    // std::vector<BssInfo> Bss;
+    // Always present (but may be empty).
+    std::vector<BssInfo> Bss;
 
     // // Present with:
     // //  - Non-zero channel utilization.

--- a/src/linux/wpa-controller/include/Wpa/ProtocolWpa.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolWpa.hxx
@@ -13,6 +13,7 @@ struct ProtocolWpa
 {
     // The delimeter used to separate key-value pairs in the WPA control protocol.
     static constexpr auto KeyValueDelimiter = '=';
+    static constexpr auto KeyValueLineDelimeter = '\n';
 
     // Command payloads.
     static constexpr auto CommandPayloadPing = "PING";

--- a/src/linux/wpa-controller/include/Wpa/ProtocolWpa.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolWpa.hxx
@@ -14,6 +14,8 @@ struct ProtocolWpa
     // The delimeter used to separate key-value pairs in the WPA control protocol.
     static constexpr auto KeyValueDelimiter = '=';
     static constexpr auto KeyValueLineDelimeter = '\n';
+    static constexpr auto KeyValueIndexDelimeterStart = '[';
+    static constexpr auto KeyValueIndexDelimeterEnd = ']';
 
     // Command payloads.
     static constexpr auto CommandPayloadPing = "PING";

--- a/src/linux/wpa-controller/include/Wpa/WpaKeyValuePair.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaKeyValuePair.hxx
@@ -4,6 +4,7 @@
 
 #include <format>
 #include <optional>
+#include <stdexcept>
 #include <string_view>
 
 #include <Wpa/ProtocolWpa.hxx>
@@ -38,27 +39,27 @@ struct WpaKeyValuePair
      *
      * @param key The key of the property.
      * @param presence Whether the property is required or optional.
+     * @param isIndexed Whether the property is indexed (i.e. has a numeric suffix in its key name).
      */
-    constexpr WpaKeyValuePair(std::string_view key, WpaValuePresence presence) :
+    constexpr WpaKeyValuePair(std::string_view key, WpaValuePresence presence, bool isIndexed = false) :
         Key(key),
-        IsRequired(notstd::to_underlying(presence))
+        IsRequired(notstd::to_underlying(presence)),
+        IsIndexed(isIndexed)
     {
         // Ensure the specified key ends with the delimiter. If not, this is a
         // programming error so throw a runtime exception.
-        if (!Key.ends_with(KeyDelimiter)) {
+        if (!IsIndexed && !Key.ends_with(KeyDelimiter)) {
             throw std::runtime_error(std::format("Key must end with {} delimiter.", KeyDelimiter));
         }
     }
 
     /**
-     * Parses the input string and attempts to resolve the property value,
-     * assigning it to the Value member if found. Note that this function does
-     * not parse the value itself, it only resolves the value location in the
-     * input string, making it available for later parsing by derived classes
-     * that know its type/structure.
+     * @brief Parses the input string and attempts to resolve the property value, assigning it to the Value member if
+     * found. Note that this function does * not parse the value itself, it only resolves the value location in the
+     * input string, making it available for later parsing by derived classes that know its type/structure.
      *
      * The input string is expected to contain a property of the form:
-     * key=value, as is encoded by the WPA control protocol.    * @brief
+     * key=value, as is encoded by the WPA control protocol.
      *
      * @param input
      * @return std::optional<std::string_view>
@@ -69,6 +70,7 @@ struct WpaKeyValuePair
     std::string_view Key;
     std::optional<std::string_view> Value;
     bool IsRequired{ true };
+    bool IsIndexed{ false };
 };
 } // namespace Wpa
 

--- a/src/linux/wpa-controller/include/Wpa/WpaKeyValuePair.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaKeyValuePair.hxx
@@ -2,9 +2,7 @@
 #ifndef WPA_KEY_VALUE_PAIR_HXX
 #define WPA_KEY_VALUE_PAIR_HXX
 
-#include <format>
 #include <optional>
-#include <stdexcept>
 #include <string_view>
 
 #include <Wpa/ProtocolWpa.hxx>
@@ -46,26 +44,7 @@ struct WpaKeyValuePair
         IsRequired(notstd::to_underlying(presence)),
         IsIndexed(isIndexed)
     {
-        // Ensure the specified key ends with the delimiter. If not, this is a
-        // programming error so throw a runtime exception.
-        if (!IsIndexed && !Key.ends_with(KeyDelimiter)) {
-            throw std::runtime_error(std::format("Key must end with {} delimiter.", KeyDelimiter));
-        }
     }
-
-    /**
-     * @brief Parses the input string and attempts to resolve the property value, assigning it to the Value member if
-     * found. Note that this function does * not parse the value itself, it only resolves the value location in the
-     * input string, making it available for later parsing by derived classes that know its type/structure.
-     *
-     * The input string is expected to contain a property of the form:
-     * key=value, as is encoded by the WPA control protocol.
-     *
-     * @param input
-     * @return std::optional<std::string_view>
-     */
-    std::optional<std::string_view>
-    TryParseValue(std::string_view input);
 
     std::string_view Key;
     std::optional<std::string_view> Value;

--- a/src/linux/wpa-controller/include/Wpa/WpaResponseParser.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaResponseParser.hxx
@@ -85,8 +85,8 @@ protected:
 
     /**
      * @brief Obtain the map of parsed properties.
-     * 
-     * @return const std::unordered_map<std::string_view, std::pair<std::string_view, std::optional<std::size_t>>>& 
+     *
+     * @return const std::unordered_map<std::string_view, std::pair<std::string_view, std::optional<std::size_t>>>&
      */
     const std::unordered_map<std::string_view, std::pair<std::string_view, std::optional<std::size_t>>>&
     GetProperties() const noexcept;

--- a/src/linux/wpa-controller/include/Wpa/WpaResponseParser.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaResponseParser.hxx
@@ -2,10 +2,13 @@
 #ifndef WPA_RESPONSE_PARSER_HXX
 #define WPA_RESPONSE_PARSER_HXX
 
+#include <cstddef>
 #include <initializer_list>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <Wpa/WpaKeyValuePair.hxx>
@@ -26,12 +29,14 @@ struct WpaResponseParser
     virtual ~WpaResponseParser() = default;
 
     /**
-     * Prevent copy and move operations. 
+     * Prevent copy and move operations.
      */
     WpaResponseParser(const WpaResponseParser&) = delete;
     WpaResponseParser(WpaResponseParser&&) = delete;
-    WpaResponseParser& operator=(const WpaResponseParser&) = delete;
-    WpaResponseParser& operator=(WpaResponseParser&&) = delete;
+    WpaResponseParser&
+    operator=(const WpaResponseParser&) = delete;
+    WpaResponseParser&
+    operator=(WpaResponseParser&&) = delete;
 
     /**
      * @brief Construct a new WpaResponseParser object.
@@ -53,16 +58,16 @@ struct WpaResponseParser
 
     /**
      * @brief Get the command associated with the response payload.
-     * 
-     * @return const WpaCommand* 
+     *
+     * @return const WpaCommand*
      */
     const WpaCommand*
     GetCommand() const noexcept;
 
     /**
      * @brief Get the response payload.
-     * 
-     * @return std::string_view 
+     *
+     * @return std::string_view
      */
     std::string_view
     GetResponsePayload() const noexcept;
@@ -80,10 +85,10 @@ protected:
 
     /**
      * @brief Obtain the map of parsed properties.
-     *
-     * @return const std::unordered_map<std::string_view, std::string_view>&
+     * 
+     * @return const std::unordered_map<std::string_view, std::pair<std::string_view, std::optional<std::size_t>>>& 
      */
-    const std::unordered_map<std::string_view, std::string_view>&
+    const std::unordered_map<std::string_view, std::pair<std::string_view, std::optional<std::size_t>>>&
     GetProperties() const noexcept;
 
 private:
@@ -103,7 +108,7 @@ private:
     const WpaCommand* m_command;
     std::string_view m_responsePayload;
     std::vector<WpaKeyValuePair> m_propertiesToParse;
-    std::unordered_map<std::string_view, std::string_view> m_properties{};
+    std::unordered_map<std::string_view, std::pair<std::string_view, std::optional<std::size_t>>> m_properties{};
 };
 
 /**
@@ -116,12 +121,14 @@ struct WpaResponseParserFactory
     virtual ~WpaResponseParserFactory() = default;
 
     /**
-     * Prevent copy and move operations. 
+     * Prevent copy and move operations.
      */
     WpaResponseParserFactory(const WpaResponseParserFactory&) = delete;
     WpaResponseParserFactory(WpaResponseParserFactory&&) = delete;
-    WpaResponseParserFactory& operator=(const WpaResponseParserFactory&) = delete;
-    WpaResponseParserFactory& operator=(WpaResponseParserFactory&&) = delete;
+    WpaResponseParserFactory&
+    operator=(const WpaResponseParserFactory&) = delete;
+    WpaResponseParserFactory&
+    operator=(WpaResponseParserFactory&&) = delete;
 
     /**
      * @brief Create a response parser object.

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -1,5 +1,4 @@
 
-
 #include <algorithm>
 #include <format>
 #include <iterator>
@@ -10,6 +9,7 @@
 #include <vector>
 
 #include <magic_enum.hpp>
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
 #include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
@@ -83,7 +83,7 @@ AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand>
     return true;
 }
 
-bool
+AccessPointOperationStatus
 AccessPointControllerTest::SetSssid(std::string_view ssid)
 {
     if (AccessPoint == nullptr) {
@@ -91,7 +91,7 @@ AccessPointControllerTest::SetSssid(std::string_view ssid)
     }
 
     AccessPoint->Ssid = ssid;
-    return true;
+    return AccessPointOperationStatus::MakeSucceeded();
 }
 
 AccessPointControllerFactoryTest::AccessPointControllerFactoryTest(AccessPointTest *accessPoint) :

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -83,6 +83,17 @@ AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand>
     return true;
 }
 
+bool
+AccessPointControllerTest::SetSssid(std::string_view ssid)
+{
+    if (AccessPoint == nullptr) {
+        throw std::runtime_error("AccessPointControllerTest::SetSssid called with null AccessPoint");
+    }
+
+    AccessPoint->Ssid = ssid;
+    return true;
+}
+
 AccessPointControllerFactoryTest::AccessPointControllerFactoryTest(AccessPointTest *accessPoint) :
     AccessPoint(accessPoint)
 {}

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -75,6 +75,16 @@ struct AccessPointControllerTest final :
      */
     virtual bool
     SetFrequencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) override;
+
+    /**
+     * @brief Set the SSID of the access point.
+     *
+     * @param ssid The SSID to be set.
+     * @return true
+     * @return false
+     */
+    bool
+    SetSssid(std::string_view ssid) override;
 };
 
 /**

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -7,6 +7,8 @@
 #include <vector>
 
 #include <microsoft/net/wifi/IAccessPointController.hxx>
+#include <microsoft/net/wifi/Ieee80211.hxx>
+#include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
 
 namespace Microsoft::Net::Wifi::Test
 {
@@ -18,10 +20,12 @@ struct AccessPointTest;
  * This implementation takes an AccessPointTest object which it uses to implement the IAccessPointController interface.
  * The owner of this class must ensure that the passes AccessPointTest* remains valid for the lifetime of this object.
  */
-struct AccessPointControllerTest final :
-    public Microsoft::Net::Wifi::IAccessPointController
+struct AccessPointControllerTest final : public Microsoft::Net::Wifi::IAccessPointController
 {
     AccessPointTest *AccessPoint{ nullptr };
+
+    AccessPointControllerTest() = default;
+    ~AccessPointControllerTest() override = default;
 
     /**
      * @brief Construct a new AccessPointControllerTest object that uses the specified AccessPointTest to implement the
@@ -29,14 +33,24 @@ struct AccessPointControllerTest final :
      *
      * @param accessPoint The access point to use.
      */
-    AccessPointControllerTest(AccessPointTest *accessPoint);
+    explicit AccessPointControllerTest(AccessPointTest *accessPoint);
+
+    /**
+     * Prevent copying and moving of AccessPointControllerTest objects.
+     */
+    AccessPointControllerTest(const AccessPointControllerTest &) = delete;
+    AccessPointControllerTest &
+    operator=(const AccessPointControllerTest &) = delete;
+    AccessPointControllerTest(AccessPointControllerTest &&) = delete;
+    AccessPointControllerTest &
+    operator=(AccessPointControllerTest &&) = delete;
 
     /**
      * @brief Get the interface name associated with this controller.
      *
      * @return std::string_view
      */
-    virtual std::string_view
+    std::string_view
     GetInterfaceName() const override;
 
     /**
@@ -45,7 +59,7 @@ struct AccessPointControllerTest final :
      * @return true
      * @return false
      */
-    virtual bool
+    bool
     GetIsEnabled() override;
 
     /**
@@ -53,7 +67,7 @@ struct AccessPointControllerTest final :
      *
      * @return Ieee80211AccessPointCapabilities
      */
-    virtual Ieee80211AccessPointCapabilities
+    Ieee80211AccessPointCapabilities
     GetCapabilities() override;
 
     /**
@@ -63,7 +77,7 @@ struct AccessPointControllerTest final :
      * @return true
      * @return false
      */
-    virtual bool
+    bool
     SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol) override;
 
     /**
@@ -73,7 +87,7 @@ struct AccessPointControllerTest final :
      * @return true
      * @return false
      */
-    virtual bool
+    bool
     SetFrequencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) override;
 
     /**
@@ -90,10 +104,11 @@ struct AccessPointControllerTest final :
 /**
  * @brief IAccessPointControllerFactory implementation for testing purposes.
  */
-struct AccessPointControllerFactoryTest final :
-    public Microsoft::Net::Wifi::IAccessPointControllerFactory
+struct AccessPointControllerFactoryTest final : public Microsoft::Net::Wifi::IAccessPointControllerFactory
 {
     AccessPointTest *AccessPoint{ nullptr };
+
+    ~AccessPointControllerFactoryTest() override = default;
 
     /**
      * @brief Construct a new AccessPointControllerFactoryTest object with no AccessPointTest parent/owner. This may
@@ -105,11 +120,22 @@ struct AccessPointControllerFactoryTest final :
     AccessPointControllerFactoryTest() = default;
 
     /**
-     * @brief Construct a new AccessPointControllerFactoryTest object. The owner of this object must ensure that the passed AccessPointTest remains valid for the lifetime of this object.
+     * @brief Construct a new AccessPointControllerFactoryTest object. The owner of this object must ensure that the
+     * passed AccessPointTest remains valid for the lifetime of this object.
      *
      * @param accessPoint The access point to create controllers for.
      */
-    AccessPointControllerFactoryTest(AccessPointTest *accessPoint);
+    explicit AccessPointControllerFactoryTest(AccessPointTest *accessPoint);
+
+    /**
+     * Prevent copying and moving of AccessPointControllerFactoryTest objects.
+     */
+    AccessPointControllerFactoryTest(const AccessPointControllerFactoryTest &) = delete;
+    AccessPointControllerFactoryTest &
+    operator=(const AccessPointControllerFactoryTest &) = delete;
+    AccessPointControllerFactoryTest(AccessPointControllerFactoryTest &&) = delete;
+    AccessPointControllerFactoryTest &
+    operator=(AccessPointControllerFactoryTest &&) = delete;
 
     /**
      * @brief Create a new instance that can control the access point.

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -6,6 +6,7 @@
 #include <string_view>
 #include <vector>
 
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
 #include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
@@ -92,12 +93,11 @@ struct AccessPointControllerTest final : public Microsoft::Net::Wifi::IAccessPoi
 
     /**
      * @brief Set the SSID of the access point.
-     *
+     * 
      * @param ssid The SSID to be set.
-     * @return true
-     * @return false
+     * @return AccessPointOperationStatus 
      */
-    bool
+    AccessPointOperationStatus
     SetSssid(std::string_view ssid) override;
 };
 

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -28,6 +28,7 @@ struct AccessPointTest final :
     bool IsEnabled{ false };
     Microsoft::Net::Wifi::Ieee80211Protocol Protocol;
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> FrequencyBands;
+    std::string Ssid;
 
     /**
      * @brief Construct a new AccessPointTest object with the given interface name and default capabilities.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow access point SSIDs to be set.

### Technical Details

* Add `IAccessPointController::SetSsid` function.
* Add `AccessPointOperationStatusCode` and `AccessPointOperationStatus` class to return rich status information from `IHostapd` interface functions.
* Revamp WPA key-value parsing to support indexed keys.
* Remove preprocessor macros for hostapd key names.

### Test Results

* All current unit tests pass.

### Reviewer Focus

* None

### Future Work

* Add API method to set SSID.
* Update `WifiAccessPointEnable` API to use this.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
