### PR TITLE
Some some possible issues identified by clang-tidy

### DIFF
--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -25,7 +25,7 @@ NetRemoteCli::NetRemoteCli(std::shared_ptr<NetRemoteCliData> cliData, std::share
 
 /* static */
 std::shared_ptr<NetRemoteCli>
-NetRemoteCli::Create(std::shared_ptr<NetRemoteCliData> cliData, std::shared_ptr<NetRemoteCliHandler> cliHandler)
+NetRemoteCli::Create(std::shared_ptr<NetRemoteCliData> cliData, const std::shared_ptr<NetRemoteCliHandler>& cliHandler)
 {
     auto instance = std::make_shared<notstd::enable_make_protected<NetRemoteCli>>(std::move(cliData), cliHandler);
     cliHandler->SetParent(instance->weak_from_this());

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
@@ -28,7 +28,7 @@ struct NetRemoteCli :
      * @return std::shared_ptr<NetRemoteClie>
      */
     static std::shared_ptr<NetRemoteCli>
-    Create(std::shared_ptr<NetRemoteCliData> cliData, std::shared_ptr<NetRemoteCliHandler> cliHandler);
+    Create(std::shared_ptr<NetRemoteCliData> cliData, const std::shared_ptr<NetRemoteCliHandler>& cliHandler);
 
     /**
      * @brief Get a reference to the parser. The parser will be configured with all common command-line interface

--- a/src/linux/libnl-helpers/Netlink80211Interface.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Interface.cxx
@@ -67,7 +67,7 @@ Nl80211Interface::Parse(struct nl_msg *nl80211Message) noexcept
     std::array<struct nlattr *, NL80211_ATTR_MAX + 1> newInterfaceMessageAttributes{};
     int ret = nla_parse(std::data(newInterfaceMessageAttributes), std::size(newInterfaceMessageAttributes), genlmsg_attrdata(genl80211MessageHeader, 0), genlmsg_attrlen(genl80211MessageHeader, 0), nullptr);
     if (ret < 0) {
-        LOG_ERROR << std::format("Failed to parse netlink message attributes with error {} ({})", ret, strerror(-ret));
+        LOGE << std::format("Failed to parse netlink message attributes with error {} ({})", ret, strerror(-ret));
         return std::nullopt;
     }
 

--- a/src/linux/libnl-helpers/Netlink80211Interface.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Interface.cxx
@@ -29,6 +29,8 @@
 
 using namespace Microsoft::Net::Netlink::Nl80211;
 
+// NOLINTBEGIN(concurrency-mt-unsafe)
+
 Nl80211Interface::Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index, uint32_t wiphyIndex) noexcept :
     Name(name),
     Type(type),
@@ -177,3 +179,5 @@ Nl80211Interface::IsAccessPoint() const noexcept
 {
     return (Type == nl80211_iftype::NL80211_IFTYPE_AP);
 }
+
+// NOLINTEND(concurrency-mt-unsafe)

--- a/src/linux/libnl-helpers/Netlink80211ProtocolState.cxx
+++ b/src/linux/libnl-helpers/Netlink80211ProtocolState.cxx
@@ -23,10 +23,10 @@ Nl80211ProtocolState::Nl80211ProtocolState()
     auto netlinkSocket{ NetlinkSocket::Allocate() };
 
     // Connect the socket to the generic netlink family.
-    int ret = genl_connect(netlinkSocket);
+    const int ret = genl_connect(netlinkSocket);
     if (ret < 0) {
         const auto err = errno;
-        LOGE << std::format("Failed to connect netlink socket for nl control with error {} ({})", err, strerror(err));
+        LOGE << std::format("Failed to connect netlink socket for nl control with error {} ({})", err, strerror(err)); // NOLINT(concurrency-mt-unsafe)
         throw err;
     }
 

--- a/src/linux/libnl-helpers/Netlink80211ProtocolState.cxx
+++ b/src/linux/libnl-helpers/Netlink80211ProtocolState.cxx
@@ -26,14 +26,14 @@ Nl80211ProtocolState::Nl80211ProtocolState()
     int ret = genl_connect(netlinkSocket);
     if (ret < 0) {
         const auto err = errno;
-        LOG_ERROR << std::format("Failed to connect netlink socket for nl control with error {} ({})", err, strerror(err));
+        LOGE << std::format("Failed to connect netlink socket for nl control with error {} ({})", err, strerror(err));
         throw err;
     }
 
     // Look up the nl80211 driver id.
     DriverId = genl_ctrl_resolve(netlinkSocket, NL80211_GENL_NAME);
     if (DriverId < 0) {
-        LOG_ERROR << std::format("Failed to resolve nl80211 netlink id with error {} ({})", DriverId, nl_geterror(DriverId));
+        LOGE << std::format("Failed to resolve nl80211 netlink id with error {} ({})", DriverId, nl_geterror(DriverId));
         throw DriverId;
     }
 
@@ -41,7 +41,7 @@ Nl80211ProtocolState::Nl80211ProtocolState()
     for (const auto& [multicastGroup, multicastGroupName] : Nl80211MulticastGroupNames) {
         int multicastGroupId = genl_ctrl_resolve_grp(netlinkSocket, NL80211_GENL_NAME, std::data(multicastGroupName));
         if (multicastGroupId < 0) {
-            LOG_ERROR << std::format("Failed to resolve nl80211 {} multicast group id with error {} ({})", multicastGroupName, multicastGroupId, nl_geterror(multicastGroupId));
+            LOGE << std::format("Failed to resolve nl80211 {} multicast group id with error {} ({})", multicastGroupName, multicastGroupId, nl_geterror(multicastGroupId));
             throw multicastGroupId;
         }
         MulticastGroupId[multicastGroup] = multicastGroupId;

--- a/src/linux/libnl-helpers/Netlink80211Wiphy.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Wiphy.cxx
@@ -178,7 +178,7 @@ Nl80211Wiphy::Parse(struct nl_msg *nl80211Message) noexcept
     std::array<struct nlattr *, NL80211_ATTR_MAX + 1> wiphyAttributes{};
     int ret = nla_parse(std::data(wiphyAttributes), std::size(wiphyAttributes), genlmsg_attrdata(genl80211MessageHeader, 0), genlmsg_attrlen(genl80211MessageHeader, 0), nullptr);
     if (ret < 0) {
-        LOG_ERROR << std::format("Failed to parse netlink message attributes with error {} ({})", ret, strerror(-ret));
+        LOGE << std::format("Failed to parse netlink message attributes with error {} ({})", ret, strerror(-ret));
         return std::nullopt;
     }
 

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
@@ -92,7 +92,7 @@ private:
      * @return std::optional<Nl80211Wiphy>
      */
     static std::optional<Nl80211Wiphy>
-    FromId(std::function<void(Microsoft::Net::Netlink::NetlinkMessage&)> addWiphyIdentifier);
+    FromId(const std::function<void(Microsoft::Net::Netlink::NetlinkMessage&)>& addWiphyIdentifier);
 };
 
 } // namespace Microsoft::Net::Netlink::Nl80211

