### PR TITLE
Eliminate exceptions from AccessPointControllerLinux::SetProtocol

### DIFF
--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -92,11 +92,9 @@ struct IAccessPointController
      * @brief Set the Ieee80211 protocol of the access point.
      *
      * @param ieeeProtocol The Ieee80211 protocol to be set.
-     * @return true
-     * @return false
-     *
+     * @return AccessPointOperationStatus 
      */
-    virtual bool
+    virtual AccessPointOperationStatus
     SetProtocol(Ieee80211Protocol ieeeProtocol) = 0;
 
     /**

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -45,9 +45,12 @@ struct IAccessPointController
      * Prevent copying and moving of IAccessPointController objects.
      */
     IAccessPointController(const IAccessPointController&) = delete;
+
+    IAccessPointController(IAccessPointController&&) = delete;
+
     IAccessPointController&
     operator=(const IAccessPointController&) = delete;
-    IAccessPointController(IAccessPointController&&) = delete;
+
     IAccessPointController&
     operator=(IAccessPointController&&) = delete;
 
@@ -63,7 +66,7 @@ struct IAccessPointController
      * @brief Get the access point operational state.
      *
      * @param operationalState The value to store the operational state.
-     * @return AccessPointOperationStatus 
+     * @return AccessPointOperationStatus
      */
     virtual AccessPointOperationStatus
     GetOperationalState(AccessPointOperationalState& operationalState) = 0;
@@ -78,7 +81,7 @@ struct IAccessPointController
 
     /**
      * @brief Set the operational state of the access point.
-     * 
+     *
      * @param operationalState The desired operational state.
      * @return AccessPointOperationStatus
      */
@@ -94,7 +97,7 @@ struct IAccessPointController
      *
      */
     virtual bool
-    SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol) = 0;
+    SetProtocol(Ieee80211Protocol ieeeProtocol) = 0;
 
     /**
      * @brief Set the frquency bands the access point should enable.
@@ -104,13 +107,13 @@ struct IAccessPointController
      * @return false
      */
     virtual bool
-    SetFrequencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) = 0;
+    SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands) = 0;
 
     /**
      * @brief Set the SSID of the access point.
-     * 
+     *
      * @param ssid The SSID to be set.
-     * @return AccessPointOperationStatus 
+     * @return AccessPointOperationStatus
      */
     virtual AccessPointOperationStatus
     SetSssid(std::string_view ssid) = 0;
@@ -129,9 +132,12 @@ struct IAccessPointControllerFactory
      * Prevent copying and moving of IAccessPointControllerFactory objects.
      */
     IAccessPointControllerFactory(const IAccessPointControllerFactory&) = delete;
+
+    IAccessPointControllerFactory(IAccessPointControllerFactory&&) = delete;
+
     IAccessPointControllerFactory&
     operator=(const IAccessPointControllerFactory&) = delete;
-    IAccessPointControllerFactory(IAccessPointControllerFactory&&) = delete;
+
     IAccessPointControllerFactory&
     operator=(IAccessPointControllerFactory&&) = delete;
 

--- a/src/linux/tools/cli/Main.cxx
+++ b/src/linux/tools/cli/Main.cxx
@@ -22,10 +22,10 @@ main(int argc, char *argv[])
     plog::init(plog::verbose, &colorConsoleAppender);
 
     auto cliData = std::make_shared<NetRemoteCliData>();
-    auto cliHandler = std::make_shared<NetRemoteCliHandler>(std::make_unique<Microsoft::Net::Remote::NetRemoteCliHandlerOperationsFactory>());
+    auto cliHandler = std::make_shared<NetRemoteCliHandler>(std::make_unique<NetRemoteCliHandlerOperationsFactory>());
     auto cli{ NetRemoteCli::Create(cliData, cliHandler) };
 
-    int ret = cli->Parse(argc, argv);
+    const int ret = cli->Parse(argc, argv);
     if (ret != 0) {
         return ret;
     }

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -72,11 +72,10 @@ struct AccessPointControllerLinux :
      * @brief Set the Ieee80211 protocol.
      *
      * @param ieeeProtocol The Ieee80211 protocol to be set.
-     * @return true
-     * @return false
+     * @return AccessPointOperationStatus
      */
-    bool
-    SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol) override;
+    AccessPointOperationStatus
+    SetProtocol(Ieee80211Protocol ieeeProtocol) override;
 
     /**
      * @brief Set the frquency bands the access point should enable.

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -46,7 +46,7 @@ struct AccessPointControllerLinux :
      * @brief Get the access point operational state.
      *
      * @param operationalState The value to store the operational state.
-     * @return AccessPointOperationStatus 
+     * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
     GetOperationalState(AccessPointOperationalState& operationalState) override;
@@ -86,7 +86,7 @@ struct AccessPointControllerLinux :
      * @return false
      */
     bool
