### PR TITLE
Log access point operations consistently

### DIFF
--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -427,7 +427,7 @@ NetRemoteService::WifiAccessPointSetFrequencyBands([[maybe_unused]] grpc::Server
     // Attempt to set the frequency bands.
     operationStatus = accessPointController->SetFrequencyBands(std::move(ieee80211FrequencyBands));
     if (!operationStatus) {
-        return HandleFailure(request, result, operationStatus.Code, std::format("Failed to set frequency bands for access point {} ({})", request->accesspointid(), operationStatus.Message));
+        return HandleFailure(request, result, operationStatus.Code, std::format("Failed to set frequency bands for access point {} ({})", request->accesspointid(), operationStatus.Details)); // FIXME
     }
 
     // Prepare result with success indication.

--- a/src/common/wifi/core/AccessPointOperationStatus.cxx
+++ b/src/common/wifi/core/AccessPointOperationStatus.cxx
@@ -1,13 +1,21 @@
 
+#include <format>
+#include <string>
+#include <string_view>
+
+#include <magic_enum.hpp>
 #include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
 
 using namespace Microsoft::Net::Wifi;
 
 /* static */
 AccessPointOperationStatus
-AccessPointOperationStatus::MakeSucceeded() noexcept
+AccessPointOperationStatus::MakeSucceeded(std::string_view accessPointId) noexcept
 {
-    return AccessPointOperationStatus{ AccessPointOperationStatusCode::Succeeded };
+    return AccessPointOperationStatus{
+        accessPointId,
+        AccessPointOperationStatusCode::Succeeded,
+    };
 }
 
 bool
@@ -20,6 +28,17 @@ bool
 AccessPointOperationStatus::Failed() const noexcept
 {
     return !Succeeded();
+}
+
+std::string
+AccessPointOperationStatus::ToString() const
+{
+    static constexpr auto Format{ "AP '{}' operation {} {}" };
+
+    const auto result = std::format("{}", Succeeded() ? "succeeded" : std::format("failed with code '{}'", magic_enum::enum_name(Code)));
+    const auto details = std::format("{}", std::empty(Details) ? "" : std::format("({})", Details));
+
+    return std::format(Format, AccessPointId, OperationName, result, details);
 }
 
 AccessPointOperationStatus::operator bool() const noexcept

--- a/src/common/wifi/core/AccessPointOperationStatus.cxx
+++ b/src/common/wifi/core/AccessPointOperationStatus.cxx
@@ -12,13 +12,13 @@ using namespace Microsoft::Net::Wifi;
 
 /* static */
 AccessPointOperationStatus
-AccessPointOperationStatus::MakeSucceeded(std::string_view accessPointId, std::source_location sourceLocation) noexcept
+AccessPointOperationStatus::MakeSucceeded(std::string_view accessPointId, std::string_view operationName, std::string_view details, std::source_location sourceLocation) noexcept
 {
     return AccessPointOperationStatus{
         accessPointId,
-        {},
+        operationName,
         AccessPointOperationStatusCode::Succeeded,
-        {},
+        details,
         sourceLocation
     };
 }
@@ -40,7 +40,7 @@ AccessPointOperationStatus::ToString() const
 {
     static constexpr auto Format{ "AP '{}' operation {} {} {} {}" };
 
-    std::optional<std::string> caller{};
+    std::optional<std::string> caller{}; // NOLINT(misc-const-correctness)
     const auto result = std::format("{}", Succeeded() ? "succeeded" : std::format("failed with code '{}'", magic_enum::enum_name(Code)));
     const auto details = std::format("{}", std::empty(Details) ? "" : std::format("- {}", Details));
 #ifdef DEBUG

--- a/src/common/wifi/core/AccessPointOperationStatusLogOnExit.cxx
+++ b/src/common/wifi/core/AccessPointOperationStatusLogOnExit.cxx
@@ -1,0 +1,26 @@
+
+#include <microsoft/net/wifi/AccessPointOperationStatusLogOnExit.hxx>
+#include <plog/Log.h>
+#include <plog/Severity.h>
+
+using namespace Microsoft::Net::Wifi;
+
+AccessPointOperationStatusLogOnExit::AccessPointOperationStatusLogOnExit(AccessPointOperationStatus* operationStatus, plog::Severity severityOnError, plog::Severity severityOnSuccess) noexcept :
+    OperationStatus(operationStatus),
+    SeverityOnError(severityOnError),
+    SeverityOnSuccess(severityOnSuccess)
+{
+}
+
+AccessPointOperationStatusLogOnExit::~AccessPointOperationStatusLogOnExit()
+{
+    if (OperationStatus != nullptr) {
+        LOG(OperationStatus->Succeeded() ? SeverityOnSuccess : SeverityOnError) << OperationStatus->ToString();
+    }
+}
+
+void
+AccessPointOperationStatusLogOnExit::Reset() noexcept
+{
+    OperationStatus = nullptr;
+}

--- a/src/common/wifi/core/AccessPointOperationStatusLogOnExit.cxx
+++ b/src/common/wifi/core/AccessPointOperationStatusLogOnExit.cxx
@@ -1,4 +1,5 @@
 
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
 #include <microsoft/net/wifi/AccessPointOperationStatusLogOnExit.hxx>
 #include <plog/Log.h>
 #include <plog/Severity.h>

--- a/src/common/wifi/core/CMakeLists.txt
+++ b/src/common/wifi/core/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(wifi-core
         AccessPointController.cxx
         AccessPointControllerException.cxx
         AccessPointOperationStatus.cxx
+        AccessPointOperationStatusLogOnExit.cxx
         Ieee80211AccessPointCapabilities.cxx
     PUBLIC
     FILE_SET HEADERS
@@ -19,6 +20,7 @@ target_sources(wifi-core
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPoint.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPointController.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPointOperationStatus.hxx
+        ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPointOperationStatusLogOnExit.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/IAccessPoint.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/IAccessPointController.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/Ieee80211.hxx
@@ -28,8 +30,9 @@ target_sources(wifi-core
 target_link_libraries(wifi-core
     PRIVATE
         magic_enum::magic_enum
-    PUBLIC
         notstd
+    PUBLIC
+        plog::plog
 )
 
 install(

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
@@ -2,7 +2,9 @@
 #ifndef ACCESS_POINT_OPERATION_STATUS_HXX
 #define ACCESS_POINT_OPERATION_STATUS_HXX
 
+#include <source_location>
 #include <string>
+#include <string_view>
 
 namespace Microsoft::Net::Wifi
 {
@@ -32,25 +34,37 @@ enum class AccessPointOperationStatusCode {
  */
 struct AccessPointOperationStatus
 {
+    std::string AccessPointId;
+    std::string OperationName;
     AccessPointOperationStatusCode Code{ AccessPointOperationStatusCode::Unknown };
-    std::string Message;
+    std::string Details;
+    std::string Message; // TODO: remove this
 
-    AccessPointOperationStatus() = default;
+    AccessPointOperationStatus() = default; // TODO: remove this
     virtual ~AccessPointOperationStatus() = default;
 
     /**
-     * @brief Create an AccessPointOperationStatus with the given status code.
+     * @brief Create an AccessPointOperationStatus with the given access point id and operation name.
      */
-    constexpr explicit AccessPointOperationStatus(AccessPointOperationStatusCode code) noexcept :
-        Code{ code }
+    constexpr AccessPointOperationStatus(std::string_view accessPointId, const char *operationName = std::source_location::current().function_name()) noexcept :
+        AccessPointOperationStatus(accessPointId, AccessPointOperationStatusCode::Unknown, operationName)
     {}
 
     /**
-     * @brief Create an AccessPointOperationStatus with the given status code and message.
+     * @brief Create an AccessPointOperationStatus with the given access point id, operation name, and status code.
      */
-    constexpr AccessPointOperationStatus(AccessPointOperationStatusCode code, std::string_view message) noexcept :
+    constexpr AccessPointOperationStatus(std::string_view accessPointId, AccessPointOperationStatusCode code, const char *operationName = std::source_location::current().function_name()) noexcept :
+        AccessPointOperationStatus(accessPointId, code, "", operationName)
+    {}
+
+    /**
+     * @brief Create an AccessPointOperationStatus with the given access point id, operation name, status code, and details.
+     */
+    constexpr AccessPointOperationStatus(std::string_view accessPointId, AccessPointOperationStatusCode code, std::string_view details, const char *operationName = std::source_location::current().function_name()) noexcept :
+        AccessPointId{ accessPointId },
+        OperationName{ operationName },
         Code{ code },
-        Message{ message }
+        Details{ details }
     {}
 
     AccessPointOperationStatus(const AccessPointOperationStatus &) = default;
@@ -64,12 +78,20 @@ struct AccessPointOperationStatus
     operator=(AccessPointOperationStatus &&) = default;
 
     /**
+     * @brief Return a string representation of the status.
+     *
+     * @return std::string
+     */
+    std::string
+    ToString() const;
+
+    /**
      * @brief Create an AccessPointOperationStatus describing an operation that succeeded.
      *
      * @return AccessPointOperationStatus
      */
     static AccessPointOperationStatus
-    MakeSucceeded() noexcept;
+    MakeSucceeded(std::string_view accessPointId) noexcept;
 
     /**
      * @brief Determine whether the operation succeeded.

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
@@ -87,11 +87,13 @@ struct AccessPointOperationStatus
      * @brief Create an AccessPointOperationStatus describing an operation that succeeded.
      *
      * @param accessPointId The ID of the access point.
+     * @param operationName The name of the operation.
+     * @param details Additional details about the operation.
      * @param sourceLocation The source location of the operation.
      * @return AccessPointOperationStatus
      */
     static AccessPointOperationStatus
-    MakeSucceeded(std::string_view accessPointId, std::source_location sourceLocation = std::source_location::current()) noexcept;
+    MakeSucceeded(std::string_view accessPointId, std::string_view operationName = {}, std::string_view details = {}, std::source_location sourceLocation = std::source_location::current()) noexcept;
 
     /**
      * @brief Determine whether the operation succeeded.

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
@@ -38,9 +38,7 @@ struct AccessPointOperationStatus
     std::string OperationName;
     AccessPointOperationStatusCode Code{ AccessPointOperationStatusCode::Unknown };
     std::string Details;
-    std::string Message; // TODO: remove this
 
-    AccessPointOperationStatus() = default; // TODO: remove this
     virtual ~AccessPointOperationStatus() = default;
 
     /**

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
@@ -54,8 +54,14 @@ struct AccessPointOperationStatus
     {
         if (std::empty(OperationName)) {
             OperationName = SourceLocation.function_name();
-            OperationName.erase(OperationName.find_first_of('('));
-            OperationName.erase(0, OperationName.find_last_of(':'));
+            auto pos = OperationName.find_first_of('('); 
+            if (pos != std::string::npos) {
+                OperationName.erase(pos);
+            }
+            pos = OperationName.find_last_of(':');
+            if (pos != std::string::npos) {
+                OperationName.erase(0, pos);
+            }
         }
     }
 

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatusLogOnExit.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatusLogOnExit.hxx
@@ -23,7 +23,7 @@ struct AccessPointOperationStatusLogOnExit final
      * @param severityOnError The severity to log on error.
      * @param severityOnSuccess The severity to log on success.
      */
-    AccessPointOperationStatusLogOnExit(AccessPointOperationStatus* operationStatus, plog::Severity severityOnError = plog::Severity::error, plog::Severity severityOnSuccess = plog::Severity::info) noexcept;
+    explicit AccessPointOperationStatusLogOnExit(AccessPointOperationStatus* operationStatus, plog::Severity severityOnError = plog::Severity::error, plog::Severity severityOnSuccess = plog::Severity::info) noexcept;
 
     /**
      * @brief Destroy the object and log the stored AccessPointOperationStatus.

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatusLogOnExit.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatusLogOnExit.hxx
@@ -1,0 +1,52 @@
+
+#ifndef ACCESS_POINT_OPERATION_STATUS_LOG_ON_EXIT_HXX
+#define ACCESS_POINT_OPERATION_STATUS_LOG_ON_EXIT_HXX
+
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
+#include <plog/Severity.h>
+
+namespace Microsoft::Net::Wifi
+{
+/**
+ * @brief Helper to log an AccessPointOperationStatus on scope exit.
+ */
+struct AccessPointOperationStatusLogOnExit final
+{
+    AccessPointOperationStatus* OperationStatus;
+    plog::Severity SeverityOnError{ plog::Severity::error };
+    plog::Severity SeverityOnSuccess{ plog::Severity::debug };
+
+    /**
+     * @brief Construct a new AccessPointOperationStatusLogOnExit object with the given AccessPointOperationStatus and logging severities.
+     *
+     * @param operationStatus The AccessPointOperationStatus to log on exit.
+     * @param severityOnError The severity to log on error.
+     * @param severityOnSuccess The severity to log on success.
+     */
+    AccessPointOperationStatusLogOnExit(AccessPointOperationStatus* operationStatus, plog::Severity severityOnError = plog::Severity::error, plog::Severity severityOnSuccess = plog::Severity::info) noexcept;
+
+    /**
+     * @brief Destroy the object and log the stored AccessPointOperationStatus.
+     */
+    ~AccessPointOperationStatusLogOnExit();
+
+    /**
+     * @brief Reset the stored status object, preventing it from being logged on exit.
+     */
+    void
+    Reset() noexcept;
+
+    /**
+     * @brief Prevent copying and moving of AccessPointOperationStatusLogOnExit objects.
+     */
+    AccessPointOperationStatusLogOnExit(const AccessPointOperationStatusLogOnExit&) = delete;
+
+    AccessPointOperationStatusLogOnExit&
+    operator=(const AccessPointOperationStatusLogOnExit&) = delete;
+
+    AccessPointOperationStatusLogOnExit&
+    operator=(AccessPointOperationStatusLogOnExit&& other) = delete;
+};
+} // namespace Microsoft::Net::Wifi
+
+#endif // ACCESS_POINT_OPERATION_STATUS_LOG_ON_EXIT_HXX

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -179,7 +179,7 @@ AccessPointControllerLinux::GetCapabilities(Ieee80211AccessPointCapabilities& ie
         std::ranges::transform(wiphy->CipherSuites, std::begin(capabilities.CipherSuites), detail::Nl80211CipherSuiteToIeee80211CipherSuite);
 
         ieee80211AccessPointCapabilities = std::move(capabilities);
-        status = AccessPointOperationStatus::MakeSucceeded();
+        status = AccessPointOperationStatus::MakeSucceeded(GetInterfaceName());
     }
 
     if (status.Succeeded()) {
@@ -201,7 +201,7 @@ AccessPointControllerLinux::GetOperationalState(AccessPointOperationalState& ope
         operationalState = (hostapdStatus.State == Wpa::HostapdInterfaceState::Enabled)
             ? AccessPointOperationalState::Enabled
             : AccessPointOperationalState::Disabled;
-        status = AccessPointOperationStatus::MakeSucceeded();
+        status = AccessPointOperationStatus::MakeSucceeded(GetInterfaceName());
     } catch (const Wpa::HostapdException& ex) {
         status.Code = AccessPointOperationStatusCode::InternalError;
         status.Message = std::format("Failed to get operational state for interface {} ({})", GetInterfaceName(), ex.what());
@@ -431,7 +431,7 @@ AccessPointControllerLinux::SetSssid(std::string_view ssid)
         return status;
     }
 
-    return AccessPointOperationStatus::MakeSucceeded();
+    return AccessPointOperationStatus::MakeSucceeded(GetInterfaceName());
 }
 
 std::unique_ptr<IAccessPointController>

--- a/tests/unit/wifi/core/CMakeLists.txt
+++ b/tests/unit/wifi/core/CMakeLists.txt
@@ -3,7 +3,9 @@ add_executable(wifi-core-test-unit)
 
 target_sources(wifi-core-test-unit
     PRIVATE
+        Main.cxx
         TestAccessPoint.cxx
+        TestAccessPointOperationStatus.cxx
         TestIeee80211.cxx
 )
 
@@ -14,8 +16,9 @@ target_include_directories(wifi-core-test-unit
 
 target_link_libraries(wifi-core-test-unit
     PRIVATE
-        Catch2::Catch2WithMain
+        Catch2::Catch2
         magic_enum::magic_enum
+        plog::plog
         strings
         wifi-core
         wifi-test-helpers

--- a/tests/unit/wifi/core/Main.cxx
+++ b/tests/unit/wifi/core/Main.cxx
@@ -1,0 +1,16 @@
+
+#include <catch2/catch_session.hpp>
+#include <plog/Appenders/ColorConsoleAppender.h>
+#include <plog/Formatters/MessageOnlyFormatter.h>
+#include <plog/Init.h>
+#include <plog/Severity.h>
+
+int
+main(int argc, char* argv[])
+{
+    static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
+
+    plog::init(plog::verbose, &colorConsoleAppender);
+
+    return Catch::Session().run(argc, argv);
+}

--- a/tests/unit/wifi/core/TestAccessPointOperationStatus.cxx
+++ b/tests/unit/wifi/core/TestAccessPointOperationStatus.cxx
@@ -1,0 +1,175 @@
+
+#include <optional>
+
+#include <catch2/catch_message.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <magic_enum.hpp>
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
+#include <plog/Log.h>
+#include <plog/Severity.h>
+
+namespace Microsoft::Net::Wifi::Test
+{
+static constexpr auto AccessPointId{ "AP1" };
+static constexpr auto OperationName{ "Operation1" };
+static constexpr auto Details{ "Details1" };
+} // namespace Microsoft::Net::Wifi::Test
+
+TEST_CASE("Create an AccessPointOperationStatus instance", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("Create with args {accessPointId} doesn't cause a crash")
+    {
+        std::optional<AccessPointOperationStatus> status;
+        REQUIRE_NOTHROW(status.emplace(AccessPointId));
+    }
+
+    SECTION("Create with args {accessPointId,operationName} doesn't cause a crash")
+    {
+        std::optional<AccessPointOperationStatus> status;
+        REQUIRE_NOTHROW(status.emplace(AccessPointId, OperationName));
+    }
+
+    SECTION("Create with args {accessPointId,operationName,code[*]} doesn't cause a crash")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            std::optional<AccessPointOperationStatus> status;
+            REQUIRE_NOTHROW(status.emplace(AccessPointId, OperationName, statusCode));
+        }
+    }
+
+    SECTION("Create with args {accessPointId,operationName,code[*],details} doesn't cause a crash")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            std::optional<AccessPointOperationStatus> status;
+            REQUIRE_NOTHROW(status.emplace(AccessPointId, OperationName, statusCode, Details));
+        }
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus instance reflects basic properties", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("AccessPointId reflects the value passed to the constructor")
+    {
+        AccessPointOperationStatus status{ AccessPointId };
+        REQUIRE(status.AccessPointId == AccessPointId);
+    }
+
+    SECTION("OperationName reflects the value passed to the constructor")
+    {
+        AccessPointOperationStatus status{ AccessPointId, OperationName };
+        REQUIRE(status.OperationName == OperationName);
+    }
+
+    SECTION("Code reflects the value passed to the constructor")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            AccessPointOperationStatus status{ AccessPointId, OperationName, statusCode };
+            REQUIRE(status.Code == statusCode);
+        }
+    }
+
+    SECTION("Details reflects the value passed to the constructor")
+    {
+        AccessPointOperationStatus status{ AccessPointId, OperationName, AccessPointOperationStatusCode::Succeeded, Details };
+        REQUIRE(status.Details == Details);
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus::MakeSucceeded returns a status with the correct code", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("MakeSucceeded returns a status with the Succeeded code")
+    {
+        const auto status = AccessPointOperationStatus::MakeSucceeded(AccessPointId);
+        REQUIRE(status.Code == AccessPointOperationStatusCode::Succeeded);
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus::Succeeded() reflects the status code", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("Returns 'true' for a status with the Succeeded code")
+    {
+        const auto status = AccessPointOperationStatus::MakeSucceeded(AccessPointId);
+        REQUIRE(status.Succeeded());
+    }
+
+    SECTION("Returns 'false' for a status with a code other than Succeeded")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            if (statusCode != AccessPointOperationStatusCode::Succeeded) {
+                const auto status = AccessPointOperationStatus{ AccessPointId, OperationName, statusCode };
+                REQUIRE_FALSE(status.Succeeded());
+            }
+        }
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus::Failed() reflects the status code", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("Returns 'true' for a status with a code other than Succeeded")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            if (statusCode != AccessPointOperationStatusCode::Succeeded) {
+                const auto status = AccessPointOperationStatus{ AccessPointId, OperationName, statusCode };
+                REQUIRE(status.Failed());
+            }
+        }
+    }
+
+    SECTION("Returns 'false' for a status with the Succeeded code")
+    {
+        const auto status = AccessPointOperationStatus::MakeSucceeded(AccessPointId);
+        REQUIRE_FALSE(status.Failed());
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus::ToString() includes all properties", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("Returns a string with all properties")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            const auto status = AccessPointOperationStatus{ AccessPointId, OperationName, statusCode, Details };
+            const auto statusMessage = status.ToString();
+            REQUIRE(statusMessage.contains(AccessPointId));
+            REQUIRE(statusMessage.contains(OperationName));
+            REQUIRE(statusMessage.contains(Details));
+            if (statusCode != AccessPointOperationStatusCode::Succeeded) {
+                REQUIRE(statusMessage.contains(magic_enum::enum_name(statusCode)));
+            }
+        }
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus::ToString() result can be printed", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("Returns a string with all properties")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            const auto status = AccessPointOperationStatus{ AccessPointId, OperationName, statusCode, Details };
+            const auto logSeverity = status.Succeeded() ? plog::debug : plog::error;
+            REQUIRE_NOTHROW([&]() {
+                LOG(logSeverity) << status.ToString();
+            }());
+        }
+    }
+}

--- a/tests/unit/wifi/core/TestAccessPointOperationStatus.cxx
+++ b/tests/unit/wifi/core/TestAccessPointOperationStatus.cxx
@@ -1,5 +1,6 @@
 
 #include <optional>
+#include <source_location>
 
 #include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -78,6 +79,24 @@ TEST_CASE("AccessPointOperationStatus instance reflects basic properties", "[wif
     {
         AccessPointOperationStatus status{ AccessPointId, OperationName, AccessPointOperationStatusCode::Succeeded, Details };
         REQUIRE(status.Details == Details);
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus instance reflects function name on empty operation name", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("OperationName reflects the function name when empty")
+    {
+        const AccessPointOperationStatus status{ AccessPointId };
+        REQUIRE(status.OperationName.contains(__func__));
+    }
+
+    SECTION("OperationName does not reflect the function name when non-empty")
+    {
+        const AccessPointOperationStatus status{ AccessPointId, OperationName };
+        REQUIRE_FALSE(status.OperationName.contains(__func__));
     }
 }
 

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -42,7 +42,7 @@ AccessPointControllerTest::GetOperationalState(AccessPointOperationalState &oper
     }
 
     operationalState = AccessPoint->OperationalState;
-    return AccessPointOperationStatus::MakeSucceeded();
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 
 AccessPointOperationStatus
@@ -53,7 +53,7 @@ AccessPointControllerTest::GetCapabilities(Ieee80211AccessPointCapabilities &iee
     }
 
     ieee80211AccessPointCapabilities = AccessPoint->Capabilities;
-    return AccessPointOperationStatus::MakeSucceeded();
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 
 AccessPointOperationStatus
@@ -64,7 +64,7 @@ AccessPointControllerTest::SetOperationalState(AccessPointOperationalState opera
     }
 
     AccessPoint->OperationalState = operationalState;
-    return AccessPointOperationStatus::MakeSucceeded();
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 
 AccessPointOperationStatus
@@ -75,7 +75,7 @@ AccessPointControllerTest::SetProtocol(Ieee80211Protocol ieeeProtocol)
     }
 
     AccessPoint->Protocol = ieeeProtocol;
