### PR TITLE
Implement WifiAccessPointDisable API

### DIFF
--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -65,7 +65,7 @@ HandleFailure(RequestT& request, ResultT& result, WifiAccessPointOperationStatus
 }
 
 /**
- * @brief Wrapper for HandleFailure that converts a Dot11AccessPointOperationStatusCode to a WifiAccessPointOperationStatusCode.
+ * @brief Wrapper for HandleFailure that converts a AccessPointOperationStatusCode to a WifiAccessPointOperationStatusCode.
  *
  * @tparam RequestT The request type. This must contain an access point id (trait).
  * @tparam ResultT The result type. This must contain an access point id and a status (traits).

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -187,7 +187,7 @@ IAccessPointToNetRemoteAccessPointResultItem(IAccessPoint& accessPoint)
     }
 
     try {
-        isEnabled = accessPointController->GetIsEnabled();
+        isEnabled = accessPointController->GetOperationalState();
     } catch (const AccessPointControllerException& apce) {
         LOGE << std::format("Failed to get enabled state for access point {} ({})", interfaceName, apce.what());
         return MakeInvalidAccessPointResultItem();
@@ -300,7 +300,7 @@ NetRemoteService::WifiAccessPointDisable([[maybe_unused]] grpc::ServerContext* c
 
     bool isEnabled{ false };
     try {
-        isEnabled = accessPointController->GetIsEnabled();
+        isEnabled = accessPointController->GetOperationalState();
     } catch (const AccessPointControllerException& apce) {
         return HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInternalError, std::format("Failed to get enabled state for access point {} ({})", request->accesspointid(), apce.what()));
     }

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -269,8 +269,28 @@ NetRemoteService::WifiAccessPointDisable([[maybe_unused]] grpc::ServerContext* c
 {
     const NetRemoteWifiApiTrace traceMe{ request->accesspointid(), result->mutable_status() };
 
+
+    // Create an AP controller for the requested AP.
+    auto accessPointController = detail::TryGetAccessPointController(request, result, m_accessPointManager);
+    if (accessPointController == nullptr) {
+        return grpc::Status::OK;
+    }
+
+
+    bool isEnabled{ false };
+    try {
+        isEnabled = accessPointController->GetIsEnabled();
+    } catch (const AccessPointControllerException& apce) {
+        return HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInternalError, std::format("Failed to get enabled state for access point {} ({})", request->accesspointid(), apce.what()));
+    }
+
     WifiAccessPointOperationStatus status{};
-    // TODO: Disable the access point.
+    if (isEnabled) {
+        // TODO: Disable the access point.
+    } else {
+        LOGI << std::format("Access point {} is already disabled", request->accesspointid());
+    }
+
     status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
 
     result->set_accesspointid(request->accesspointid());

--- a/src/common/wifi/core/AccessPointOperationStatus.cxx
+++ b/src/common/wifi/core/AccessPointOperationStatus.cxx
@@ -10,7 +10,20 @@ AccessPointOperationStatus::MakeSucceeded() noexcept
     return AccessPointOperationStatus{ AccessPointOperationStatusCode::Succeeded };
 }
 
+bool
+AccessPointOperationStatus::Succeeded() const noexcept
+{
+    return (Code == AccessPointOperationStatusCode::Succeeded);
+}
+
+bool
+AccessPointOperationStatus::Failed() const noexcept
+{
+    return !Succeeded();
+}
+
 AccessPointOperationStatus::operator bool() const noexcept
 {
+    return Succeeded();
     return (Code == AccessPointOperationStatusCode::Succeeded);
 }

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
@@ -61,6 +61,24 @@ struct AccessPointOperationStatus
     MakeSucceeded() noexcept;
 
     /**
+     * @brief Determine whether the operation succeeded.
+     * 
+     * @return true 
+     * @return false 
+     */
+    bool
+    Succeeded() const noexcept;
+
+   /**
+     * @brief Determine whether the operation failed.
+    * 
+    * @return true 
+    * @return false 
+    */
+    bool
+    Failed() const noexcept;
+
+    /**
      * @brief Implicit bool operator allowing AccessPointOperationStatus to be used directly in condition statements
      * (eg. if (status) // ...).
      *

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
@@ -7,6 +7,14 @@
 namespace Microsoft::Net::Wifi
 {
 /**
+ * @brief Operational state of an access point.
+ */
+enum class AccessPointOperationalState : bool {
+    Disabled = false,
+    Enabled = true,
+};
+
+/**
  * @brief High-level status reported by various access point operations.
  */
 enum class AccessPointOperationStatusCode {

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -60,13 +60,13 @@ struct IAccessPointController
     GetInterfaceName() const = 0;
 
     /**
-     * @brief Get whether the access point is enabled.
+     * @brief Get the access point operational state.
      *
-     * @return true
-     * @return false
+     * @param operationalState The value to store the operational state.
+     * @return AccessPointOperationStatus 
      */
-    virtual bool
-    GetOperationalState() = 0;
+    virtual AccessPointOperationStatus
+    GetOperationalState(AccessPointOperationalState& operationalState) = 0;
 
     /**
      * @brief Get the capabilities of the access point.

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -77,6 +77,15 @@ struct IAccessPointController
     GetCapabilities() = 0;
 
     /**
+     * @brief Set the operational state of the access point.
+     * 
+     * @param operationalState The desired operational state.
+     * @return AccessPointOperationStatus
+     */
+    virtual AccessPointOperationStatus
+    SetOperationalState(AccessPointOperationalState operationalState) = 0;
+
+    /**
      * @brief Set the Ieee80211 protocol of the access point.
      *
      * @param ieeeProtocol The Ieee80211 protocol to be set.

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -66,7 +66,7 @@ struct IAccessPointController
      * @return false
      */
     virtual bool
-    GetIsEnabled() = 0;
+    GetOperationalState() = 0;
 
     /**
      * @brief Get the capabilities of the access point.

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -190,6 +190,13 @@ AccessPointControllerLinux::GetIsEnabled()
     return isEnabled;
 }
 
+AccessPointOperationStatus
+AccessPointControllerLinux::SetOperationalState([[maybe_unused]] AccessPointOperationalState operationalState)
+{
+    // TODO: Implement this method.
+    return AccessPointOperationStatus(AccessPointOperationStatusCode::OperationNotSupported);
+}
+
 bool
 AccessPointControllerLinux::SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol)
 {

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -175,19 +175,23 @@ AccessPointControllerLinux::GetCapabilities()
     return capabilities;
 }
 
-bool
-AccessPointControllerLinux::GetOperationalState()
+AccessPointOperationStatus
+AccessPointControllerLinux::GetOperationalState(AccessPointOperationalState& operationalState)
 {
-    bool isEnabled{ false };
+    AccessPointOperationStatus status{};
 
     try {
         auto hostapdStatus = m_hostapd.GetStatus();
-        isEnabled = (hostapdStatus.State == Wpa::HostapdInterfaceState::Enabled);
+        operationalState = (hostapdStatus.State == Wpa::HostapdInterfaceState::Enabled) 
+            ? AccessPointOperationalState::Enabled 
+            : AccessPointOperationalState::Disabled;
+        status = AccessPointOperationStatus::MakeSucceeded();
     } catch (const Wpa::HostapdException& ex) {
-        throw AccessPointControllerException(std::format("Failed to get status for interface {} ({})", GetInterfaceName(), ex.what()));
+        status.Code = AccessPointOperationStatusCode::InternalError;
+        status.Message = std::format("Failed to get operational state for interface {} ({})", GetInterfaceName(), ex.what());
     }
 
-    return isEnabled;
+    return status;
 }
 
 AccessPointOperationStatus

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -176,7 +176,7 @@ AccessPointControllerLinux::GetCapabilities()
 }
 
 bool
-AccessPointControllerLinux::GetIsEnabled()
+AccessPointControllerLinux::GetOperationalState()
 {
     bool isEnabled{ false };
 

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -191,10 +191,37 @@ AccessPointControllerLinux::GetIsEnabled()
 }
 
 AccessPointOperationStatus
-AccessPointControllerLinux::SetOperationalState([[maybe_unused]] AccessPointOperationalState operationalState)
+AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState operationalState)
 {
-    // TODO: Implement this method.
-    return AccessPointOperationStatus(AccessPointOperationStatusCode::OperationNotSupported);
+    AccessPointOperationStatus status{};
+
+    switch (operationalState) {
+    case AccessPointOperationalState::Enabled: {
+        try {
+            m_hostapd.Enable();
+        } catch (const Wpa::HostapdException& ex) {
+            status.Code = AccessPointOperationStatusCode::InternalError;
+            status.Message = std::format("Failed to set operational state to 'enabled' for {} (unknown error)", GetInterfaceName());
+        }
+        break;
+    }
+    case AccessPointOperationalState::Disabled: {
+        try {
+            m_hostapd.Disable();
+        } catch (const Wpa::HostapdException& ex) {
+            status.Code = AccessPointOperationStatusCode::InternalError;
+            status.Message = std::format("Failed to set operational state to 'disabled' for {} (unknown error)", GetInterfaceName());
+        }
+        break;
+    }
+    default: {
+        status.Code = AccessPointOperationStatusCode::InvalidParameter;
+        status.Message = std::format("Invalid operational state value '{}' for {}", magic_enum::enum_name(operationalState), GetInterfaceName());
+        break;
+    }
+    }
+
+    return status;
 }
 
 bool

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -60,6 +60,15 @@ struct AccessPointControllerLinux :
     GetCapabilities() override;
 
     /**
+     * @brief Set the operational state of the access point.
+     *
+     * @param operationalState The desired operational state.
+     * @return AccessPointOperationStatus
+     */
+    AccessPointOperationStatus
+    SetOperationalState(AccessPointOperationalState operationalState) override;
+
+    /**
      * @brief Set the Ieee80211 protocol.
      *
      * @param ieeeProtocol The Ieee80211 protocol to be set.

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -49,7 +49,7 @@ struct AccessPointControllerLinux :
      * @return false
      */
     bool
-    GetIsEnabled() override;
+    GetOperationalState() override;
 
     /**
      * @brief Get the Capabilities object

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -43,13 +43,13 @@ struct AccessPointControllerLinux :
     operator=(AccessPointControllerLinux&&) = delete;
 
     /**
-     * @brief Get whether the access point is enabled.
+     * @brief Get the access point operational state.
      *
-     * @return true
-     * @return false
+     * @param operationalState The value to store the operational state.
+     * @return AccessPointOperationStatus 
      */
-    bool
-    GetOperationalState() override;
+    AccessPointOperationStatus
+    GetOperationalState(AccessPointOperationalState& operationalState) override;
 
     /**
      * @brief Get the Capabilities object

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -115,12 +115,12 @@ TEST_CASE("Send command: GetStatus() (root)", "[wpa][hostapd][client][remote]")
 
         const auto ieee80211nInitial = hostapd.GetStatus().Ieee80211n;
 
-        auto ieee80211nValueExpected = !!ieee80211nInitial;
+        auto ieee80211nValueExpected = static_cast<bool>(ieee80211nInitial);
         REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211N, GetPropertyEnablementValue(ieee80211nValueExpected)));
         auto ieee80211nValueUpdated = hostapd.GetStatus().Ieee80211n;
         REQUIRE(ieee80211nValueUpdated == ieee80211nValueExpected);
 
-        ieee80211nValueExpected = !!ieee80211nValueUpdated;
+        ieee80211nValueExpected = static_cast<bool>(ieee80211nValueUpdated);
         REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211N, GetPropertyEnablementValue(ieee80211nValueExpected)));
         ieee80211nValueUpdated = hostapd.GetStatus().Ieee80211n;
         REQUIRE(ieee80211nValueUpdated == ieee80211nValueExpected);
@@ -132,12 +132,12 @@ TEST_CASE("Send command: GetStatus() (root)", "[wpa][hostapd][client][remote]")
 
         const auto ieee80211acInitial = hostapd.GetStatus().Ieee80211ac;
 
-        auto ieee80211acValueExpected = !!ieee80211acInitial;
+        auto ieee80211acValueExpected =  static_cast<bool>(ieee80211acInitial);
         REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AC, GetPropertyEnablementValue(ieee80211acValueExpected)));
         auto ieee80211acValueUpdated = hostapd.GetStatus().Ieee80211ac;
         REQUIRE(ieee80211acValueUpdated == ieee80211acValueExpected);
 
-        ieee80211acValueExpected = !!ieee80211acValueUpdated;
+        ieee80211acValueExpected = static_cast<bool>(ieee80211acValueUpdated);
         REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AC, GetPropertyEnablementValue(ieee80211acValueExpected)));
         ieee80211acValueUpdated = hostapd.GetStatus().Ieee80211ac;
         REQUIRE(ieee80211acValueUpdated == ieee80211acValueExpected);
@@ -149,12 +149,12 @@ TEST_CASE("Send command: GetStatus() (root)", "[wpa][hostapd][client][remote]")
 
         const auto ieee80211axInitial = hostapd.GetStatus().Ieee80211ax;
 
-        auto ieee80211axValueExpected = !!ieee80211axInitial;
+        auto ieee80211axValueExpected = static_cast<bool>(ieee80211axInitial);
         REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AX, GetPropertyEnablementValue(ieee80211axValueExpected)));
         auto ieee80211axValueUpdated = hostapd.GetStatus().Ieee80211ax;
         REQUIRE(ieee80211axValueUpdated == ieee80211axValueExpected);
 
-        ieee80211axValueExpected = !!ieee80211axValueUpdated;
+        ieee80211axValueExpected = static_cast<bool>(ieee80211axValueUpdated);
         REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AX, GetPropertyEnablementValue(ieee80211axValueExpected)));
         ieee80211axValueUpdated = hostapd.GetStatus().Ieee80211ax;
         REQUIRE(ieee80211axValueUpdated == ieee80211axValueExpected);

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -34,14 +34,15 @@ AccessPointControllerTest::GetInterfaceName() const
     return AccessPoint->InterfaceName;
 }
 
-bool
-AccessPointControllerTest::GetOperationalState()
+AccessPointOperationStatus
+AccessPointControllerTest::GetOperationalState(AccessPointOperationalState& operationalState)
 {
     if (AccessPoint == nullptr) {
         throw std::runtime_error("AccessPointControllerTest::GetOperationalState called with null AccessPoint");
     }
 
-    return AccessPoint->IsEnabled;
+    operationalState = AccessPoint->OperationalState;
+    return AccessPointOperationStatus::MakeSucceeded();
 }
 
 Ieee80211AccessPointCapabilities

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -35,10 +35,10 @@ AccessPointControllerTest::GetInterfaceName() const
 }
 
 bool
-AccessPointControllerTest::GetIsEnabled()
+AccessPointControllerTest::GetOperationalState()
 {
     if (AccessPoint == nullptr) {
-        throw std::runtime_error("AccessPointControllerTest::GetIsEnabled called with null AccessPoint");
+        throw std::runtime_error("AccessPointControllerTest::GetOperationalState called with null AccessPoint");
     }
 
     return AccessPoint->IsEnabled;

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -54,6 +54,17 @@ AccessPointControllerTest::GetCapabilities()
     return AccessPoint->Capabilities;
 }
 
+AccessPointOperationStatus
+AccessPointControllerTest::SetOperationalState(AccessPointOperationalState operationalState)
+{
+    if (AccessPoint == nullptr) {
+        throw std::runtime_error("AccessPointControllerTest::SetOperationalState called with null AccessPoint");
+    }
+
+    AccessPoint->OperationalState = operationalState;
+    return AccessPointOperationStatus::MakeSucceeded();
+}
+
 bool
 AccessPointControllerTest::SetProtocol(Ieee80211Protocol ieeeProtocol)
 {

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -56,13 +56,13 @@ struct AccessPointControllerTest final :
     GetInterfaceName() const override;
 
     /**
-     * @brief Get whether the access point is enabled.
+     * @brief Get the access point operational state.
      *
-     * @return true
-     * @return false
+     * @param operationalState The value to store the operational state.
+     * @return AccessPointOperationStatus 
      */
-    bool
-    GetOperationalState() override;
+    AccessPointOperationStatus
+    GetOperationalState(AccessPointOperationalState& operationalState) override;
 
     /**
      * @brief Get the capabilities of the access point.

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -19,9 +19,10 @@ struct AccessPointTest;
  * @brief IAccessPointController implementation for testing purposes.
  *
  * This implementation takes an AccessPointTest object which it uses to implement the IAccessPointController interface.
- * The owner of this class must ensure that the passes AccessPointTest* remains valid for the lifetime of this object.
+ * The owner of this class must ensure that the passed AccessPointTest* remains valid for the lifetime of this object.
  */
-struct AccessPointControllerTest final : public Microsoft::Net::Wifi::IAccessPointController
+struct AccessPointControllerTest final :
+    public Microsoft::Net::Wifi::IAccessPointController
 {
     AccessPointTest *AccessPoint{ nullptr };
 
@@ -72,6 +73,15 @@ struct AccessPointControllerTest final : public Microsoft::Net::Wifi::IAccessPoi
     GetCapabilities() override;
 
     /**
+     * @brief Set the operational state of the access point.
+     *
+     * @param operationalState The desired operational state.
+     * @return AccessPointOperationStatus
+     */
+    AccessPointOperationStatus
+    SetOperationalState(AccessPointOperationalState operationalState) override;
+
+    /**
      * @brief Set the Ieee80211 protocol of the access point.
      *
      * @param ieeeProtocol The Ieee80211 protocol to be set
@@ -93,9 +103,9 @@ struct AccessPointControllerTest final : public Microsoft::Net::Wifi::IAccessPoi
 
     /**
      * @brief Set the SSID of the access point.
-     * 
+     *
      * @param ssid The SSID to be set.
-     * @return AccessPointOperationStatus 
+     * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
     SetSssid(std::string_view ssid) override;

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -62,7 +62,7 @@ struct AccessPointControllerTest final :
      * @return false
      */
     bool
-    GetIsEnabled() override;
+    GetOperationalState() override;
 
     /**
      * @brief Get the capabilities of the access point.

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -29,6 +29,7 @@ struct AccessPointTest final :
     Microsoft::Net::Wifi::Ieee80211Protocol Protocol;
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> FrequencyBands;
     std::string Ssid;
+    AccessPointOperationalState OperationalState{ AccessPointOperationalState::Disabled };
 
     /**
      * @brief Construct a new AccessPointTest object with the given interface name and default capabilities.

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -25,7 +25,6 @@ struct AccessPointTest final :
 {
     std::string InterfaceName;
     Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities Capabilities;
-    bool IsEnabled{ false };
     Microsoft::Net::Wifi::Ieee80211Protocol Protocol;
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> FrequencyBands;
     std::string Ssid;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow disabling an access point.

### Technical Details

* Introduce operational state `AccessPointOperationalState` (enabled, disabled) in lower layers instead of broken out enabled/disabled state.
* Add `SetOperationalState` to `IAccessPointController`.
* Change `IAccessPointController::GetIsEnabled` to `GetOperationalState` and update return value from `bool` to `AccessPointOperationStatus`, eliminating prior thrown exceptions.
* Add `HandleFailure` wrapper overload accepting `AccessPointOperationStatusCode` instead of direct API type.
* Implement `NetRemoteService::WifiAccessPointDisable` with above functionality.
* Add `NetRemoteService::WifiAccessPointDisable` unit tests.
* Fix implicit conversions from `int` -> `bool`.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