-    SetFrequencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) override;
+    SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands) override;
 
     /**
      * @brief Set the SSID of the access point.
@@ -115,9 +115,12 @@ struct AccessPointControllerLinuxFactory :
      * Prevent copying and moving of this object.
      */
     AccessPointControllerLinuxFactory(const AccessPointControllerLinuxFactory&) = delete;
+
+    AccessPointControllerLinuxFactory(AccessPointControllerLinuxFactory&&) = delete;
+
     AccessPointControllerLinuxFactory&
     operator=(const AccessPointControllerLinuxFactory&) = delete;
-    AccessPointControllerLinuxFactory(AccessPointControllerLinuxFactory&&) = delete;
+
     AccessPointControllerLinuxFactory&
     operator=(AccessPointControllerLinuxFactory&&) = delete;
 

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -1,6 +1,5 @@
 
 #include <chrono>
-#include <initializer_list>
 #include <optional>
 #include <string>
 #include <string_view>

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -35,7 +35,7 @@ AccessPointControllerTest::GetInterfaceName() const
 }
 
 AccessPointOperationStatus
-AccessPointControllerTest::GetOperationalState(AccessPointOperationalState& operationalState)
+AccessPointControllerTest::GetOperationalState(AccessPointOperationalState &operationalState)
 {
     if (AccessPoint == nullptr) {
         throw std::runtime_error("AccessPointControllerTest::GetOperationalState called with null AccessPoint");
@@ -66,7 +66,7 @@ AccessPointControllerTest::SetOperationalState(AccessPointOperationalState opera
     return AccessPointOperationStatus::MakeSucceeded();
 }
 
-bool
+AccessPointOperationStatus
 AccessPointControllerTest::SetProtocol(Ieee80211Protocol ieeeProtocol)
 {
     if (AccessPoint == nullptr) {
@@ -74,7 +74,7 @@ AccessPointControllerTest::SetProtocol(Ieee80211Protocol ieeeProtocol)
     }
 
     AccessPoint->Protocol = ieeeProtocol;
-    return true;
+    return AccessPointOperationStatus::MakeSucceeded();
 }
 
 bool

--- a/tests/unit/wifi/helpers/AccessPointTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointTest.cxx
@@ -1,5 +1,6 @@
 #include <memory>
 #include <string_view>
+#include <utility>
 
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <microsoft/net/wifi/IAccessPointController.hxx>
@@ -14,9 +15,9 @@ AccessPointTest::AccessPointTest(std::string_view interfaceName) :
     AccessPointTest(interfaceName, Ieee80211AccessPointCapabilities{})
 {}
 
-AccessPointTest::AccessPointTest(std::string_view interfaceName, Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities capabilities) :
+AccessPointTest::AccessPointTest(std::string_view interfaceName, Ieee80211AccessPointCapabilities capabilities) :
     InterfaceName(interfaceName),
-    Capabilities(capabilities)
+    Capabilities(std::move(capabilities))
 {}
 
 std::string_view

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -85,10 +85,9 @@ struct AccessPointControllerTest final :
      * @brief Set the Ieee80211 protocol of the access point.
      *
      * @param ieeeProtocol The Ieee80211 protocol to be set
-     * @return true
-     * @return false
+     * @return AccessPointOperationStatus
      */
-    bool
+    AccessPointOperationStatus
     SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol) override;
 
     /**

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -23,11 +23,11 @@ namespace Microsoft::Net::Wifi::Test
 struct AccessPointTest final :
     public IAccessPoint
 {
+    std::string Ssid;
     std::string InterfaceName;
     Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities Capabilities;
-    Microsoft::Net::Wifi::Ieee80211Protocol Protocol;
+    Microsoft::Net::Wifi::Ieee80211Protocol Protocol{ Microsoft::Net::Wifi::Ieee80211Protocol::Unknown };
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> FrequencyBands;
-    std::string Ssid;
     AccessPointOperationalState OperationalState{ AccessPointOperationalState::Disabled };
 
     /**


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the implementation of `IAccessPointController` functions do not throw exceptions to allow the API layer to avoid `try/catch` blocks.

### Technical Details

* Change `IAccessPointController::SetProtocol` to return `AccessPointOperationStatus` instead of `bool`.
* Update `AccessPointControllerLinux::SetProtocol` to report errors consistently.

### Test Results

* All unit tests pass.
* Additional ad-hoc testing in progress.

### Reviewer Focus

* None

### Future Work

* Ensure API function `WifiAccessPointSetPhyType` doesn't leak exceptions outside the API boundary elsewhere. #165 
* The cli tool must be updated to allow invoking `WifiAccessPointSetPhyType`.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