-    return AccessPointOperationStatus::MakeSucceeded();
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 
 AccessPointOperationStatus
@@ -88,6 +88,7 @@ AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand>
     for (const auto &frequencyBandToSet : frequencyBands) {
         if (std::ranges::find(AccessPoint->Capabilities.FrequencyBands, frequencyBandToSet) == std::cend(AccessPoint->Capabilities.FrequencyBands)) {
             return {
+                AccessPoint->InterfaceName,
                 AccessPointOperationStatusCode::InvalidParameter,
                 std::format("AccessPointControllerTest::SetFrequencyBands called with unsupported frequency band {}", magic_enum::enum_name(frequencyBandToSet))
             };
@@ -95,7 +96,7 @@ AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand>
     }
 
     AccessPoint->FrequencyBands = std::move(frequencyBands);
-    return AccessPointOperationStatus::MakeSucceeded();
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 
 AccessPointOperationStatus
@@ -106,7 +107,7 @@ AccessPointControllerTest::SetSssid(std::string_view ssid)
     }
 
     AccessPoint->Ssid = ssid;
-    return AccessPointOperationStatus::MakeSucceeded();
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 
 AccessPointControllerFactoryTest::AccessPointControllerFactoryTest(AccessPointTest *accessPoint) :

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -15,7 +15,6 @@
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
 #include <microsoft/net/wifi/test/AccessPointControllerTest.hxx>
 #include <microsoft/net/wifi/test/AccessPointTest.hxx>
