### PR TITLE
Simple C++23 functionality replacements

### DIFF
--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -7,8 +7,7 @@
 #include <cstdint>
 #include <initializer_list>
 #include <string>
-
-#include <notstd/Utility.hxx>
+#include <utility>
 
 namespace Microsoft::Net::Wifi
 {
@@ -205,27 +204,27 @@ enum class Ieee80211AkmSuite : uint32_t {
  * only supports enums with values up to UINT16_MAX-1, and the AKM suite underlying type is uint32_t, so cannot be used.
  */
 constexpr std::initializer_list<uint32_t> AllIeee80211Akms{
-    notstd::to_underlying(Ieee80211AkmSuite::Reserved0),
-    notstd::to_underlying(Ieee80211AkmSuite::Ieee8021x),
-    notstd::to_underlying(Ieee80211AkmSuite::Psk),
-    notstd::to_underlying(Ieee80211AkmSuite::Ft8021x),
-    notstd::to_underlying(Ieee80211AkmSuite::FtPsk),
-    notstd::to_underlying(Ieee80211AkmSuite::Ieee8021xSha256),
-    notstd::to_underlying(Ieee80211AkmSuite::PskSha256),
-    notstd::to_underlying(Ieee80211AkmSuite::Tdls),
-    notstd::to_underlying(Ieee80211AkmSuite::Sae),
-    notstd::to_underlying(Ieee80211AkmSuite::FtSae),
-    notstd::to_underlying(Ieee80211AkmSuite::ApPeerKey),
-    notstd::to_underlying(Ieee80211AkmSuite::Ieee8021xSuiteB),
-    notstd::to_underlying(Ieee80211AkmSuite::Ieee8011xSuiteB192),
-    notstd::to_underlying(Ieee80211AkmSuite::Ft8021xSha384),
-    notstd::to_underlying(Ieee80211AkmSuite::FilsSha256),
-    notstd::to_underlying(Ieee80211AkmSuite::FilsSha384),
-    notstd::to_underlying(Ieee80211AkmSuite::FtFilsSha256),
-    notstd::to_underlying(Ieee80211AkmSuite::FtFilsSha384),
-    notstd::to_underlying(Ieee80211AkmSuite::Owe),
-    notstd::to_underlying(Ieee80211AkmSuite::FtPskSha384),
-    notstd::to_underlying(Ieee80211AkmSuite::PskSha384),
+    std::to_underlying(Ieee80211AkmSuite::Reserved0),
+    std::to_underlying(Ieee80211AkmSuite::Ieee8021x),
+    std::to_underlying(Ieee80211AkmSuite::Psk),
+    std::to_underlying(Ieee80211AkmSuite::Ft8021x),
+    std::to_underlying(Ieee80211AkmSuite::FtPsk),
+    std::to_underlying(Ieee80211AkmSuite::Ieee8021xSha256),
+    std::to_underlying(Ieee80211AkmSuite::PskSha256),
+    std::to_underlying(Ieee80211AkmSuite::Tdls),
+    std::to_underlying(Ieee80211AkmSuite::Sae),
+    std::to_underlying(Ieee80211AkmSuite::FtSae),
+    std::to_underlying(Ieee80211AkmSuite::ApPeerKey),
+    std::to_underlying(Ieee80211AkmSuite::Ieee8021xSuiteB),
+    std::to_underlying(Ieee80211AkmSuite::Ieee8011xSuiteB192),
+    std::to_underlying(Ieee80211AkmSuite::Ft8021xSha384),
+    std::to_underlying(Ieee80211AkmSuite::FilsSha256),
+    std::to_underlying(Ieee80211AkmSuite::FilsSha384),
+    std::to_underlying(Ieee80211AkmSuite::FtFilsSha256),
+    std::to_underlying(Ieee80211AkmSuite::FtFilsSha384),
+    std::to_underlying(Ieee80211AkmSuite::Owe),
+    std::to_underlying(Ieee80211AkmSuite::FtPskSha384),
+    std::to_underlying(Ieee80211AkmSuite::PskSha384),
 };
 
 /**

--- a/src/linux/server/Main.cxx
+++ b/src/linux/server/Main.cxx
@@ -13,7 +13,6 @@
 #include <microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx>
 #include <microsoft/net/wifi/AccessPointLinux.hxx>
 #include <microsoft/net/wifi/AccessPointManager.hxx>
-#include <notstd/Utility.hxx>
 #include <plog/Appenders/ColorConsoleAppender.h>
 #include <plog/Appenders/RollingFileAppender.h>
 #include <plog/Formatters/MessageOnlyFormatter.h>
@@ -44,11 +43,11 @@ main(int argc, char *argv[])
     const auto logSeverity = logging::LogVerbosityToPlogSeverity(configuration.LogVerbosity);
 
     // Configure logging, appending all loggers to the default instance.
-    plog::init<notstd::to_underlying(LogInstanceId::Console)>(logSeverity, &colorConsoleAppender);
-    plog::init(logSeverity).addAppender(plog::get<notstd::to_underlying(LogInstanceId::Console)>());
+    plog::init<std::to_underlying(LogInstanceId::Console)>(logSeverity, &colorConsoleAppender);
+    plog::init(logSeverity).addAppender(plog::get<std::to_underlying(LogInstanceId::Console)>());
     if (configuration.EnableFileLogging) {
-        plog::init<notstd::to_underlying(LogInstanceId::File)>(logSeverity, &rollingFileAppender);
-        plog::init(logSeverity).addAppender(plog::get<notstd::to_underlying(LogInstanceId::File)>());
+        plog::init<std::to_underlying(LogInstanceId::File)>(logSeverity, &rollingFileAppender);
+        plog::init(logSeverity).addAppender(plog::get<std::to_underlying(LogInstanceId::File)>());
     }
 
     // Create an access point manager and discovery agent.

--- a/src/linux/wpa-controller/WpaResponseParser.cxx
+++ b/src/linux/wpa-controller/WpaResponseParser.cxx
@@ -61,9 +61,9 @@ WpaResponseParser::GetResponsePayload() const noexcept
 bool
 WpaResponseParser::TryParseProperties()
 {
-    // Convert a range to a string-view for pre-C++23 where std::string_view doesn't have a range constructor.
+    // Convert a range to a string-view.
     constexpr auto toStringView = [](auto&& sv) {
-        return std::string_view{ std::data(sv), std::size(sv) };
+        return std::string_view(sv);
     };
     // Convert a key-value pair to its key.
     constexpr auto toKey = [](auto&& keyValuePair) {

--- a/src/linux/wpa-controller/include/Wpa/WpaKeyValuePair.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaKeyValuePair.hxx
@@ -4,9 +4,9 @@
 
 #include <optional>
 #include <string_view>
+#include <utility>
 
 #include <Wpa/ProtocolWpa.hxx>
-#include <notstd/Utility.hxx>
 
 namespace Wpa
 {
@@ -41,7 +41,7 @@ struct WpaKeyValuePair
      */
     constexpr WpaKeyValuePair(std::string_view key, WpaValuePresence presence, bool isIndexed = false) :
         Key(key),
-        IsRequired(notstd::to_underlying(presence)),
+        IsRequired(std::to_underlying(presence)),
         IsIndexed(isIndexed)
     {
     }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Replace re-implemented C++23 functionality with actual `std` implementation.
* Make use of new C++23 functionality in easy/obvious cases.

### Technical Details

* Replace use of `notstd::to_underlying` with `std::to_underlying`.
* Use new `std::string_view` range constructor.

### Test Results

* TBD

### Reviewer Focus

* None

### Future Work

* Additional C++23 features like `std::expected` will be used in a future PR.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
