### PR TITLE
Add unit test for WifiDataStreamUpload with multiple parallel clients

### DIFF
--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -114,15 +114,19 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
     SECTION("Can be called with multiple parallel clients")
     {
         static constexpr auto numberOfDataBlocksToWrite = 10;
-        static constexpr auto numberOfClientThreads = 5;
+        static constexpr auto numberOfClients = 5;
 
+        std::vector<std::unique_ptr<NetRemoteDataStreaming::Stub>> dataStreamingClients;
+        std::vector<std::unique_ptr<DataStreamWriter>> dataStreamWriters;
         std::vector<std::jthread> clientThreads;
-        for (std::size_t i = 0; i < numberOfClientThreads; i++) {
-            clientThreads.emplace_back([&]() {
-                auto dataStreamWriter = std::make_unique<DataStreamWriter>(client.get(), numberOfDataBlocksToWrite);
 
+        for (std::size_t i = 0; i < numberOfClients; i++) {
+            dataStreamingClients.push_back(NetRemoteDataStreaming::NewStub(channel));
+            dataStreamWriters.push_back(std::make_unique<DataStreamWriter>(dataStreamingClients.back().get(), numberOfDataBlocksToWrite));
+
+            clientThreads.emplace_back([&, i]() {
                 WifiDataStreamUploadResult result{};
-                grpc::Status status = dataStreamWriter->Await(&result);
+                grpc::Status status = dataStreamWriters[i]->Await(&result);
                 REQUIRE(status.ok());
                 REQUIRE(result.numberofdatablocksreceived() == numberOfDataBlocksToWrite);
                 REQUIRE(result.status().code() == WifiDataStreamOperationStatusCodeSucceeded);

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -28,77 +28,77 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
     auto channel = grpc::CreateChannel(RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());
     auto client = NetRemoteDataStreaming::NewStub(channel);
 
-    SECTION("Can be called")
+    class DataStreamWriter : public grpc::ClientWriteReactor<WifiDataStreamUploadData>
     {
-        class DataStreamWriter : public grpc::ClientWriteReactor<WifiDataStreamUploadData>
+    public:
+        DataStreamWriter(NetRemoteDataStreaming::Stub* client, uint32_t numberOfDataBlocksToWrite) :
+            m_numberOfDataBlocksToWrite(numberOfDataBlocksToWrite)
         {
-        public:
-            DataStreamWriter(NetRemoteDataStreaming::Stub* client, uint32_t numberOfDataBlocksToWrite) :
-                m_numberOfDataBlocksToWrite(numberOfDataBlocksToWrite)
-            {
-                client->async()->WifiDataStreamUpload(&m_clientContext, &m_result, this);
-                StartCall();
+            client->async()->WifiDataStreamUpload(&m_clientContext, &m_result, this);
+            StartCall();
+            NextWrite();
+        }
+
+        void
+        OnWriteDone(bool isOk) override
+        {
+            if (isOk) {
                 NextWrite();
+            } else {
+                StartWritesDone();
             }
+        }
 
-            void
-            OnWriteDone(bool isOk) override
-            {
-                if (isOk) {
-                    NextWrite();
-                } else {
-                    StartWritesDone();
-                }
+        void
+        OnDone(const grpc::Status& status) override
+        {
+            std::unique_lock lock(m_mutex);
+
+            m_status = status;
+            m_done = true;
+            m_cv.notify_one();
+        }
+
+        grpc::Status
+        Await(WifiDataStreamUploadResult* result)
+        {
+            std::unique_lock lock(m_mutex);
+
+            m_cv.wait(lock, [this] {
+                return m_done;
+            });
+            *result = m_result;
+
+            return m_status;
+        }
+
+    private:
+        void
+        NextWrite()
+        {
+            if (m_numberOfDataBlocksToWrite > 0) {
+                m_data.set_data(std::format("Data #{}", ++m_numberOfDataBlocksWritten));
+                StartWrite(&m_data);
+                m_numberOfDataBlocksToWrite--;
+            } else {
+                StartWritesDone();
             }
+        }
 
-            void
-            OnDone(const grpc::Status& status) override
-            {
-                std::unique_lock lock(m_mutex);
+    private:
+        grpc::ClientContext m_clientContext{};
+        WifiDataStreamUploadData m_data{};
+        WifiDataStreamUploadResult m_result{};
+        uint32_t m_numberOfDataBlocksToWrite{};
+        uint32_t m_numberOfDataBlocksWritten{};
+        grpc::Status m_status{};
+        std::mutex m_mutex{};
+        std::condition_variable m_cv{};
+        bool m_done{ false };
+    };
 
-                m_status = status;
-                m_done = true;
-                m_cv.notify_one();
-            }
-
-            grpc::Status
-            Await(WifiDataStreamUploadResult* result)
-            {
-                std::unique_lock lock(m_mutex);
-
-                m_cv.wait(lock, [this] {
-                    return m_done;
-                });
-                *result = m_result;
-
-                return m_status;
-            }
-
-        private:
-            void
-            NextWrite()
-            {
-                if (m_numberOfDataBlocksToWrite > 0) {
-                    m_data.set_data(std::format("Data #{}", ++m_numberOfDataBlocksWritten));
-                    StartWrite(&m_data);
-                    m_numberOfDataBlocksToWrite--;
-                } else {
-                    StartWritesDone();
-                }
-            }
-
-        private:
-            grpc::ClientContext m_clientContext{};
-            WifiDataStreamUploadData m_data{};
-            WifiDataStreamUploadResult m_result{};
-            uint32_t m_numberOfDataBlocksToWrite{};
-            uint32_t m_numberOfDataBlocksWritten{};
-            grpc::Status m_status{};
-            std::mutex m_mutex{};
-            std::condition_variable m_cv{};
-            bool m_done{ false };
-        };
-
+    SECTION("Can be called with one client")
+    {
         static constexpr auto numberOfDataBlocksToWrite = 10;
         auto dataStreamWriter = std::make_unique<DataStreamWriter>(client.get(), numberOfDataBlocksToWrite);
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

This PR adds a unit test for the `WifiDataStreamUpload` API with multiple parallel clients.

### Technical Details

* Added new unit test case with multiple clients running in parallel threads.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
