### PR TITLE
Eliminate exceptions from AccessPointControllerLinux::SetFrequencyBands

### DIFF
--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -425,13 +425,9 @@ NetRemoteService::WifiAccessPointSetFrequencyBands([[maybe_unused]] grpc::Server
     }
 
     // Attempt to set the frequency bands.
-    try {
-        const auto setBandsSucceeded = accessPointController->SetFrequencyBands(std::move(ieee80211FrequencyBands));
-        if (!setBandsSucceeded) {
-            return HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInternalError, std::format("Failed to set frequency bands for access point {}", request->accesspointid()));
-        }
-    } catch (const AccessPointControllerException& apce) {
-        return HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInternalError, std::format("Failed to set frequency bands for access point {} ({})", request->accesspointid(), apce.what()));
+    operationStatus = accessPointController->SetFrequencyBands(std::move(ieee80211FrequencyBands));
+    if (!operationStatus) {
+        return HandleFailure(request, result, operationStatus.Code, std::format("Failed to set frequency bands for access point {} ({})", request->accesspointid(), operationStatus.Message));
     }
 
     // Prepare result with success indication.

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
@@ -45,6 +45,14 @@ struct AccessPointOperationStatus
         Code{ code }
     {}
 
+    /**
+     * @brief Create an AccessPointOperationStatus with the given status code and message.
+     */
+    constexpr AccessPointOperationStatus(AccessPointOperationStatusCode code, std::string_view message) noexcept :
+        Code{ code },
+        Message{ message }
+    {}
+
     AccessPointOperationStatus(const AccessPointOperationStatus &) = default;
     AccessPointOperationStatus(AccessPointOperationStatus &&) = default;
     AccessPointOperationStatus &
@@ -62,19 +70,19 @@ struct AccessPointOperationStatus
 
     /**
      * @brief Determine whether the operation succeeded.
-     * 
-     * @return true 
-     * @return false 
+     *
+     * @return true
+     * @return false
      */
     bool
     Succeeded() const noexcept;
 
-   /**
+    /**
      * @brief Determine whether the operation failed.
-    * 
-    * @return true 
-    * @return false 
-    */
+     *
+     * @return true
+     * @return false
+     */
     bool
     Failed() const noexcept;
 

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
@@ -54,9 +54,12 @@ struct AccessPointOperationStatus
     {}
 
     AccessPointOperationStatus(const AccessPointOperationStatus &) = default;
+
     AccessPointOperationStatus(AccessPointOperationStatus &&) = default;
+
     AccessPointOperationStatus &
     operator=(const AccessPointOperationStatus &) = default;
+
     AccessPointOperationStatus &
     operator=(AccessPointOperationStatus &&) = default;
 

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -102,10 +102,9 @@ struct IAccessPointController
      * @brief Set the frquency bands the access point should enable.
      *
      * @param frequencyBands The frequency bands to be set.
-     * @return true
-     * @return false
+     * @return AccessPointOperationStatus
      */
-    virtual bool
+    virtual AccessPointOperationStatus
     SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands) = 0;
 
     /**

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -282,7 +282,7 @@ AccessPointControllerLinux::SetProtocol(Ieee80211Protocol ieeeProtocol)
 
     // Attempt to set all required properties.
     try {
-        for (const auto& propertyToSet : propertiesToSet) {
+        for (auto& propertyToSet : propertiesToSet) {
             std::tie(propertyKeyToSet, propertyValueToSet) = std::move(propertyToSet);
             hostapdOperationSucceeded = m_hostapd.SetProperty(propertyKeyToSet, propertyValueToSet);
             if (!hostapdOperationSucceeded) {

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -82,10 +82,9 @@ struct AccessPointControllerLinux :
      * @brief Set the frquency bands the access point should enable.
      *
      * @param frequencyBands The frequency bands to be set.
-     * @return true
-     * @return false
+     * @return AccessPointOperationStatus
      */
-    bool
+    AccessPointOperationStatus
     SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands) override;
 
     /**

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -78,7 +78,7 @@ AccessPointControllerTest::SetProtocol(Ieee80211Protocol ieeeProtocol)
     return AccessPointOperationStatus::MakeSucceeded();
 }
 
-bool
+AccessPointOperationStatus
 AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands)
 {
     if (AccessPoint == nullptr) {
@@ -87,13 +87,15 @@ AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand>
 
     for (const auto &frequencyBandToSet : frequencyBands) {
         if (std::ranges::find(AccessPoint->Capabilities.FrequencyBands, frequencyBandToSet) == std::cend(AccessPoint->Capabilities.FrequencyBands)) {
-            LOGE << std::format("AccessPointControllerTest::SetFrequencyBands called with unsupported frequency band {}", magic_enum::enum_name(frequencyBandToSet));
-            return false;
+            return {
+                AccessPointOperationStatusCode::InvalidParameter,
+                std::format("AccessPointControllerTest::SetFrequencyBands called with unsupported frequency band {}", magic_enum::enum_name(frequencyBandToSet))
+            };
         }
     }
 
     AccessPoint->FrequencyBands = std::move(frequencyBands);
-    return true;
+    return AccessPointOperationStatus::MakeSucceeded();
 }
 
 AccessPointOperationStatus

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -41,9 +41,12 @@ struct AccessPointControllerTest final :
      * Prevent copying and moving of AccessPointControllerTest objects.
      */
     AccessPointControllerTest(const AccessPointControllerTest &) = delete;
+
+    AccessPointControllerTest(AccessPointControllerTest &&) = delete;
+
     AccessPointControllerTest &
     operator=(const AccessPointControllerTest &) = delete;
-    AccessPointControllerTest(AccessPointControllerTest &&) = delete;
+
     AccessPointControllerTest &
     operator=(AccessPointControllerTest &&) = delete;
 
@@ -95,10 +98,9 @@ struct AccessPointControllerTest final :
      * @brief Set the frquency bands the access point should enable.
      *
      * @param frequencyBands The frequency bands to be set.
-     * @return true
-     * @return false
+     * @return AccessPointOperationStatus
      */
-    bool
+    AccessPointOperationStatus
     SetFrequencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) override;
 
     /**


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals
* Ensure the implementation of `IAccessPointController` functions do not throw exceptions to allow the API layer to avoid try/catch blocks.

### Technical Details

* Change `IAccessPointController::SetFrequencyBands` to return `AccessPointOperationStatus` instead of bool.
* Update `AccessPointControllerLinux::SetFrequencyBands` to report errors consistently.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* The code in `AccessPointControllerLinux` tries hard to have a single exit point, but it's complicating the implementation logic and looks messy. The implementation of the interface functions should instead prefer simpler control flow, exiting early where possible instead of maintaining a single exit point.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