--- a/src/linux/tools/apmonitor/Main.cxx
+++ b/src/linux/tools/apmonitor/Main.cxx
@@ -1,5 +1,9 @@
 
-#include <csignal> // NOLINT(misc-include-cleaner)
+// NOLINTBEGIN(misc-include-cleaner, concurrency-mt-unsafe)
+// clang-tidy can't seem to figure out that sig/SIG* stuff is indirectly included by <csignal>. While we could include
+// the actual headers directly, this goes against the std library's convention of including the top-level header.
+
+#include <csignal>
 #include <format>
 #include <memory>
 #include <utility>
@@ -37,7 +41,7 @@ main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     accessPointDiscoveryAgent->Start();
 
     // Mask SIGTERM and SIGINT so they can be explicitly waited on from the main thread.
-    int signal;
+    int signal = 0;
     sigset_t mask;
     sigemptyset(&mask);
     sigaddset(&mask, SIGTERM);
@@ -49,11 +53,14 @@ main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     }
 
     // Wait for the process to be signaled to exit.
-    while (sigwait(&mask, &signal) != 0)
+    while (sigwait(&mask, &signal) != 0) {
         ;
+    }
 
     // Received interrupt or terminate signal, so shut down.
     accessPointDiscoveryAgent->Stop();
 
     return 0;
 }
+
+// NOLINTEND(misc-include-cleaner, concurrency-mt-unsafe)

--- a/src/linux/tools/apmonitor/Main.cxx
+++ b/src/linux/tools/apmonitor/Main.cxx
@@ -33,7 +33,7 @@ main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
         LOGI << std::format("{} -> {}", accessPointChanged->GetInterfaceName(), magic_enum::enum_name(presence));
     });
 
-    LOG_INFO << "starting access point discovery agent";
+    LOGI << "starting access point discovery agent";
     accessPointDiscoveryAgent->Start();
 
     // Mask SIGTERM and SIGINT so they can be explicitly waited on from the main thread.
@@ -44,7 +44,7 @@ main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     sigaddset(&mask, SIGINT);
 
     if (sigprocmask(SIG_BLOCK, &mask, nullptr) < 0) {
-        LOG_ERROR << "failed to block terminate signals";
+        LOGE << "failed to block terminate signals";
         return -1;
     }
 

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -158,10 +158,11 @@ IsNl80211InterfaceTypeAp(const Nl80211Interface &nl80211Interface)
  * @return std::shared_ptr<IAccessPoint>
  */
 std::shared_ptr<IAccessPoint>
-MakeAccessPoint(std::shared_ptr<AccessPointFactoryLinux> accessPointFactory, const Nl80211Interface &nl80211Interface)
+MakeAccessPoint(const std::shared_ptr<AccessPointFactoryLinux> &accessPointFactory, const Nl80211Interface &nl80211Interface)
 {
+    auto &interfaceName = nl80211Interface.Name;
     auto createArgs = std::make_unique<AccessPointCreateArgsLinux>(std::move(nl80211Interface));
-    return accessPointFactory->Create(nl80211Interface.Name, std::move(createArgs));
+    return accessPointFactory->Create(interfaceName, std::move(createArgs));
 }
 } // namespace detail
 

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -72,14 +72,14 @@ private:
      * @brief Request that the netlink processing loop stop.
      */
     void
-    RequestNetlinkProcessingLoopStop();
+    RequestNetlinkProcessingLoopStop() const;
 
     /**
      * @brief Handles when the netlink socket is ready for reading.
      *
      * @param netlinkSocket The netlink socket that is ready for reading.
      */
-    void
+    static void
     HandleNetlinkSocketReady(Microsoft::Net::Netlink::NetlinkSocket &netlinkSocket);
 
     /**


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Avoid possible issues due to code smells.

### Technical Details

* Initialize all variables in netlink code.
* Use plog short macros `LOGX` instead of `LOG_XYZ`.
* Ignore some instances triggering `concurrency-mt-unsafe` involving `std::strerror`.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Some other clang-tidy issues related to exceptions will be handled in a separate PR.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
