### PR TITLE
Eliminate exceptions from AccessPointControllerLinux::GetCapabilities

### DIFF
--- a/src/common/wifi/core/CMakeLists.txt
+++ b/src/common/wifi/core/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(wifi-core
         AccessPointController.cxx
         AccessPointControllerException.cxx
         AccessPointOperationStatus.cxx
+        Ieee80211AccessPointCapabilities.cxx
     PUBLIC
     FILE_SET HEADERS
     BASE_DIRS ${WIFI_CORE_PUBLIC_INCLUDE}
@@ -25,6 +26,8 @@ target_sources(wifi-core
 )
 
 target_link_libraries(wifi-core
+    PRIVATE
+        magic_enum::magic_enum
     PUBLIC
         notstd
 )

--- a/src/common/wifi/core/Ieee80211AccessPointCapabilities.cxx
+++ b/src/common/wifi/core/Ieee80211AccessPointCapabilities.cxx
@@ -1,0 +1,44 @@
+
+#include <sstream>
+#include <string>
+
+#include <magic_enum.hpp>
+#include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
+
+using namespace Microsoft::Net::Wifi;
+
+std::string
+Ieee80211AccessPointCapabilities::ToString() const
+{
+    std::ostringstream result{};
+
+    result << "Protocols: ";
+    for (const auto& protocol : Protocols) {
+        result << magic_enum::enum_name(protocol);
+        result << ' ';
+    }
+
+    result << '\n'
+           << "Frequency Bands: ";
+    for (const auto& frequencyBand : FrequencyBands) {
+        result << magic_enum::enum_name(frequencyBand);
+        result << ' ';
+    }
+
+    result << '\n'
+           << "Akm Suites: ";
+    for (const auto& akmSuite : AkmSuites) {
+        result << magic_enum::enum_name(akmSuite);
+        result << ' ';
+    }
+
+    result << '\n'
+           << "Cipher Suites: ";
+    for (const auto& cipherSuite : CipherSuites) {
+        result << magic_enum::enum_name(cipherSuite);
+        result << ' ';
+    }
+    result << '\n';
+
+    return result.str();
+}

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -74,10 +74,11 @@ struct IAccessPointController
     /**
      * @brief Get the capabilities of the access point.
      *
-     * @return Ieee80211AccessPointCapabilities
+     * @param ieee80211AccessPointCapabilities The value to store the capabilities.
+     * @return AccessPointOperationStatus
      */
-    virtual Ieee80211AccessPointCapabilities
-    GetCapabilities() = 0;
+    virtual AccessPointOperationStatus
+    GetCapabilities(Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) = 0;
 
     /**
      * @brief Set the operational state of the access point.
@@ -92,7 +93,7 @@ struct IAccessPointController
      * @brief Set the Ieee80211 protocol of the access point.
      *
      * @param ieeeProtocol The Ieee80211 protocol to be set.
-     * @return AccessPointOperationStatus 
+     * @return AccessPointOperationStatus
      */
     virtual AccessPointOperationStatus
     SetProtocol(Ieee80211Protocol ieeeProtocol) = 0;

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
@@ -2,6 +2,7 @@
 #ifndef IEEE_80211_ACCESS_POINT_CAPABILITIES_HXX
 #define IEEE_80211_ACCESS_POINT_CAPABILITIES_HXX
 
+#include <string>
 #include <vector>
 
 #include <microsoft/net/wifi/Ieee80211.hxx>
@@ -17,6 +18,14 @@ struct Ieee80211AccessPointCapabilities
     std::vector<Ieee80211FrequencyBand> FrequencyBands;
     std::vector<Ieee80211AkmSuite> AkmSuites;
     std::vector<Ieee80211CipherSuite> CipherSuites;
+
+    /**
+     * @brief Get a string representation of the capabilities.
+     * 
+     * @return std::string 
+     */
+    std::string
+    ToString() const;
 };
 } // namespace Microsoft::Net::Wifi
 

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -52,12 +52,13 @@ struct AccessPointControllerLinux :
     GetOperationalState(AccessPointOperationalState& operationalState) override;
 
     /**
-     * @brief Get the Capabilities object
+     * @brief Get the capabilities of the access point.
      *
-     * @return Ieee80211AccessPointCapabilities
+     * @param ieee80211AccessPointCapabilities The value to store the capabilities.
+     * @return AccessPointOperationStatus
      */
-    Ieee80211AccessPointCapabilities
-    GetCapabilities() override;
+    AccessPointOperationStatus
+    GetCapabilities(Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) override;
 
     /**
      * @brief Set the operational state of the access point.

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -45,14 +45,15 @@ AccessPointControllerTest::GetOperationalState(AccessPointOperationalState &oper
     return AccessPointOperationStatus::MakeSucceeded();
 }
 
-Ieee80211AccessPointCapabilities
-AccessPointControllerTest::GetCapabilities()
+AccessPointOperationStatus
+AccessPointControllerTest::GetCapabilities(Ieee80211AccessPointCapabilities &ieee80211AccessPointCapabilities)
 {
     if (AccessPoint == nullptr) {
         throw std::runtime_error("AccessPointControllerTest::GetCapabilities called with null AccessPoint");
     }
 
-    return AccessPoint->Capabilities;
+    ieee80211AccessPointCapabilities = AccessPoint->Capabilities;
+    return AccessPointOperationStatus::MakeSucceeded();
 }
 
 AccessPointOperationStatus

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -59,18 +59,19 @@ struct AccessPointControllerTest final :
      * @brief Get the access point operational state.
      *
      * @param operationalState The value to store the operational state.
-     * @return AccessPointOperationStatus 
+     * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    GetOperationalState(AccessPointOperationalState& operationalState) override;
+    GetOperationalState(AccessPointOperationalState &operationalState) override;
 
     /**
      * @brief Get the capabilities of the access point.
      *
-     * @return Ieee80211AccessPointCapabilities
+     * @param ieee80211AccessPointCapabilities The value to store the capabilities.
+     * @return AccessPointOperationStatus
      */
-    Ieee80211AccessPointCapabilities
-    GetCapabilities() override;
+    AccessPointOperationStatus
+    GetCapabilities(Ieee80211AccessPointCapabilities &ieee80211AccessPointCapabilities) override;
 
     /**
      * @brief Set the operational state of the access point.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [x] Non-functional change

### Goals

* Ensure the implementation of IAccessPointController functions do not throw exceptions to allow the API layer to avoid try/catch blocks.

### Technical Details

* Change `IAccessPointController::GetCapabilities` to return `AccessPointOperationStatus` instead of bool.
* Update `AccessPointControllerLinux::GetCapabilities` to report errors consistently.
* Add `Ieee80211AccessPointCapabilities::ToString()`.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Ensure API functions don't leak exceptions outside the API boundary elsewhere. #165
* Ensure API functions report lower layer error messages reported in `AccessPointOperationStatus.Message`. #169

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
