### PR TITLE
Sample usage of proposed data streaming APIs

### DIFF
--- a/protocol/CMakeLists.txt
+++ b/protocol/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PROTO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/protos)
 set(PROTO_DIR_BINARY ${CMAKE_CURRENT_BINARY_DIR}/${NETREMOTE_PROTOCOL_PUBLIC_INCLUDE_SUFFIX})
 set(PROTO_FILES
     ${PROTO_DIR}/NetRemote.proto
+    ${PROTO_DIR}/NetRemoteCallbackService.proto
     ${PROTO_DIR}/NetRemoteService.proto
     ${PROTO_DIR}/NetRemoteWifi.proto
     ${PROTO_DIR}/WifiCore.proto
@@ -24,6 +25,7 @@ set(PROTO_FILES
 #
 set(PROTO_HEADERS_GENERATED
     ${PROTO_DIR_BINARY}/NetRemote.pb.h
+    ${PROTO_DIR_BINARY}/NetRemoteCallbackService.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteService.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteWifi.pb.h
     ${PROTO_DIR_BINARY}/WifiCore.pb.h
@@ -31,6 +33,7 @@ set(PROTO_HEADERS_GENERATED
 
 set(PROTO_HEADERS_GENERATED_GRPC
     ${PROTO_DIR_BINARY}/NetRemote.grpc.pb.h
+    ${PROTO_DIR_BINARY}/NetRemoteCallbackService.grpc.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteService.grpc.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteWifi.grpc.pb.h
     ${PROTO_DIR_BINARY}/WifiCore.grpc.pb.h

--- a/protocol/protos/NetRemoteCallbackService.proto
+++ b/protocol/protos/NetRemoteCallbackService.proto
@@ -8,7 +8,7 @@ import "NetRemoteWifi.proto";
 
 service NetRemoteCallback
 {
-    rpc WifiDataStreamUpload (stream Microsoft.Net.Remote.Wifi.WifiDataStreamData) returns (Microsoft.Net.Remote.Wifi.WifiDataStreamUploadResult);
-    rpc WifiDataStreamDownload (Microsoft.Net.Remote.Wifi.WifiDataStreamDownloadRequest) returns (stream Microsoft.Net.Remote.Wifi.WifiDataStreamData);
-    rpc WifiDataStreamBidirectional (stream Microsoft.Net.Remote.Wifi.WifiDataStreamData) returns (stream Microsoft.Net.Remote.Wifi.WifiDataStreamData);
+    rpc WifiDataStreamUpload (stream Microsoft.Net.Remote.Wifi.WifiDataStreamUploadData) returns (Microsoft.Net.Remote.Wifi.WifiDataStreamUploadResult);
+    rpc WifiDataStreamDownload (Microsoft.Net.Remote.Wifi.WifiDataStreamDownloadRequest) returns (stream Microsoft.Net.Remote.Wifi.WifiDataStreamDownloadData);
+    rpc WifiDataStreamBidirectional (stream Microsoft.Net.Remote.Wifi.WifiDataStreamUploadData) returns (stream Microsoft.Net.Remote.Wifi.WifiDataStreamDownloadData);
 }

--- a/protocol/protos/NetRemoteCallbackService.proto
+++ b/protocol/protos/NetRemoteCallbackService.proto
@@ -1,0 +1,12 @@
+
+syntax = "proto3";
+
+package Microsoft.Net.Remote.Service;
+
+import "NetRemote.proto";
+import "NetRemoteWifi.proto";
+
+service NetRemoteCallback
+{
+    rpc WifiDataStreamUpload (stream Microsoft.Net.Remote.Wifi.WifiDataStreamUploadRequest) returns (Microsoft.Net.Remote.Wifi.WifiDataStreamUploadResult) {}
+}

--- a/protocol/protos/NetRemoteCallbackService.proto
+++ b/protocol/protos/NetRemoteCallbackService.proto
@@ -8,5 +8,6 @@ import "NetRemoteWifi.proto";
 
 service NetRemoteCallback
 {
-    rpc WifiDataStreamUpload (stream Microsoft.Net.Remote.Wifi.WifiDataStreamData) returns (Microsoft.Net.Remote.Wifi.WifiDataStreamUploadResult) {}
+    rpc WifiDataStreamUpload (stream Microsoft.Net.Remote.Wifi.WifiDataStreamData) returns (Microsoft.Net.Remote.Wifi.WifiDataStreamUploadResult);
+    rpc WifiDataStreamDownload (Microsoft.Net.Remote.Wifi.WifiDataStreamDownloadRequest) returns (stream Microsoft.Net.Remote.Wifi.WifiDataStreamData);
 }

--- a/protocol/protos/NetRemoteCallbackService.proto
+++ b/protocol/protos/NetRemoteCallbackService.proto
@@ -8,5 +8,5 @@ import "NetRemoteWifi.proto";
 
 service NetRemoteCallback
 {
-    rpc WifiDataStreamUpload (stream Microsoft.Net.Remote.Wifi.WifiDataStreamUploadRequest) returns (Microsoft.Net.Remote.Wifi.WifiDataStreamUploadResult) {}
+    rpc WifiDataStreamUpload (stream Microsoft.Net.Remote.Wifi.WifiDataStreamData) returns (Microsoft.Net.Remote.Wifi.WifiDataStreamUploadResult) {}
 }

--- a/protocol/protos/NetRemoteCallbackService.proto
+++ b/protocol/protos/NetRemoteCallbackService.proto
@@ -10,4 +10,5 @@ service NetRemoteCallback
 {
     rpc WifiDataStreamUpload (stream Microsoft.Net.Remote.Wifi.WifiDataStreamData) returns (Microsoft.Net.Remote.Wifi.WifiDataStreamUploadResult);
     rpc WifiDataStreamDownload (Microsoft.Net.Remote.Wifi.WifiDataStreamDownloadRequest) returns (stream Microsoft.Net.Remote.Wifi.WifiDataStreamData);
+    rpc WifiDataStreamBidirectional (stream Microsoft.Net.Remote.Wifi.WifiDataStreamData) returns (stream Microsoft.Net.Remote.Wifi.WifiDataStreamData);
 }

--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -13,5 +13,4 @@ service NetRemote
     rpc WifiAccessPointDisable (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableResult);
     rpc WifiAccessPointSetPhyType (Microsoft.Net.Remote.Wifi.WifiAccessPointSetPhyTypeRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetPhyTypeResult);
     rpc WifiAccessPointSetFrequencyBands (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsResult);
-    rpc WifiDataStreamUpload (stream Microsoft.Net.Remote.Wifi.WifiDataStreamUploadRequest) returns (Microsoft.Net.Remote.Wifi.WifiDataStreamUploadResult);
 }

--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -13,4 +13,5 @@ service NetRemote
     rpc WifiAccessPointDisable (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableResult);
     rpc WifiAccessPointSetPhyType (Microsoft.Net.Remote.Wifi.WifiAccessPointSetPhyTypeRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetPhyTypeResult);
     rpc WifiAccessPointSetFrequencyBands (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsResult);
+    rpc WifiDataStreamUpload (stream Microsoft.Net.Remote.Wifi.WifiDataStreamUploadRequest) returns (Microsoft.Net.Remote.Wifi.WifiDataStreamUploadResult);
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -119,7 +119,33 @@ message WifiDataStreamUploadResult
     WifiDataStreamOperationStatus Status = 2;
 }
 
+enum WifiDataStreamType
+{
+    Fixed = 0;
+    Continuous = 1;
+}
+
+message WifiDataStreamFixedTypeProperties
+{
+    uint32 NumberOfDataBlocksToStream = 1;
+}
+
+message WifiDataStreamContinuousTypeProperties
+{
+
+}
+
+message WifiDataStreamProperties
+{
+    WifiDataStreamType Type = 1;
+    oneof Properties
+    {
+        WifiDataStreamFixedTypeProperties FixedTypeProperties = 2;
+        WifiDataStreamContinuousTypeProperties ContinuousTypeProperties = 3;
+    }
+}
+
 message WifiDataStreamDownloadRequest
 {
-    uint32 DataRequestedCount = 1;
+    WifiDataStreamProperties Properties = 1;
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -106,6 +106,7 @@ message WifiAccessPointSetFrequencyBandsResult
 message WifiDataStreamData
 {
     string Data = 1;
+    uint32 Count = 2;
 }
 
 message WifiDataStreamUploadResult

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -109,7 +109,7 @@ message WifiDataStreamUploadData
 message WifiDataStreamDownloadData
 {
     bytes Data = 1;
-    uint32 Count = 2;
+    uint32 SequenceNumber = 2;
     WifiDataStreamOperationStatus Status = 3;
 }
 
@@ -135,13 +135,20 @@ message WifiDataStreamContinuousTypeProperties
 
 }
 
+enum WifiDataStreamPattern
+{
+    Constant = 0;
+    // Other throughput patterns, e.g. large spikes
+}
+
 message WifiDataStreamProperties
 {
     WifiDataStreamType Type = 1;
+    WifiDataStreamPattern Pattern = 2;
     oneof Properties
     {
-        WifiDataStreamFixedTypeProperties FixedTypeProperties = 2;
-        WifiDataStreamContinuousTypeProperties ContinuousTypeProperties = 3;
+        WifiDataStreamFixedTypeProperties FixedTypeProperties = 3;
+        WifiDataStreamContinuousTypeProperties ContinuousTypeProperties = 4;
     }
 }
 

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -103,12 +103,12 @@ message WifiAccessPointSetFrequencyBandsResult
 
 message WifiDataStreamUploadData
 {
-    string Data = 1;
+    bytes Data = 1;
 }
 
 message WifiDataStreamDownloadData
 {
-    string Data = 1;
+    bytes Data = 1;
     uint32 Count = 2;
     WifiDataStreamOperationStatus Status = 3;
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -44,8 +44,9 @@ enum WifiDataStreamOperationStatusCode
 {
     WifiDataStreamOperationStatusCodeUnknown = 0;
     WifiDataStreamOperationStatusCodeSucceeded = 1;
-    WifiDataStreamOperationStatusCodeInvalidParameter = 2;
-    WifiDataStreamOperationStatusCodeOperationNotSupported = 3;
+    WifiDataStreamOperationStatusCodeFailed = 2;
+    WifiDataStreamOperationStatusCodeInvalidParameter = 3;
+    WifiDataStreamOperationStatusCodeOperationNotSupported = 4;
 }
 
 message WifiDataStreamOperationStatus
@@ -111,4 +112,9 @@ message WifiDataStreamUploadResult
 {
     uint32 DataReceivedCount = 1;
     WifiDataStreamOperationStatus Status = 2;
+}
+
+message WifiDataStreamDownloadRequest
+{
+    uint32 DataRequestedCount = 1;
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -45,8 +45,6 @@ enum WifiDataStreamOperationStatusCode
     WifiDataStreamOperationStatusCodeUnknown = 0;
     WifiDataStreamOperationStatusCodeSucceeded = 1;
     WifiDataStreamOperationStatusCodeFailed = 2;
-    WifiDataStreamOperationStatusCodeInvalidParameter = 3;
-    WifiDataStreamOperationStatusCodeOperationNotSupported = 4;
 }
 
 message WifiDataStreamOperationStatus

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -103,10 +103,17 @@ message WifiAccessPointSetFrequencyBandsResult
     WifiAccessPointOperationStatus Status = 2;
 }
 
-message WifiDataStreamData
+message WifiDataStreamUploadData
 {
     string Data = 1;
     uint32 Count = 2;
+}
+
+message WifiDataStreamDownloadData
+{
+    string Data = 1;
+    uint32 Count = 2;
+    WifiDataStreamOperationStatus Status = 3;
 }
 
 message WifiDataStreamUploadResult

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -102,12 +102,13 @@ message WifiAccessPointSetFrequencyBandsResult
     WifiAccessPointOperationStatus Status = 2;
 }
 
-message WifiDataStreamUploadRequest
+message WifiDataStreamData
 {
     string Data = 1;
 }
 
 message WifiDataStreamUploadResult
 {
-    WifiDataStreamOperationStatus Status = 1;
+    uint32 DataReceivedCount = 1;
+    WifiDataStreamOperationStatus Status = 2;
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -104,7 +104,6 @@ message WifiAccessPointSetFrequencyBandsResult
 message WifiDataStreamUploadData
 {
     string Data = 1;
-    uint32 Count = 2;
 }
 
 message WifiDataStreamDownloadData

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -40,6 +40,21 @@ message WifiAccessPointOperationStatus
     google.protobuf.Any Details = 3;
 }
 
+enum WifiDataStreamOperationStatusCode
+{
+    WifiDataStreamOperationStatusCodeUnknown = 0;
+    WifiDataStreamOperationStatusCodeSucceeded = 1;
+    WifiDataStreamOperationStatusCodeInvalidParameter = 2;
+    WifiDataStreamOperationStatusCodeOperationNotSupported = 3;
+}
+
+message WifiDataStreamOperationStatus
+{
+    WifiDataStreamOperationStatusCode Code = 1;
+    string Message = 2;
+    google.protobuf.Any Details = 3;
+}
+
 message WifiAccessPointEnableRequest
 {
     string AccessPointId = 1;
@@ -85,4 +100,14 @@ message WifiAccessPointSetFrequencyBandsResult
 {
     string AccessPointId = 1;
     WifiAccessPointOperationStatus Status = 2;
+}
+
+message WifiDataStreamUploadRequest
+{
+    string Data = 1;
+}
+
+message WifiDataStreamUploadResult
+{
+    WifiDataStreamOperationStatus Status = 1;
 }

--- a/src/common/server/NetRemoteServer.cxx
+++ b/src/common/server/NetRemoteServer.cxx
@@ -33,6 +33,12 @@ NetRemoteServer::GetService() noexcept
     return m_service;
 }
 
+Service::NetRemoteCallbackService&
+NetRemoteServer::GetCallbackService() noexcept
+{
+    return m_callbackService;
+}
+
 void
 NetRemoteServer::Run()
 {
@@ -43,6 +49,7 @@ NetRemoteServer::Run()
     grpc::ServerBuilder builder{};
     builder.AddListeningPort(m_serverAddress, grpc::InsecureServerCredentials());
     builder.RegisterService(&m_service);
+    builder.RegisterService(&m_callbackService);
 
     m_server = builder.BuildAndStart();
     LOGI << std::format("Netremote server started listening on {}", m_serverAddress);

--- a/src/common/server/include/microsoft/net/remote/NetRemoteServer.hxx
+++ b/src/common/server/include/microsoft/net/remote/NetRemoteServer.hxx
@@ -7,6 +7,7 @@
 
 #include <grpcpp/server.h>
 #include <microsoft/net/remote/NetRemoteServerConfiguration.hxx>
+#include <microsoft/net/remote/NetRemoteCallbackService.hxx>
 #include <microsoft/net/remote/NetRemoteService.hxx>
 
 namespace Microsoft::Net::Remote
@@ -52,6 +53,14 @@ struct NetRemoteServer
     GetService() noexcept;
 
     /**
+     * @brief Get the NetRemoteCallbackService object instance.
+     * 
+     * @return Service::NetRemoteCallbackService&
+     */
+    Service::NetRemoteCallbackService&
+    GetCallbackService() noexcept;
+
+    /**
      * @brief Start the server if not already started.
      */
     void
@@ -67,6 +76,7 @@ private:
     std::string m_serverAddress;
     std::unique_ptr<grpc::Server> m_server;
     Service::NetRemoteService m_service;
+    Service::NetRemoteCallbackService m_callbackService;
 };
 } // namespace Microsoft::Net::Remote
 

--- a/src/common/service/CMakeLists.txt
+++ b/src/common/service/CMakeLists.txt
@@ -8,6 +8,7 @@ set(NET_REMOTE_SERVICE_PUBLIC_INCLUDE_PREFIX ${NET_REMOTE_SERVICE_PUBLIC_INCLUDE
 target_sources(${PROJECT_NAME}-service
     PRIVATE
         NetRemoteService.cxx
+        NetRemoteCallbackService.cxx
         NetRemoteApiTrace.hxx
         NetRemoteApiTrace.cxx 
         NetRemoteWifiApiTrace.hxx
@@ -17,6 +18,7 @@ target_sources(${PROJECT_NAME}-service
     BASE_DIRS ${NET_REMOTE_SERVICE_PUBLIC_INCLUDE}
     FILES
         ${NET_REMOTE_SERVICE_PUBLIC_INCLUDE_PREFIX}/NetRemoteService.hxx
+        ${NET_REMOTE_SERVICE_PUBLIC_INCLUDE_PREFIX}/NetRemoteCallbackService.hxx
 )
 
 target_link_libraries(${PROJECT_NAME}-service

--- a/src/common/service/NetRemoteCallbackService.cxx
+++ b/src/common/service/NetRemoteCallbackService.cxx
@@ -20,7 +20,8 @@ NetRemoteCallbackService::WifiDataStreamUpload([[maybe_unused]] ::grpc::Callback
             StartRead(&m_data);
         }
 
-        void OnReadDone(bool ok) override
+        void
+        OnReadDone(bool ok) override
         {
             if (ok) {
                 LOGD << "Data read successful";
@@ -31,7 +32,7 @@ NetRemoteCallbackService::WifiDataStreamUpload([[maybe_unused]] ::grpc::Callback
             } else {
                 // A false "ok" value could either mean a failed RPC or that no more data is available.
                 // Unfortunately, there is no clear way to tell which situation occurred.
-                LOGD << "Data read failed (RPC failed OR no more data)";    
+                LOGD << "Data read failed (RPC failed OR no more data)";
 
                 m_result->set_datareceivedcount(m_dataReceivedCount);
                 *m_result->mutable_status() = std::move(m_readStatus);
@@ -39,7 +40,8 @@ NetRemoteCallbackService::WifiDataStreamUpload([[maybe_unused]] ::grpc::Callback
             }
         }
 
-        void OnCancel() override
+        void
+        OnCancel() override
         {
             LOGE << "RPC cancelled";
             m_result->set_datareceivedcount(m_dataReceivedCount);
@@ -47,7 +49,8 @@ NetRemoteCallbackService::WifiDataStreamUpload([[maybe_unused]] ::grpc::Callback
             Finish(::grpc::Status::CANCELLED);
         }
 
-        void OnDone() override
+        void
+        OnDone() override
         {
             delete this;
         }
@@ -78,7 +81,8 @@ NetRemoteCallbackService::WifiDataStreamDownload([[maybe_unused]] ::grpc::Callba
             NextWrite();
         }
 
-        void OnWriteDone(bool ok) override
+        void
+        OnWriteDone(bool ok) override
         {
             // Check for a failed status code from HandleWriteFailure since that invoked a final write, thus causing this callback to be invoked.
             if (m_writeStatus.code() == WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeFailed) {
@@ -98,13 +102,15 @@ NetRemoteCallbackService::WifiDataStreamDownload([[maybe_unused]] ::grpc::Callba
             }
         }
 
-        void OnDone() override
+        void
+        OnDone() override
         {
             delete this;
         }
 
     private:
-        void NextWrite()
+        void
+        NextWrite()
         {
             if (m_dataRequestedCount > 0) {
                 const auto data = std::format("Data #{}", ++m_dataSentCount);
@@ -119,7 +125,8 @@ NetRemoteCallbackService::WifiDataStreamDownload([[maybe_unused]] ::grpc::Callba
             }
         }
 
-        void HandleWriteFailure()
+        void
+        HandleWriteFailure()
         {
             LOGD << "HandleWriteFailure called";
             m_writeStatus.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeFailed);
@@ -154,7 +161,8 @@ NetRemoteCallbackService::WifiDataStreamBidirectional([[maybe_unused]] ::grpc::C
             NextWrite();
         }
 
-        void OnReadDone(bool ok) override
+        void
+        OnReadDone(bool ok) override
         {
             if (ok) {
                 LOGD << "Data read successful";
@@ -168,7 +176,8 @@ NetRemoteCallbackService::WifiDataStreamBidirectional([[maybe_unused]] ::grpc::C
             }
         }
 
-        void OnWriteDone(bool ok) override
+        void
+        OnWriteDone(bool ok) override
         {
             // Check for a failed status code from HandleFailure since that invoked a final write, thus causing this callback to be invoked.
             if (m_status.code() == WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeFailed) {
@@ -181,25 +190,28 @@ NetRemoteCallbackService::WifiDataStreamBidirectional([[maybe_unused]] ::grpc::C
                 m_status.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeSucceeded);
                 m_status.set_message("Data write successful");
                 NextWrite();
-            } //else {
-                //LOGE << "Data write failed";
-                //HandleFailure("Data write failed");
+            } // else {
+              // LOGE << "Data write failed";
+              // HandleFailure("Data write failed");
             //}
         }
 
-        void OnCancel() override
+        void
+        OnCancel() override
         {
             LOGE << "RPC cancelled";
             Finish(::grpc::Status::CANCELLED);
         }
 
-        void OnDone() override
+        void
+        OnDone() override
         {
             delete this;
         }
 
     private:
-        void NextWrite()
+        void
+        NextWrite()
         {
             const auto data = std::format("Data #{}", ++m_dataSentCount);
             LOGD << "Writing " << data;
@@ -209,7 +221,8 @@ NetRemoteCallbackService::WifiDataStreamBidirectional([[maybe_unused]] ::grpc::C
             StartWrite(&m_writeData);
         }
 
-        void HandleFailure(const std::string failureMessage)
+        void
+        HandleFailure(const std::string failureMessage)
         {
             LOGD << "HandleFailure called";
             m_status.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeFailed);

--- a/src/common/service/NetRemoteCallbackService.cxx
+++ b/src/common/service/NetRemoteCallbackService.cxx
@@ -129,12 +129,8 @@ NetRemoteCallbackService::WifiDataStreamBidirectional([[maybe_unused]] ::grpc::C
         void OnReadDone(bool ok) override
         {
             if (ok) {
-                LOGD << "Data read successful";
                 StartRead(&m_readData);
             } else {
-                // A false "ok" value could either mean a failed RPC or that no more data is available.
-                // Unfortunately, there is no clear way to tell which situation occurred.
-                LOGD << "Data read failed (RPC failed OR no more data)";
                 Finish(::grpc::Status::OK);
             }
         }
@@ -143,15 +139,11 @@ NetRemoteCallbackService::WifiDataStreamBidirectional([[maybe_unused]] ::grpc::C
         {
             if (ok) {
                 NextWrite();
-            } else {
-                LOGE << "Data write failed";
-                Finish(::grpc::Status::OK);
             }
         }
 
         void OnCancel() override
         {
-            LOGE << "RPC cancelled";
             Finish(::grpc::Status::CANCELLED);
         }
 

--- a/src/common/service/NetRemoteCallbackService.cxx
+++ b/src/common/service/NetRemoteCallbackService.cxx
@@ -23,18 +23,8 @@ NetRemoteCallbackService::WifiDataStreamUpload([[maybe_unused]] ::grpc::Callback
         void OnReadDone(bool ok) override
         {
             if (ok) {
-                if (m_data.count() != ++m_dataReceivedCount) {
-                    LOGE << std::format("Client data count {} does not match received data count {}", m_data.count(), m_dataReceivedCount);
-                    m_readStatus.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeFailed);
-                    m_readStatus.set_message(std::format("Client data count {} does not match received data count {}", m_data.count(), m_dataReceivedCount));
-
-                    m_result->set_datareceivedcount(m_dataReceivedCount);
-                    *m_result->mutable_status() = std::move(m_readStatus);
-                    Finish(::grpc::Status::OK);
-                    return;
-                }
-
                 LOGD << "Data read successful";
+                m_dataReceivedCount++;
                 m_readStatus.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeSucceeded);
                 m_readStatus.set_message("Data read successful");
                 StartRead(&m_data);
@@ -167,14 +157,8 @@ NetRemoteCallbackService::WifiDataStreamBidirectional([[maybe_unused]] ::grpc::C
         void OnReadDone(bool ok) override
         {
             if (ok) {
-                if (m_readData.count() != ++m_dataReceivedCount) {
-                    const auto failureMessage = std::format("Client data count {} does not match received data count {}", m_readData.count(), m_dataReceivedCount);
-                    LOGE << failureMessage;
-                    HandleFailure(failureMessage);
-                    return;
-                }
-
                 LOGD << "Data read successful";
+                m_dataReceivedCount++;
                 m_status.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeSucceeded);
                 m_status.set_message("Data read successful");
                 StartRead(&m_readData);

--- a/src/common/service/NetRemoteCallbackService.cxx
+++ b/src/common/service/NetRemoteCallbackService.cxx
@@ -126,7 +126,7 @@ NetRemoteCallbackService::WifiDataStreamDownload([[maybe_unused]] ::grpc::Callba
                 const auto data = std::format("Data #{}", ++m_dataSentCount);
                 LOGD << "Writing " << data;
                 m_data.set_data(data);
-                m_data.set_count(m_dataSentCount);
+                m_data.set_sequencenumber(m_dataSentCount);
                 *m_data.mutable_status() = m_writeStatus;
                 StartWrite(&m_data);
             } else {
@@ -227,7 +227,7 @@ NetRemoteCallbackService::WifiDataStreamBidirectional([[maybe_unused]] ::grpc::C
             const auto data = std::format("Data #{}", ++m_dataSentCount);
             LOGD << "Writing " << data;
             m_writeData.set_data(data);
-            m_writeData.set_count(m_dataSentCount);
+            m_writeData.set_sequencenumber(m_dataSentCount);
             *m_writeData.mutable_status() = m_status;
             StartWrite(&m_writeData);
         }

--- a/src/common/service/NetRemoteCallbackService.cxx
+++ b/src/common/service/NetRemoteCallbackService.cxx
@@ -1,0 +1,16 @@
+#include <microsoft/net/remote/NetRemoteCallbackService.hxx>
+#include <plog/Log.h>
+
+using namespace Microsoft::Net::Remote::Service;
+
+using Microsoft::Net::Remote::Wifi::WifiDataStreamOperationStatus;
+using Microsoft::Net::Remote::Wifi::WifiDataStreamOperationStatusCode;
+
+::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadRequest>*
+NetRemoteCallbackService::WifiDataStreamUpload(::grpc::CallbackServerContext* context, ::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* response)
+{
+    LOGD << "Received WifiDataStreamUpload request";
+
+    ::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadRequest>* readReactor{};
+    return readReactor;
+}

--- a/src/common/service/NetRemoteCallbackService.cxx
+++ b/src/common/service/NetRemoteCallbackService.cxx
@@ -6,11 +6,58 @@ using namespace Microsoft::Net::Remote::Service;
 using Microsoft::Net::Remote::Wifi::WifiDataStreamOperationStatus;
 using Microsoft::Net::Remote::Wifi::WifiDataStreamOperationStatusCode;
 
-::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadRequest>*
-NetRemoteCallbackService::WifiDataStreamUpload(::grpc::CallbackServerContext* context, ::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* response)
+::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData>*
+NetRemoteCallbackService::WifiDataStreamUpload([[maybe_unused]] ::grpc::CallbackServerContext* context, ::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* result)
 {
     LOGD << "Received WifiDataStreamUpload request";
 
-    ::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadRequest>* readReactor{};
-    return readReactor;
+    class StreamReader : public ::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData>
+    {
+    public:
+        StreamReader(::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* result) :
+            m_result(result)
+        {
+            StartRead(&m_data);
+        }
+
+        void OnReadDone(bool ok) override
+        {
+            if (ok) {
+                LOGD << "Data read successful";
+                m_dataReceivedCount++;
+                m_readStatus.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeSucceeded);
+                m_readStatus.set_message("Data read successful");
+                StartRead(&m_data);
+            } else {
+                // A false "ok" value could either mean a failed RPC or that no more data is available.
+                // Unfortunately, there is no clear way to tell which situation occurred.
+                LOGD << "Data read failed (RPC failed OR no more data)";    
+
+                m_result->set_datareceivedcount(m_dataReceivedCount);
+                *m_result->mutable_status() = std::move(m_readStatus);
+                Finish(::grpc::Status::OK);
+            }
+        }
+
+        void OnCancel() override
+        {
+            LOGE << "RPC cancelled";
+            m_result->set_datareceivedcount(m_dataReceivedCount);
+            *m_result->mutable_status() = std::move(m_readStatus);
+            Finish(::grpc::Status::CANCELLED);
+        }
+
+        void OnDone() override
+        {
+            delete this;
+        }
+
+    private:
+        ::Microsoft::Net::Remote::Wifi::WifiDataStreamData m_data{};
+        ::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* m_result{};
+        uint32_t m_dataReceivedCount{};
+        ::Microsoft::Net::Remote::Wifi::WifiDataStreamOperationStatus m_readStatus{};
+    };
+
+    return new StreamReader(result);
 }

--- a/src/common/service/NetRemoteCallbackService.cxx
+++ b/src/common/service/NetRemoteCallbackService.cxx
@@ -6,12 +6,12 @@ using namespace Microsoft::Net::Remote::Service;
 using Microsoft::Net::Remote::Wifi::WifiDataStreamOperationStatus;
 using Microsoft::Net::Remote::Wifi::WifiDataStreamOperationStatusCode;
 
-::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData>*
+::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData>*
 NetRemoteCallbackService::WifiDataStreamUpload([[maybe_unused]] ::grpc::CallbackServerContext* context, ::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* result)
 {
     LOGD << "Received WifiDataStreamUpload request";
 
-    class StreamReader : public ::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData>
+    class StreamReader : public ::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData>
     {
     public:
         StreamReader(::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* result) :
@@ -27,6 +27,10 @@ NetRemoteCallbackService::WifiDataStreamUpload([[maybe_unused]] ::grpc::Callback
                     LOGE << std::format("Client data count {} does not match received data count {}", m_data.count(), m_dataReceivedCount);
                     m_readStatus.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeFailed);
                     m_readStatus.set_message(std::format("Client data count {} does not match received data count {}", m_data.count(), m_dataReceivedCount));
+
+                    m_result->set_datareceivedcount(m_dataReceivedCount);
+                    *m_result->mutable_status() = std::move(m_readStatus);
+                    Finish(::grpc::Status::OK);
                     return;
                 }
 
@@ -59,7 +63,7 @@ NetRemoteCallbackService::WifiDataStreamUpload([[maybe_unused]] ::grpc::Callback
         }
 
     private:
-        ::Microsoft::Net::Remote::Wifi::WifiDataStreamData m_data{};
+        ::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData m_data{};
         ::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* m_result{};
         uint32_t m_dataReceivedCount{};
         ::Microsoft::Net::Remote::Wifi::WifiDataStreamOperationStatus m_readStatus{};
@@ -68,28 +72,39 @@ NetRemoteCallbackService::WifiDataStreamUpload([[maybe_unused]] ::grpc::Callback
     return new StreamReader(result);
 }
 
-::grpc::ServerWriteReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData>*
+::grpc::ServerWriteReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamDownloadData>*
 NetRemoteCallbackService::WifiDataStreamDownload([[maybe_unused]] ::grpc::CallbackServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiDataStreamDownloadRequest* request)
 {
     LOGD << "Received WifiDataStreamDownload request";
 
-    class StreamWriter : public ::grpc::ServerWriteReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData>
+    class StreamWriter : public ::grpc::ServerWriteReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamDownloadData>
     {
     public:
         StreamWriter(const ::Microsoft::Net::Remote::Wifi::WifiDataStreamDownloadRequest* request)
         {
             m_dataRequestedCount = request->datarequestedcount();
+            m_writeStatus.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeUnknown);
+            m_writeStatus.set_message("No data sent yet");
             NextWrite();
         }
 
         void OnWriteDone(bool ok) override
         {
+            // Check for a failed status code from HandleWriteFailure since that invoked a final write, thus causing this callback to be invoked.
+            if (m_writeStatus.code() == WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeFailed) {
+                Finish(::grpc::Status::OK);
+                return;
+            }
+
             if (ok) {
+                LOGD << "Data write successful";
                 m_dataRequestedCount--;
+                m_writeStatus.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeSucceeded);
+                m_writeStatus.set_message("Data write successful");
                 NextWrite();
             } else {
                 LOGE << "Data write failed";
-                Finish(::grpc::Status::OK);
+                HandleWriteFailure();
             }
         }
 
@@ -102,8 +117,11 @@ NetRemoteCallbackService::WifiDataStreamDownload([[maybe_unused]] ::grpc::Callba
         void NextWrite()
         {
             if (m_dataRequestedCount > 0) {
-                m_data.set_data(std::format("Data #{}", ++m_dataSentCount));
+                const auto data = std::format("Data #{}", ++m_dataSentCount);
+                LOGD << "Writing " << data;
+                m_data.set_data(data);
                 m_data.set_count(m_dataSentCount);
+                *m_data.mutable_status() = m_writeStatus;
                 StartWrite(&m_data);
             } else {
                 // No more data to write
@@ -111,25 +129,37 @@ NetRemoteCallbackService::WifiDataStreamDownload([[maybe_unused]] ::grpc::Callba
             }
         }
 
+        void HandleWriteFailure()
+        {
+            LOGD << "HandleWriteFailure called";
+            m_writeStatus.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeFailed);
+            m_writeStatus.set_message("Data write failed");
+            StartWrite(&m_data);
+        }
+
     private:
-        ::Microsoft::Net::Remote::Wifi::WifiDataStreamData m_data{};
+        ::Microsoft::Net::Remote::Wifi::WifiDataStreamDownloadData m_data{};
         uint32_t m_dataRequestedCount{};
         uint32_t m_dataSentCount{};
+        ::Microsoft::Net::Remote::Wifi::WifiDataStreamOperationStatus m_writeStatus{};
     };
 
     return new StreamWriter(request);
 }
 
-::grpc::ServerBidiReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData, ::Microsoft::Net::Remote::Wifi::WifiDataStreamData>*
+::grpc::ServerBidiReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData, ::Microsoft::Net::Remote::Wifi::WifiDataStreamDownloadData>*
 NetRemoteCallbackService::WifiDataStreamBidirectional([[maybe_unused]] ::grpc::CallbackServerContext* context)
 {
     LOGD << "Received WifiDataStreamBidirectional request";
 
-    class StreamReaderWriter : public ::grpc::ServerBidiReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData, ::Microsoft::Net::Remote::Wifi::WifiDataStreamData>
+    class StreamReaderWriter : public ::grpc::ServerBidiReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData, ::Microsoft::Net::Remote::Wifi::WifiDataStreamDownloadData>
     {
     public:
         StreamReaderWriter()
         {
+            m_status.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeUnknown);
+            m_status.set_message("No data sent yet");
+
             StartRead(&m_readData);
             NextWrite();
         }
@@ -138,25 +168,44 @@ NetRemoteCallbackService::WifiDataStreamBidirectional([[maybe_unused]] ::grpc::C
         {
             if (ok) {
                 if (m_readData.count() != ++m_dataReceivedCount) {
-                    LOGE << std::format("Client data count {} does not match received data count {}", m_readData.count(), m_dataReceivedCount);
-                    Finish(::grpc::Status::OK);
+                    const auto failureMessage = std::format("Client data count {} does not match received data count {}", m_readData.count(), m_dataReceivedCount);
+                    LOGE << failureMessage;
+                    HandleFailure(failureMessage);
                     return;
                 }
+
+                LOGD << "Data read successful";
+                m_status.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeSucceeded);
+                m_status.set_message("Data read successful");
                 StartRead(&m_readData);
             } else {
+                LOGE << "Data read failed";
                 Finish(::grpc::Status::OK);
             }
         }
 
         void OnWriteDone(bool ok) override
         {
-            if (ok) {
-                NextWrite();
+            // Check for a failed status code from HandleFailure since that invoked a final write, thus causing this callback to be invoked.
+            if (m_status.code() == WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeFailed) {
+                Finish(::grpc::Status::OK);
+                return;
             }
+
+            if (ok) {
+                LOGD << "Data write successful";
+                m_status.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeSucceeded);
+                m_status.set_message("Data write successful");
+                NextWrite();
+            } //else {
+                //LOGE << "Data write failed";
+                //HandleFailure("Data write failed");
+            //}
         }
 
         void OnCancel() override
         {
+            LOGE << "RPC cancelled";
             Finish(::grpc::Status::CANCELLED);
         }
 
@@ -168,16 +217,28 @@ NetRemoteCallbackService::WifiDataStreamBidirectional([[maybe_unused]] ::grpc::C
     private:
         void NextWrite()
         {
-            m_writeData.set_data(std::format("Data #{}", ++m_dataSentCount));
+            const auto data = std::format("Data #{}", ++m_dataSentCount);
+            LOGD << "Writing " << data;
+            m_writeData.set_data(data);
             m_writeData.set_count(m_dataSentCount);
+            *m_writeData.mutable_status() = m_status;
+            StartWrite(&m_writeData);
+        }
+
+        void HandleFailure(const std::string failureMessage)
+        {
+            LOGD << "HandleFailure called";
+            m_status.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeFailed);
+            m_status.set_message(failureMessage);
             StartWrite(&m_writeData);
         }
 
     private:
-        ::Microsoft::Net::Remote::Wifi::WifiDataStreamData m_readData{};
-        ::Microsoft::Net::Remote::Wifi::WifiDataStreamData m_writeData{};
+        ::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData m_readData{};
+        ::Microsoft::Net::Remote::Wifi::WifiDataStreamDownloadData m_writeData{};
         uint32_t m_dataReceivedCount{};
         uint32_t m_dataSentCount{};
+        ::Microsoft::Net::Remote::Wifi::WifiDataStreamOperationStatus m_status{};
     };
 
     return new StreamReaderWriter();

--- a/src/common/service/include/microsoft/net/remote/NetRemoteCallbackService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteCallbackService.hxx
@@ -25,6 +25,9 @@ private:
 
     virtual ::grpc::ServerWriteReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData>*
     WifiDataStreamDownload(::grpc::CallbackServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiDataStreamDownloadRequest* request) override;
+
+    virtual ::grpc::ServerBidiReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData, ::Microsoft::Net::Remote::Wifi::WifiDataStreamData>*
+    WifiDataStreamBidirectional(::grpc::CallbackServerContext* context) override;
 };
 } // namespace Microsoft::Net::Remote::Service
 

--- a/src/common/service/include/microsoft/net/remote/NetRemoteCallbackService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteCallbackService.hxx
@@ -20,8 +20,8 @@ public:
     NetRemoteCallbackService() = default;
 
 private:
-    virtual ::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadRequest>*
-    WifiDataStreamUpload(::grpc::CallbackServerContext* context, ::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* response) override;
+    virtual ::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData>*
+    WifiDataStreamUpload(::grpc::CallbackServerContext* context, ::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* result) override;
 };
 } // namespace Microsoft::Net::Remote::Service
 

--- a/src/common/service/include/microsoft/net/remote/NetRemoteCallbackService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteCallbackService.hxx
@@ -22,6 +22,9 @@ public:
 private:
     virtual ::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData>*
     WifiDataStreamUpload(::grpc::CallbackServerContext* context, ::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* result) override;
+
+    virtual ::grpc::ServerWriteReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData>*
+    WifiDataStreamDownload(::grpc::CallbackServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiDataStreamDownloadRequest* request) override;
 };
 } // namespace Microsoft::Net::Remote::Service
 

--- a/src/common/service/include/microsoft/net/remote/NetRemoteCallbackService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteCallbackService.hxx
@@ -20,13 +20,13 @@ public:
     NetRemoteCallbackService() = default;
 
 private:
-    virtual ::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData>*
+    virtual ::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData>*
     WifiDataStreamUpload(::grpc::CallbackServerContext* context, ::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* result) override;
 
-    virtual ::grpc::ServerWriteReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData>*
+    virtual ::grpc::ServerWriteReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamDownloadData>*
     WifiDataStreamDownload(::grpc::CallbackServerContext* context, const ::Microsoft::Net::Remote::Wifi::WifiDataStreamDownloadRequest* request) override;
 
-    virtual ::grpc::ServerBidiReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamData, ::Microsoft::Net::Remote::Wifi::WifiDataStreamData>*
+    virtual ::grpc::ServerBidiReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData, ::Microsoft::Net::Remote::Wifi::WifiDataStreamDownloadData>*
     WifiDataStreamBidirectional(::grpc::CallbackServerContext* context) override;
 };
 } // namespace Microsoft::Net::Remote::Service

--- a/src/common/service/include/microsoft/net/remote/NetRemoteCallbackService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteCallbackService.hxx
@@ -1,0 +1,28 @@
+
+#ifndef NET_REMOTE_CALLBACK_SERVICE_HXX
+#define NET_REMOTE_CALLBACK_SERVICE_HXX
+
+#include <microsoft/net/remote/protocol/NetRemoteCallbackService.grpc.pb.h>
+
+namespace Microsoft::Net::Remote::Service
+{
+/**
+ * @brief Implementation of the NetRemoteCallback::CallbackService gRPC service.
+ */
+class NetRemoteCallbackService :
+    public NetRemoteCallback::CallbackService
+{
+public:
+    /**
+     * @brief Construct a new NetRemoteCallbackService object.
+     *
+     */
+    NetRemoteCallbackService() = default;
+
+private:
+    virtual ::grpc::ServerReadReactor<::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadRequest>*
+    WifiDataStreamUpload(::grpc::CallbackServerContext* context, ::Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* response) override;
+};
+} // namespace Microsoft::Net::Remote::Service
+
+#endif // NET_REMOTE_CALLBACK_SERVICE_HXX

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(${PROJECT_NAME}-test-unit
         ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteCommon.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteServer.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteServiceClient.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteCallbackServiceClient.cxx
 )
 
 target_link_libraries(${PROJECT_NAME}-test-unit

--- a/tests/unit/TestNetRemoteCallbackServiceClient.cxx
+++ b/tests/unit/TestNetRemoteCallbackServiceClient.cxx
@@ -147,7 +147,7 @@ TEST_CASE("WifiDataStreamDownload API", "[basic][rpc][client][remote]")
             OnReadDone(bool ok) override
             {
                 if (ok) {
-                    REQUIRE(m_data.count() == ++m_dataReceivedCount);
+                    REQUIRE(m_data.sequencenumber() == ++m_dataReceivedCount);
                     StartRead(&m_data);
                 }
                 // If read fails, then there is likely no more data to be read, so do nothing.
@@ -246,7 +246,7 @@ TEST_CASE("WifiDataStreamBidirectional API", "[basic][rpc][client][remote]")
             OnReadDone(bool ok) override
             {
                 if (ok) {
-                    REQUIRE(m_readData.count() == ++m_dataReceivedCount);
+                    REQUIRE(m_readData.sequencenumber() == ++m_dataReceivedCount);
                     StartRead(&m_readData);
                 }
             }

--- a/tests/unit/TestNetRemoteCallbackServiceClient.cxx
+++ b/tests/unit/TestNetRemoteCallbackServiceClient.cxx
@@ -44,7 +44,8 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
                 NextWrite();
             }
 
-            void OnWriteDone(bool ok) override
+            void
+            OnWriteDone(bool ok) override
             {
                 if (ok) {
                     NextWrite();
@@ -53,7 +54,8 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
                 }
             }
 
-            void OnDone(const grpc::Status& status) override
+            void
+            OnDone(const grpc::Status& status) override
             {
                 std::unique_lock lock(m_mutex);
 
@@ -62,7 +64,8 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
                 m_cv.notify_one();
             }
 
-            grpc::Status Await(WifiDataStreamUploadResult* result)
+            grpc::Status
+            Await(WifiDataStreamUploadResult* result)
             {
                 std::unique_lock lock(m_mutex);
 
@@ -75,7 +78,8 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
             }
 
         private:
-            void NextWrite()
+            void
+            NextWrite()
             {
                 if (m_dataToWriteCount > 0) {
                     m_data.set_data(std::format("Data #{}", ++m_dataSentCount));
@@ -95,7 +99,7 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
             grpc::Status m_status{};
             std::mutex m_mutex{};
             std::condition_variable m_cv{};
-            bool m_done{false};
+            bool m_done{ false };
         };
 
         static constexpr auto dataToWriteCount = 10;
@@ -139,7 +143,8 @@ TEST_CASE("WifiDataStreamDownload API", "[basic][rpc][client][remote]")
                 StartRead(&m_data);
             }
 
-            void OnReadDone(bool ok) override
+            void
+            OnReadDone(bool ok) override
             {
                 if (ok) {
                     REQUIRE(m_data.count() == ++m_dataReceivedCount);
@@ -148,7 +153,8 @@ TEST_CASE("WifiDataStreamDownload API", "[basic][rpc][client][remote]")
                 // If read fails, then there is likely no more data to be read, so do nothing.
             }
 
-            void OnDone(const grpc::Status& status) override
+            void
+            OnDone(const grpc::Status& status) override
             {
                 std::unique_lock lock(m_mutex);
 
@@ -157,7 +163,8 @@ TEST_CASE("WifiDataStreamDownload API", "[basic][rpc][client][remote]")
                 m_cv.notify_one();
             }
 
-            grpc::Status Await(uint32_t* dataReceivedCount, WifiDataStreamOperationStatus* operationStatus)
+            grpc::Status
+            Await(uint32_t* dataReceivedCount, WifiDataStreamOperationStatus* operationStatus)
             {
                 std::unique_lock lock(m_mutex);
 
@@ -177,7 +184,7 @@ TEST_CASE("WifiDataStreamDownload API", "[basic][rpc][client][remote]")
             grpc::Status m_status{};
             std::mutex m_mutex{};
             std::condition_variable m_cv{};
-            bool m_done{false};
+            bool m_done{ false };
         };
 
         static constexpr auto dataRequestedCount = 10;
@@ -226,15 +233,17 @@ TEST_CASE("WifiDataStreamBidirectional API", "[basic][rpc][client][remote]")
                 NextWrite();
             }
 
-            void OnReadDone(bool ok) override
+            void
+            OnReadDone(bool ok) override
             {
                 if (ok) {
                     REQUIRE(m_readData.count() == ++m_dataReceivedCount);
                     StartRead(&m_readData);
                 }
             }
-        
-            void OnWriteDone(bool ok) override
+
+            void
+            OnWriteDone(bool ok) override
             {
                 if (ok) {
                     NextWrite();
@@ -243,7 +252,8 @@ TEST_CASE("WifiDataStreamBidirectional API", "[basic][rpc][client][remote]")
                 }
             }
 
-            void OnDone(const grpc::Status& status) override
+            void
+            OnDone(const grpc::Status& status) override
             {
                 std::unique_lock lock(m_mutex);
 
@@ -252,7 +262,8 @@ TEST_CASE("WifiDataStreamBidirectional API", "[basic][rpc][client][remote]")
                 m_cv.notify_one();
             }
 
-            grpc::Status Await(WifiDataStreamOperationStatus* operationStatus)
+            grpc::Status
+            Await(WifiDataStreamOperationStatus* operationStatus)
             {
                 std::unique_lock lock(m_mutex);
 
@@ -265,7 +276,8 @@ TEST_CASE("WifiDataStreamBidirectional API", "[basic][rpc][client][remote]")
             }
 
         private:
-            void NextWrite()
+            void
+            NextWrite()
             {
                 if (m_dataToWriteCount > 0) {
                     m_writeData.set_data(std::format("Data #{}", ++m_dataSentCount));
@@ -286,7 +298,7 @@ TEST_CASE("WifiDataStreamBidirectional API", "[basic][rpc][client][remote]")
             grpc::Status m_status{};
             std::mutex m_mutex{};
             std::condition_variable m_cv{};
-            bool m_done{false};
+            bool m_done{ false };
         };
 
         static constexpr auto dataToWriteCount = 10;

--- a/tests/unit/TestNetRemoteCallbackServiceClient.cxx
+++ b/tests/unit/TestNetRemoteCallbackServiceClient.cxx
@@ -1,0 +1,109 @@
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
+#include <catch2/catch_test_macros.hpp>
+#include <grpcpp/create_channel.h>
+#include <magic_enum.hpp>
+#include <microsoft/net/remote/NetRemoteServer.hxx>
+#include <microsoft/net/remote/protocol/NetRemoteCallbackService.grpc.pb.h>
+
+#include "TestNetRemoteCommon.hxx"
+
+using Microsoft::Net::Remote::Test::RemoteServiceAddressHttp;
+
+TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
+{
+    using namespace Microsoft::Net::Remote;
+    using namespace Microsoft::Net::Remote::Service;
+    using namespace Microsoft::Net::Remote::Test;
+    using namespace Microsoft::Net::Remote::Wifi;
+    using namespace Microsoft::Net::Wifi;
+
+    NetRemoteServerConfiguration Configuration{
+        .ServerAddress = RemoteServiceAddressHttp
+    };
+
+    NetRemoteServer server{ Configuration };
+    server.Run();
+
+    auto channel = grpc::CreateChannel(RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());
+    auto client = NetRemoteCallback::NewStub(channel);
+
+    SECTION("Can be called")
+    {
+        class StreamWriter : public grpc::ClientWriteReactor<WifiDataStreamData>
+        {
+        public:
+            StreamWriter(NetRemoteCallback::Stub* client, uint32_t dataToWriteCount) :
+                m_dataToWriteCount(dataToWriteCount)
+            {
+                client->async()->WifiDataStreamUpload(&m_clientContext, &m_result, this);
+                StartCall();
+                NextWrite();
+            }
+
+            void OnWriteDone(bool ok) override
+            {
+                if (ok) {
+                    NextWrite();
+                } else {
+                    StartWritesDone();
+                }
+            }
+
+            void OnDone(const grpc::Status& status) override
+            {
+                std::unique_lock lock(m_mutex);
+
+                m_status = status;
+                m_done = true;
+                m_cv.notify_one();
+            }
+
+            grpc::Status Await(WifiDataStreamUploadResult* result)
+            {
+                std::unique_lock lock(m_mutex);
+
+                m_cv.wait(lock, [this] {
+                    return m_done;
+                });
+                *result = m_result;
+
+                return m_status;
+            }
+
+        private:
+            void NextWrite()
+            {
+                if (m_dataToWriteCount > 0) {
+                    WifiDataStreamData data{};
+                    data.set_data("Data");
+                    StartWrite(&data);
+                    m_dataToWriteCount--;
+                } else {
+                    StartWritesDone();
+                }
+            }
+
+        private:
+            grpc::ClientContext m_clientContext{};
+            WifiDataStreamUploadResult m_result{};
+            uint32_t m_dataToWriteCount{};
+            grpc::Status m_status{};
+            std::mutex m_mutex{};
+            std::condition_variable m_cv{};
+            bool m_done{false};
+        };
+
+        static constexpr auto dataToWriteCount = 10;
+        auto streamWriter = std::make_unique<StreamWriter>(client.get(), dataToWriteCount);
+
+        WifiDataStreamUploadResult result{};
+        grpc::Status status = streamWriter->Await(&result);
+        REQUIRE(status.ok());
+        REQUIRE(result.datareceivedcount() == dataToWriteCount);
+        REQUIRE(result.status().code() == WifiDataStreamOperationStatusCodeSucceeded);
+    }
+}

--- a/tests/unit/TestNetRemoteCallbackServiceClient.cxx
+++ b/tests/unit/TestNetRemoteCallbackServiceClient.cxx
@@ -79,7 +79,6 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
             {
                 if (m_dataToWriteCount > 0) {
                     m_data.set_data(std::format("Data #{}", ++m_dataSentCount));
-                    m_data.set_count(m_dataSentCount);
                     StartWrite(&m_data);
                     m_dataToWriteCount--;
                 } else {
@@ -270,7 +269,6 @@ TEST_CASE("WifiDataStreamBidirectional API", "[basic][rpc][client][remote]")
             {
                 if (m_dataToWriteCount > 0) {
                     m_writeData.set_data(std::format("Data #{}", ++m_dataSentCount));
-                    m_writeData.set_count(m_dataSentCount);
                     StartWrite(&m_writeData);
                     m_dataToWriteCount--;
                 } else {

--- a/tests/unit/TestNetRemoteCallbackServiceClient.cxx
+++ b/tests/unit/TestNetRemoteCallbackServiceClient.cxx
@@ -78,7 +78,8 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
             void NextWrite()
             {
                 if (m_dataToWriteCount > 0) {
-                    m_data.set_data("Data");
+                    m_data.set_data(std::format("Data #{}", ++m_dataSentCount));
+                    m_data.set_count(m_dataSentCount);
                     StartWrite(&m_data);
                     m_dataToWriteCount--;
                 } else {
@@ -88,9 +89,10 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
 
         private:
             grpc::ClientContext m_clientContext{};
+            WifiDataStreamData m_data{};
             WifiDataStreamUploadResult m_result{};
             uint32_t m_dataToWriteCount{};
-            WifiDataStreamData m_data{};
+            uint32_t m_dataSentCount{};
             grpc::Status m_status{};
             std::mutex m_mutex{};
             std::condition_variable m_cv{};
@@ -141,7 +143,7 @@ TEST_CASE("WifiDataStreamDownload API", "[basic][rpc][client][remote]")
             void OnReadDone(bool ok) override
             {
                 if (ok) {
-                    m_dataReceivedCount++;
+                    REQUIRE(m_data.count() == ++m_dataReceivedCount);
                     StartRead(&m_data);
                 }
                 // If read fails, then there is likely no more data to be read, so do nothing.
@@ -170,8 +172,8 @@ TEST_CASE("WifiDataStreamDownload API", "[basic][rpc][client][remote]")
 
         private:
             grpc::ClientContext m_clientContext{};
-            uint32_t m_dataReceivedCount{};
             WifiDataStreamData m_data{};
+            uint32_t m_dataReceivedCount{};
             grpc::Status m_status{};
             std::mutex m_mutex{};
             std::condition_variable m_cv{};
@@ -225,6 +227,7 @@ TEST_CASE("WifiDataStreamBidirectional API", "[basic][rpc][client][remote]")
             void OnReadDone(bool ok) override
             {
                 if (ok) {
+                    REQUIRE(m_readData.count() == ++m_dataReceivedCount);
                     StartRead(&m_readData);
                 }
             }
@@ -262,7 +265,8 @@ TEST_CASE("WifiDataStreamBidirectional API", "[basic][rpc][client][remote]")
             void NextWrite()
             {
                 if (m_dataToWriteCount > 0) {
-                    m_writeData.set_data("Data");
+                    m_writeData.set_data(std::format("Data #{}", ++m_dataSentCount));
+                    m_writeData.set_count(m_dataSentCount);
                     StartWrite(&m_writeData);
                     m_dataToWriteCount--;
                 } else {
@@ -272,9 +276,11 @@ TEST_CASE("WifiDataStreamBidirectional API", "[basic][rpc][client][remote]")
 
         private:
             grpc::ClientContext m_clientContext{};
-            uint32_t m_dataToWriteCount{};
             WifiDataStreamData m_readData{};
             WifiDataStreamData m_writeData{};
+            uint32_t m_dataToWriteCount{};
+            uint32_t m_dataSentCount{};
+            uint32_t m_dataReceivedCount{};
             grpc::Status m_status{};
             std::mutex m_mutex{};
             std::condition_variable m_cv{};

--- a/tests/unit/TestNetRemoteCallbackServiceClient.cxx
+++ b/tests/unit/TestNetRemoteCallbackServiceClient.cxx
@@ -131,7 +131,7 @@ TEST_CASE("WifiDataStreamDownload API", "[basic][rpc][client][remote]")
     auto channel = grpc::CreateChannel(RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());
     auto client = NetRemoteCallback::NewStub(channel);
 
-    SECTION("Can be called")
+    SECTION("Can be called with WifiDataStreamType::Fixed")
     {
         class StreamReader : public grpc::ClientReadReactor<WifiDataStreamDownloadData>
         {
@@ -189,7 +189,16 @@ TEST_CASE("WifiDataStreamDownload API", "[basic][rpc][client][remote]")
 
         static constexpr auto dataRequestedCount = 10;
         WifiDataStreamDownloadRequest request{};
-        request.set_datarequestedcount(dataRequestedCount);
+
+        WifiDataStreamProperties streamProperties{};
+        streamProperties.set_type(WifiDataStreamType::Fixed);
+
+        WifiDataStreamFixedTypeProperties fixedTypeProperties{};
+        fixedTypeProperties.set_numberofdatablockstostream(dataRequestedCount);
+
+        *streamProperties.mutable_fixedtypeproperties() = std::move(fixedTypeProperties);
+
+        *request.mutable_properties() = std::move(streamProperties);
         auto streamReader = std::make_unique<StreamReader>(client.get(), &request);
 
         uint32_t dataReceivedCount{};


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

This draft PR shows sample usage of the proposed data streaming APIs in both the server (API implementations) and client (unit tests) sides.

### Technical Details

* Added three new APIs: `WifiDataStreamUpload`, `WifiDataStreamDownload`, and `WifiDataStreamBidirectional` to `NetRemoteCallbackService.proto`, along with corresponding types in `NetRemoteWifi.proto`.
* Added `NetRemoteCallbackService` with sample implementations of the three APIs.
* Added `TestNetRemoteCallbackServiceClient` unit test file with unit tests for all three APIs.

### Test Results

All tests pass.

### Reviewer Focus

Overall design and usage.

### Future Work

Once design is approved, APIs will be fully implemented and cleaned up, along with unit tests.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
