### PR TITLE
Implement WifiDataStreamUpload API

### DIFF
--- a/protocol/protos/NetRemoteDataStreamingService.proto
+++ b/protocol/protos/NetRemoteDataStreamingService.proto
@@ -8,4 +8,5 @@ import "NetRemoteWifi.proto";
 
 service NetRemoteDataStreaming
 {
+    rpc WifiDataStreamUpload (stream Microsoft.Net.Remote.Wifi.WifiDataStreamUploadData) returns (Microsoft.Net.Remote.Wifi.WifiDataStreamUploadResult);
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -40,6 +40,19 @@ message WifiAccessPointOperationStatus
     google.protobuf.Any Details = 3;
 }
 
+enum WifiDataStreamOperationStatusCode
+{
+    WifiDataStreamOperationStatusCodeUnknown = 0;
+    WifiDataStreamOperationStatusCodeSucceeded = 1;
+    WifiDataStreamOperationStatusCodeFailed = 2;
+}
+
+message WifiDataStreamOperationStatus
+{
+    WifiDataStreamOperationStatusCode Code = 1;
+    string Message = 2;
+}
+
 message WifiAccessPointEnableRequest
 {
     string AccessPointId = 1;
@@ -85,4 +98,15 @@ message WifiAccessPointSetFrequencyBandsResult
 {
     string AccessPointId = 1;
     WifiAccessPointOperationStatus Status = 2;
+}
+
+message WifiDataStreamUploadData
+{
+    bytes Data = 1;
+}
+
+message WifiDataStreamUploadResult
+{
+    uint32 DataReceivedCount = 1;
+    WifiDataStreamOperationStatus Status = 2;
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -45,6 +45,7 @@ enum WifiDataStreamOperationStatusCode
     WifiDataStreamOperationStatusCodeUnknown = 0;
     WifiDataStreamOperationStatusCodeSucceeded = 1;
     WifiDataStreamOperationStatusCodeFailed = 2;
+    WifiDataStreamOperationStatusCodeCancelled = 3;
 }
 
 message WifiDataStreamOperationStatus

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -107,6 +107,6 @@ message WifiDataStreamUploadData
 
 message WifiDataStreamUploadResult
 {
-    uint32 DataReceivedCount = 1;
+    uint32 NumberOfDataBlocksReceived = 1;
     WifiDataStreamOperationStatus Status = 2;
 }

--- a/src/common/service/CMakeLists.txt
+++ b/src/common/service/CMakeLists.txt
@@ -9,6 +9,8 @@ target_sources(${PROJECT_NAME}-service
     PRIVATE
         NetRemoteService.cxx
         NetRemoteDataStreamingService.cxx
+        NetRemoteDataStreamingReactors.hxx
+        NetRemoteDataStreamingReactors.cxx
         NetRemoteApiTrace.hxx
         NetRemoteApiTrace.cxx 
         NetRemoteWifiApiTrace.hxx

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -31,6 +31,8 @@ void
 DataStreamReader::OnCancel()
 {
     m_result->set_numberofdatablocksreceived(m_numberOfDataBlocksReceived);
+    m_readStatus.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeCancelled);
+    m_readStatus.set_message("RPC cancelled");
     *m_result->mutable_status() = std::move(m_readStatus);
     Finish(grpc::Status::CANCELLED);
 }

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -1,0 +1,42 @@
+
+#include "NetRemoteDataStreamingReactors.hxx"
+
+using namespace Microsoft::Net::Remote::Service::Reactors;
+using namespace Microsoft::Net::Remote::Wifi;
+
+DataStreamReader::DataStreamReader(WifiDataStreamUploadResult* result) :
+    m_result(result)
+{
+    StartRead(&m_data);
+}
+
+void
+DataStreamReader::OnReadDone(bool ok)
+{
+    if (ok) {
+        m_numberOfDataBlocksReceived++;
+        m_readStatus.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeSucceeded);
+        m_readStatus.set_message("Data read successful");
+        StartRead(&m_data);
+    } else {
+        // A false "ok" value could either mean a failed RPC or that no more data is available.
+        // Unfortunately, there is no clear way to tell which situation occurred.
+        m_result->set_numberofdatablocksreceived(m_numberOfDataBlocksReceived);
+        *m_result->mutable_status() = std::move(m_readStatus);
+        Finish(grpc::Status::OK);
+    }
+}
+
+void
+DataStreamReader::OnCancel()
+{
+    m_result->set_numberofdatablocksreceived(m_numberOfDataBlocksReceived);
+    *m_result->mutable_status() = std::move(m_readStatus);
+    Finish(grpc::Status::CANCELLED);
+}
+
+void
+DataStreamReader::OnDone()
+{
+    delete this;
+}

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -11,15 +11,15 @@ DataStreamReader::DataStreamReader(WifiDataStreamUploadResult* result) :
 }
 
 void