-#include <plog/Log.h>
 
 using namespace Microsoft::Net::Wifi;
 using namespace Microsoft::Net::Wifi::Test;

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -89,6 +89,7 @@ AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand>
         if (std::ranges::find(AccessPoint->Capabilities.FrequencyBands, frequencyBandToSet) == std::cend(AccessPoint->Capabilities.FrequencyBands)) {
             return {
                 AccessPoint->InterfaceName,
+                {},
                 AccessPointOperationStatusCode::InvalidParameter,
                 std::format("AccessPointControllerTest::SetFrequencyBands called with unsupported frequency band {}", magic_enum::enum_name(frequencyBandToSet))
             };


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure operations involving access points in the implementation layers report their status consistently.

### Technical Details

* Add `AccessPointOperationStatus::ToString()` method with standardized output strings.
* Rename `AccessPointOperationStatus::Message` to `AccessPointOperationStatus::Details` as this is the more accurate name.
* Print source line location info in `AccessPointOperationStatus::ToString()` output for `DEBUG` builds.
* Replace one-off usage of `LOG*` macros with `AccessPointOperationStatus` instance fields with `ToString()` method.
* Add `AccessPointOperationStatus` unit tests.
* Add RAII-helper `AccessPointOperationStatusLogOnExit` for logging an `AccessPointOperationStatus` instance on scope exit/end of lifetime.
* Update control flow of code in `AccessPointControllerLinux` to exit early where possible, and automatically log it's associated `AccessPointOperationStatus`.
* Consolidate hostapd interface error handling or return values and thrown exceptions.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* The API layer still uses `AccessPointOperationStatus` somewhat inconsistently, so this needs to be updated.
* The API layer should employ a similar concept for error reporting, updating the `HandleFailure` helpers in the process.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