-DataStreamReader::OnReadDone(bool ok)
+DataStreamReader::OnReadDone(bool isOk)
 {
-    if (ok) {
+    if (isOk) {
         m_numberOfDataBlocksReceived++;
         m_readStatus.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeSucceeded);
         m_readStatus.set_message("Data read successful");
         StartRead(&m_data);
     } else {
-        // A false "ok" value could either mean a failed RPC or that no more data is available.
+        // A false "isOk" value could either mean a failed RPC or that no more data is available.
         // Unfortunately, there is no clear way to tell which situation occurred.
         m_result->set_numberofdatablocksreceived(m_numberOfDataBlocksReceived);
         *m_result->mutable_status() = std::move(m_readStatus);

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -1,0 +1,51 @@
+
+#ifndef NET_REMOTE_DATA_STREAMING_REACTORS_HXX
+#define NET_REMOTE_DATA_STREAMING_REACTORS_HXX
+
+#include <microsoft/net/remote/protocol/NetRemoteDataStreamingService.grpc.pb.h>
+
+namespace Microsoft::Net::Remote::Service::Reactors
+{
+/**
+ * @brief Implementation of the gRPC ServerReadReactor for server-side data stream reading.
+ */
+class DataStreamReader :
+    public grpc::ServerReadReactor<Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData>
+{
+public:
+    /**
+     * @brief Construct a new DataStreamReader object with the specified data stream upload result output parameter.
+     *
+     * @param result The result of the data stream read operation.
+     */
+    explicit DataStreamReader(Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* result);
+
+    /**
+     * @brief Callback that is executed when a read operation is completed.
+     *
+     * @param isOk Indicates whether a message was read as expected.
+     */
+    void
+    OnReadDone(bool isOk) override;
+
+    /**
+     * @brief Callback that is executed when an RPC is cancelled before successfully sending a status to the client.
+     */
+    void
+    OnCancel() override;
+
+    /**
+     * @brief Callback that is executed when all RPC operations are completed for a given RPC.
+     */
+    void
+    OnDone() override;
+
+private:
+    Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData m_data{};
+    Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* m_result{};
+    uint32_t m_numberOfDataBlocksReceived{};
+    Microsoft::Net::Remote::Wifi::WifiDataStreamOperationStatus m_readStatus{};
+};
+} // namespace Microsoft::Net::Remote::Service::Reactors
+
+#endif // NET_REMOTE_DATA_STREAMING_REACTORS_HXX

--- a/src/common/service/NetRemoteDataStreamingService.cxx
+++ b/src/common/service/NetRemoteDataStreamingService.cxx
@@ -1,2 +1,12 @@
 
+#include "NetRemoteDataStreamingReactors.hxx"
 #include <microsoft/net/remote/NetRemoteDataStreamingService.hxx>
+
+using namespace Microsoft::Net::Remote::Service;
+using namespace Microsoft::Net::Remote::Wifi;
+
+grpc::ServerReadReactor<WifiDataStreamUploadData>*
+NetRemoteDataStreamingService::WifiDataStreamUpload([[maybe_unused]] grpc::CallbackServerContext* context, WifiDataStreamUploadResult* result)
+{
+    return new Reactors::DataStreamReader(result);
+}

--- a/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
@@ -17,6 +17,17 @@ public:
      * @brief Construct a new NetRemoteDataStreamingService object.
      */
     NetRemoteDataStreamingService() = default;
+
+private:
+    /**
+     * @brief Stream data from the client to the server.
+     *
+     * @param context
+     * @param result
+     * @return grpc::ServerReadReactor<Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData>*
+     */
+    grpc::ServerReadReactor<Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData>*
+    WifiDataStreamUpload(grpc::CallbackServerContext* context, Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* result) override;
 };
 } // namespace Microsoft::Net::Remote::Service
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(${PROJECT_NAME}-test-unit
         ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteCommon.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteServer.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteServiceClient.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteDataStreamingServiceClient.cxx
 )
 
 target_link_libraries(${PROJECT_NAME}-test-unit

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -1,0 +1,111 @@
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
+#include <catch2/catch_test_macros.hpp>
+#include <grpcpp/create_channel.h>
+#include <microsoft/net/remote/NetRemoteServer.hxx>
+#include <microsoft/net/remote/protocol/NetRemoteDataStreamingService.grpc.pb.h>
+
+#include "TestNetRemoteCommon.hxx"
+
+TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
+{
+    using namespace Microsoft::Net::Remote;
+    using namespace Microsoft::Net::Remote::Service;
+    using namespace Microsoft::Net::Remote::Wifi;
+
+    using Microsoft::Net::Remote::Test::RemoteServiceAddressHttp;
+
+    NetRemoteServerConfiguration Configuration{
+        .ServerAddress = RemoteServiceAddressHttp,
+    };
+
+    NetRemoteServer server{ Configuration };
+    server.Run();
+
+    auto channel = grpc::CreateChannel(RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());
+    auto client = NetRemoteDataStreaming::NewStub(channel);
+
+    SECTION("Can be called")
+    {
+        class DataStreamWriter : public grpc::ClientWriteReactor<WifiDataStreamUploadData>
+        {
+        public:
+            DataStreamWriter(NetRemoteDataStreaming::Stub* client, uint32_t numberOfDataBlocksToWrite) :
+                m_numberOfDataBlocksToWrite(numberOfDataBlocksToWrite)
+            {
+                client->async()->WifiDataStreamUpload(&m_clientContext, &m_result, this);
+                StartCall();
+                NextWrite();
+            }
+
+            void
+            OnWriteDone(bool isOk) override
+            {
+                if (isOk) {
+                    NextWrite();
+                } else {
+                    StartWritesDone();
+                }
+            }
+
+            void
+            OnDone(const grpc::Status& status) override
+            {
+                std::unique_lock lock(m_mutex);
+
+                m_status = status;
+                m_done = true;
+                m_cv.notify_one();
+            }
+
+            grpc::Status
+            Await(WifiDataStreamUploadResult* result)
+            {
+                std::unique_lock lock(m_mutex);
+
+                m_cv.wait(lock, [this] {
+                    return m_done;
+                });
+                *result = m_result;
+
+                return m_status;
+            }
+
+        private:
+            void
+            NextWrite()
+            {
+                if (m_numberOfDataBlocksToWrite > 0) {
+                    m_data.set_data(std::format("Data #{}", ++m_numberOfDataBlocksWritten));
+                    StartWrite(&m_data);
+                    m_numberOfDataBlocksToWrite--;
+                } else {
+                    StartWritesDone();
+                }
+            }
+
+        private:
+            grpc::ClientContext m_clientContext{};
+            WifiDataStreamUploadData m_data{};
+            WifiDataStreamUploadResult m_result{};
+            uint32_t m_numberOfDataBlocksToWrite{};
+            uint32_t m_numberOfDataBlocksWritten{};
+            grpc::Status m_status{};
+            std::mutex m_mutex{};
+            std::condition_variable m_cv{};
+            bool m_done{ false };
+        };
+
+        static constexpr auto numberOfDataBlocksToWrite = 10;
+        auto dataStreamWriter = std::make_unique<DataStreamWriter>(client.get(), numberOfDataBlocksToWrite);
+
+        WifiDataStreamUploadResult result{};
+        grpc::Status status = dataStreamWriter->Await(&result);
+        REQUIRE(status.ok());
+        REQUIRE(result.numberofdatablocksreceived() == numberOfDataBlocksToWrite);
+        REQUIRE(result.status().code() == WifiDataStreamOperationStatusCodeSucceeded);
+    }
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

This PR provides the implementation for the `WifiDataStreamUpload` API, along with a simple unit test.

### Technical Details

* Added `WifiDataStreamUpload` RPC to `NetRemoteDataStreamingService.proto` and necessary data types to `NetRemoteWifi.proto`.
* Added `WifiDataStreamOperationStatus` and `WifiDataStreamOperationStatusCode` types in `NetRemoteWifi.proto`.
* Added `NetRemoteDataStreamingReactors.*xx` with a `ServerReadReactor` implementation for server-side handling of the API.
* Added `TestNetRemoteDataStreamingServiceClient.cxx` unit test file with a simple unit test for the API.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

*Provide another unit test with multiple parallel clients for the upload API.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
