### PR TITLE
Address review comments for initial API

### DIFF
--- a/protocol/CMakeLists.txt
+++ b/protocol/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PROTO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/protos)
 set(PROTO_DIR_BINARY ${CMAKE_CURRENT_BINARY_DIR}/${NETREMOTE_PROTOCOL_PUBLIC_INCLUDE_SUFFIX})
 set(PROTO_FILES
     ${PROTO_DIR}/NetRemote.proto
+    ${PROTO_DIR}/NetRemoteDataStream.proto
     ${PROTO_DIR}/NetRemoteDataStreamingService.proto
     ${PROTO_DIR}/NetRemoteService.proto
     ${PROTO_DIR}/NetRemoteWifi.proto

--- a/protocol/protos/NetRemoteDataStream.proto
+++ b/protocol/protos/NetRemoteDataStream.proto
@@ -1,0 +1,31 @@
+
+syntax = "proto3";
+
+package Microsoft.Net.Remote.DataStream;
+
+import "google/protobuf/any.proto";
+
+enum DataStreamOperationStatusCode
+{
+    DataStreamOperationStatusCodeUnknown = 0;
+    DataStreamOperationStatusCodeSucceeded = 1;
+    DataStreamOperationStatusCodeFailed = 2;
+    DataStreamOperationStatusCodeCancelled = 3;
+}
+
+message DataStreamOperationStatus
+{
+    DataStreamOperationStatusCode Code = 1;
+    string Message = 2;
+}
+
+message DataStreamUploadData
+{
+    bytes Data = 1;
+}
+
+message DataStreamUploadResult
+{
+    uint32 NumberOfDataBlocksReceived = 1;
+    DataStreamOperationStatus Status = 2;
+}

--- a/protocol/protos/NetRemoteDataStreamingService.proto
+++ b/protocol/protos/NetRemoteDataStreamingService.proto
@@ -4,9 +4,9 @@ syntax = "proto3";
 package Microsoft.Net.Remote.Service;
 
 import "NetRemote.proto";
-import "NetRemoteWifi.proto";
+import "NetRemoteDataStream.proto";
 
 service NetRemoteDataStreaming
 {
-    rpc WifiDataStreamUpload (stream Microsoft.Net.Remote.Wifi.WifiDataStreamUploadData) returns (Microsoft.Net.Remote.Wifi.WifiDataStreamUploadResult);
+    rpc DataStreamUpload (stream Microsoft.Net.Remote.DataStream.DataStreamUploadData) returns (Microsoft.Net.Remote.DataStream.DataStreamUploadResult);
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -40,20 +40,6 @@ message WifiAccessPointOperationStatus
     google.protobuf.Any Details = 3;
 }
 
-enum WifiDataStreamOperationStatusCode
-{
-    WifiDataStreamOperationStatusCodeUnknown = 0;
-    WifiDataStreamOperationStatusCodeSucceeded = 1;
-    WifiDataStreamOperationStatusCodeFailed = 2;
-    WifiDataStreamOperationStatusCodeCancelled = 3;
-}
-
-message WifiDataStreamOperationStatus
-{
-    WifiDataStreamOperationStatusCode Code = 1;
-    string Message = 2;
-}
-
 message WifiAccessPointEnableRequest
 {
     string AccessPointId = 1;
@@ -99,15 +85,4 @@ message WifiAccessPointSetFrequencyBandsResult
 {
     string AccessPointId = 1;
     WifiAccessPointOperationStatus Status = 2;
-}
-
-message WifiDataStreamUploadData
-{
-    bytes Data = 1;
-}
-
-message WifiDataStreamUploadResult
-{
-    uint32 NumberOfDataBlocksReceived = 1;
-    WifiDataStreamOperationStatus Status = 2;
 }

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -1,10 +1,10 @@
 
 #include "NetRemoteDataStreamingReactors.hxx"
 
+using namespace Microsoft::Net::Remote::DataStream;
 using namespace Microsoft::Net::Remote::Service::Reactors;
-using namespace Microsoft::Net::Remote::Wifi;
 
-DataStreamReader::DataStreamReader(WifiDataStreamUploadResult* result) :
+DataStreamReader::DataStreamReader(DataStreamUploadResult* result) :
     m_result(result)
 {
     StartRead(&m_data);
@@ -15,7 +15,7 @@ DataStreamReader::OnReadDone(bool isOk)
 {
     if (isOk) {
         m_numberOfDataBlocksReceived++;
-        m_readStatus.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeSucceeded);
+        m_readStatus.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeSucceeded);
         m_readStatus.set_message("Data read successful");
         StartRead(&m_data);
     } else {
@@ -31,7 +31,7 @@ void
 DataStreamReader::OnCancel()
 {
     m_result->set_numberofdatablocksreceived(m_numberOfDataBlocksReceived);
-    m_readStatus.set_code(WifiDataStreamOperationStatusCode::WifiDataStreamOperationStatusCodeCancelled);
+    m_readStatus.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeCancelled);
     m_readStatus.set_message("RPC cancelled");
     *m_result->mutable_status() = std::move(m_readStatus);
     Finish(grpc::Status::CANCELLED);

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -10,7 +10,7 @@ namespace Microsoft::Net::Remote::Service::Reactors
  * @brief Implementation of the gRPC ServerReadReactor for server-side data stream reading.
  */
 class DataStreamReader :
-    public grpc::ServerReadReactor<Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData>
+    public grpc::ServerReadReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData>
 {
 public:
     /**
@@ -18,7 +18,7 @@ public:
      *
      * @param result The result of the data stream read operation.
      */
-    explicit DataStreamReader(Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* result);
+    explicit DataStreamReader(Microsoft::Net::Remote::DataStream::DataStreamUploadResult* result);
 
     /**
      * @brief Callback that is executed when a read operation is completed.
@@ -41,10 +41,10 @@ public:
     OnDone() override;
 
 private:
-    Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData m_data{};
-    Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* m_result{};
+    Microsoft::Net::Remote::DataStream::DataStreamUploadData m_data{};
+    Microsoft::Net::Remote::DataStream::DataStreamUploadResult* m_result{};
     uint32_t m_numberOfDataBlocksReceived{};
-    Microsoft::Net::Remote::Wifi::WifiDataStreamOperationStatus m_readStatus{};
+    Microsoft::Net::Remote::DataStream::DataStreamOperationStatus m_readStatus{};
 };
 } // namespace Microsoft::Net::Remote::Service::Reactors
 

--- a/src/common/service/NetRemoteDataStreamingService.cxx
+++ b/src/common/service/NetRemoteDataStreamingService.cxx
@@ -2,11 +2,11 @@
 #include "NetRemoteDataStreamingReactors.hxx"
 #include <microsoft/net/remote/NetRemoteDataStreamingService.hxx>
 
+using namespace Microsoft::Net::Remote::DataStream;
 using namespace Microsoft::Net::Remote::Service;
-using namespace Microsoft::Net::Remote::Wifi;
 
-grpc::ServerReadReactor<WifiDataStreamUploadData>*
-NetRemoteDataStreamingService::WifiDataStreamUpload([[maybe_unused]] grpc::CallbackServerContext* context, WifiDataStreamUploadResult* result)
+grpc::ServerReadReactor<DataStreamUploadData>*
+NetRemoteDataStreamingService::DataStreamUpload([[maybe_unused]] grpc::CallbackServerContext* context, DataStreamUploadResult* result)
 {
     return new Reactors::DataStreamReader(result);
 }

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -427,7 +427,7 @@ NetRemoteService::WifiAccessPointSetFrequencyBands([[maybe_unused]] grpc::Server
     // Attempt to set the frequency bands.
     operationStatus = accessPointController->SetFrequencyBands(std::move(ieee80211FrequencyBands));
     if (!operationStatus) {
-        return HandleFailure(request, result, operationStatus.Code, std::format("Failed to set frequency bands for access point {} ({})", request->accesspointid(), operationStatus.Message));
+        return HandleFailure(request, result, operationStatus.Code, std::format("Failed to set frequency bands for access point {} ({})", request->accesspointid(), operationStatus.Details)); // FIXME
     }
 
     // Prepare result with success indication.

--- a/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
@@ -24,10 +24,10 @@ private:
      *
      * @param context
      * @param result
-     * @return grpc::ServerReadReactor<Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData>*
+     * @return grpc::ServerReadReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData>*
      */
-    grpc::ServerReadReactor<Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData>*
-    WifiDataStreamUpload(grpc::CallbackServerContext* context, Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* result) override;
+    grpc::ServerReadReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData>*
+    DataStreamUpload(grpc::CallbackServerContext* context, Microsoft::Net::Remote::DataStream::DataStreamUploadResult* result) override;
 };
 } // namespace Microsoft::Net::Remote::Service
 

--- a/src/common/wifi/core/AccessPointOperationStatus.cxx
+++ b/src/common/wifi/core/AccessPointOperationStatus.cxx
@@ -1,13 +1,26 @@
 
+#include <format>
+#include <optional>
+#include <source_location>
+#include <string>
+#include <string_view>
+
+#include <magic_enum.hpp>
 #include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
 
 using namespace Microsoft::Net::Wifi;
 
 /* static */
 AccessPointOperationStatus
-AccessPointOperationStatus::MakeSucceeded() noexcept
+AccessPointOperationStatus::MakeSucceeded(std::string_view accessPointId, std::string_view operationName, std::string_view details, std::source_location sourceLocation) noexcept
 {
-    return AccessPointOperationStatus{ AccessPointOperationStatusCode::Succeeded };
+    return AccessPointOperationStatus{
+        accessPointId,
+        operationName,
+        AccessPointOperationStatusCode::Succeeded,
+        details,
+        sourceLocation
+    };
 }
 
 bool
@@ -22,8 +35,22 @@ AccessPointOperationStatus::Failed() const noexcept
     return !Succeeded();
 }
 
+std::string
+AccessPointOperationStatus::ToString() const
+{
+    static constexpr auto Format{ "AP '{}' operation {} {} {} {}" };
+
+    std::optional<std::string> caller{}; // NOLINT(misc-const-correctness)
+    const auto result = std::format("{}", Succeeded() ? "succeeded" : std::format("failed with code '{}'", magic_enum::enum_name(Code)));
+    const auto details = std::format("{}", std::empty(Details) ? "" : std::format("- {}", Details));
+#ifdef DEBUG
+    caller = std::format("[{}({}:{}) {}]", SourceLocation.file_name(), SourceLocation.line(), SourceLocation.column(), SourceLocation.function_name());
+#endif
+
+    return std::format(Format, AccessPointId, OperationName, result, details, caller.value_or(""));
+}
+
 AccessPointOperationStatus::operator bool() const noexcept
 {
     return Succeeded();
-    return (Code == AccessPointOperationStatusCode::Succeeded);
 }

--- a/src/common/wifi/core/AccessPointOperationStatusLogOnExit.cxx
+++ b/src/common/wifi/core/AccessPointOperationStatusLogOnExit.cxx
@@ -1,0 +1,27 @@
+
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
+#include <microsoft/net/wifi/AccessPointOperationStatusLogOnExit.hxx>
+#include <plog/Log.h>
+#include <plog/Severity.h>
+
+using namespace Microsoft::Net::Wifi;
+
+AccessPointOperationStatusLogOnExit::AccessPointOperationStatusLogOnExit(AccessPointOperationStatus* operationStatus, plog::Severity severityOnError, plog::Severity severityOnSuccess) noexcept :
+    OperationStatus(operationStatus),
+    SeverityOnError(severityOnError),
+    SeverityOnSuccess(severityOnSuccess)
+{
+}
+
+AccessPointOperationStatusLogOnExit::~AccessPointOperationStatusLogOnExit()
+{
+    if (OperationStatus != nullptr) {
+        LOG(OperationStatus->Succeeded() ? SeverityOnSuccess : SeverityOnError) << OperationStatus->ToString();
+    }
+}
+
+void
+AccessPointOperationStatusLogOnExit::Reset() noexcept
+{
+    OperationStatus = nullptr;
+}

--- a/src/common/wifi/core/CMakeLists.txt
+++ b/src/common/wifi/core/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(wifi-core
         AccessPointController.cxx
         AccessPointControllerException.cxx
         AccessPointOperationStatus.cxx
+        AccessPointOperationStatusLogOnExit.cxx
         Ieee80211AccessPointCapabilities.cxx
     PUBLIC
     FILE_SET HEADERS
@@ -19,6 +20,7 @@ target_sources(wifi-core
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPoint.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPointController.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPointOperationStatus.hxx
+        ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPointOperationStatusLogOnExit.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/IAccessPoint.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/IAccessPointController.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/Ieee80211.hxx
@@ -28,8 +30,9 @@ target_sources(wifi-core
 target_link_libraries(wifi-core
     PRIVATE
         magic_enum::magic_enum
-    PUBLIC
         notstd
+    PUBLIC
+        plog::plog
 )
 
 install(

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatusLogOnExit.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatusLogOnExit.hxx
@@ -1,0 +1,52 @@
+
+#ifndef ACCESS_POINT_OPERATION_STATUS_LOG_ON_EXIT_HXX
+#define ACCESS_POINT_OPERATION_STATUS_LOG_ON_EXIT_HXX
+
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
+#include <plog/Severity.h>
+
+namespace Microsoft::Net::Wifi
+{
+/**
+ * @brief Helper to log an AccessPointOperationStatus on scope exit.
+ */
+struct AccessPointOperationStatusLogOnExit final
+{
+    AccessPointOperationStatus* OperationStatus;
+    plog::Severity SeverityOnError{ plog::Severity::error };
+    plog::Severity SeverityOnSuccess{ plog::Severity::debug };
+
+    /**
+     * @brief Construct a new AccessPointOperationStatusLogOnExit object with the given AccessPointOperationStatus and logging severities.
+     *
+     * @param operationStatus The AccessPointOperationStatus to log on exit.
+     * @param severityOnError The severity to log on error.
+     * @param severityOnSuccess The severity to log on success.
+     */
+    explicit AccessPointOperationStatusLogOnExit(AccessPointOperationStatus* operationStatus, plog::Severity severityOnError = plog::Severity::error, plog::Severity severityOnSuccess = plog::Severity::info) noexcept;
+
+    /**
+     * @brief Destroy the object and log the stored AccessPointOperationStatus.
+     */
+    ~AccessPointOperationStatusLogOnExit();
+
+    /**
+     * @brief Reset the stored status object, preventing it from being logged on exit.
+     */
+    void
+    Reset() noexcept;
+
+    /**
+     * @brief Prevent copying and moving of AccessPointOperationStatusLogOnExit objects.
+     */
+    AccessPointOperationStatusLogOnExit(const AccessPointOperationStatusLogOnExit&) = delete;
+
+    AccessPointOperationStatusLogOnExit&
+    operator=(const AccessPointOperationStatusLogOnExit&) = delete;
+
+    AccessPointOperationStatusLogOnExit&
+    operator=(AccessPointOperationStatusLogOnExit&& other) = delete;
+};
+} // namespace Microsoft::Net::Wifi
+
+#endif // ACCESS_POINT_OPERATION_STATUS_LOG_ON_EXIT_HXX

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -21,10 +21,11 @@
 #include <microsoft/net/wifi/AccessPointController.hxx>
 #include <microsoft/net/wifi/AccessPointControllerLinux.hxx>
 #include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
+#include <microsoft/net/wifi/AccessPointOperationStatusLogOnExit.hxx>
 #include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
-#include <plog/Log.h>
+#include <plog/Severity.h>
 
 using namespace Microsoft::Net::Wifi;
 
@@ -154,39 +155,36 @@ IeeeFrequencyBandToHostapdBand(Ieee80211FrequencyBand ieeeFrequencyBand)
 AccessPointOperationStatus
 AccessPointControllerLinux::GetCapabilities(Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities)
 {
-    AccessPointOperationStatus status{};
+    AccessPointOperationStatus status{ GetInterfaceName() };
+    const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
 
     const auto wiphy = Nl80211Wiphy::FromInterfaceName(GetInterfaceName());
     if (!wiphy.has_value()) {
         status.Code = AccessPointOperationStatusCode::AccessPointInvalid;
-        status.Message = std::format("Failed to get wiphy for interface {}", GetInterfaceName());
-    } else {
-        Ieee80211AccessPointCapabilities capabilities;
-
-        // Convert protocols.
-        capabilities.Protocols = detail::Nl80211WiphyToIeee80211Protocols(wiphy.value());
-
-        // Convert frequency bands.
-        capabilities.FrequencyBands = std::vector<Ieee80211FrequencyBand>(std::size(wiphy->Bands));
-        std::ranges::transform(std::views::keys(wiphy->Bands), std::begin(capabilities.FrequencyBands), detail::Nl80211BandToIeee80211FrequencyBand);
-
-        // Convert AKM suites.
-        capabilities.AkmSuites = std::vector<Ieee80211AkmSuite>(std::size(wiphy->AkmSuites));
-        std::ranges::transform(wiphy->AkmSuites, std::begin(capabilities.AkmSuites), detail::Nl80211AkmSuiteToIeee80211AkmSuite);
-
-        // Convert cipher suites.
-        capabilities.CipherSuites = std::vector<Ieee80211CipherSuite>(std::size(wiphy->CipherSuites));
-        std::ranges::transform(wiphy->CipherSuites, std::begin(capabilities.CipherSuites), detail::Nl80211CipherSuiteToIeee80211CipherSuite);
-
-        ieee80211AccessPointCapabilities = std::move(capabilities);
-        status = AccessPointOperationStatus::MakeSucceeded();
+        status.Details = "failed to get wiphy for interface";
+        return status;
     }
 
-    if (status.Succeeded()) {
-        LOGD << std::format("Got capabilities for interface {}", GetInterfaceName());
-    } else {
-        LOGE << std::format("Failed to get capabilities for interface {} ({} - {})", GetInterfaceName(), magic_enum::enum_name(status.Code), status.Message);
-    }
+    Ieee80211AccessPointCapabilities capabilities{};
+
+    // Convert protocols.
+    capabilities.Protocols = detail::Nl80211WiphyToIeee80211Protocols(wiphy.value());
+
+    // Convert frequency bands.
+    capabilities.FrequencyBands = std::vector<Ieee80211FrequencyBand>(std::size(wiphy->Bands));
+    std::ranges::transform(std::views::keys(wiphy->Bands), std::begin(capabilities.FrequencyBands), detail::Nl80211BandToIeee80211FrequencyBand);
+
+    // Convert AKM suites.
+    capabilities.AkmSuites = std::vector<Ieee80211AkmSuite>(std::size(wiphy->AkmSuites));
+    std::ranges::transform(wiphy->AkmSuites, std::begin(capabilities.AkmSuites), detail::Nl80211AkmSuiteToIeee80211AkmSuite);
+
+    // Convert cipher suites.
+    capabilities.CipherSuites = std::vector<Ieee80211CipherSuite>(std::size(wiphy->CipherSuites));
+    std::ranges::transform(wiphy->CipherSuites, std::begin(capabilities.CipherSuites), detail::Nl80211CipherSuiteToIeee80211CipherSuite);
+
+    ieee80211AccessPointCapabilities = std::move(capabilities);
+
+    status.Code = AccessPointOperationStatusCode::Succeeded;
 
     return status;
 }
@@ -194,17 +192,18 @@ AccessPointControllerLinux::GetCapabilities(Ieee80211AccessPointCapabilities& ie
 AccessPointOperationStatus
 AccessPointControllerLinux::GetOperationalState(AccessPointOperationalState& operationalState)
 {
-    AccessPointOperationStatus status{};
+    AccessPointOperationStatus status{ GetInterfaceName() };
+    const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
 
     try {
         auto hostapdStatus = m_hostapd.GetStatus();
         operationalState = (hostapdStatus.State == Wpa::HostapdInterfaceState::Enabled)
             ? AccessPointOperationalState::Enabled
             : AccessPointOperationalState::Disabled;
-        status = AccessPointOperationStatus::MakeSucceeded();
+        status.Code = AccessPointOperationStatusCode::Succeeded;
     } catch (const Wpa::HostapdException& ex) {
         status.Code = AccessPointOperationStatusCode::InternalError;
-        status.Message = std::format("Failed to get operational state for interface {} ({})", GetInterfaceName(), ex.what());
+        status.Details = std::format("failed to get operational state - {}", ex.what());
     }
 
     return status;
@@ -213,30 +212,33 @@ AccessPointControllerLinux::GetOperationalState(AccessPointOperationalState& ope
 AccessPointOperationStatus
 AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState operationalState)
 {
-    AccessPointOperationStatus status{};
+    AccessPointOperationStatus status{ GetInterfaceName() };
+    const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
 
     switch (operationalState) {
     case AccessPointOperationalState::Enabled: {
         try {
             m_hostapd.Enable();
+            status.Code = AccessPointOperationStatusCode::Succeeded;
         } catch (const Wpa::HostapdException& ex) {
             status.Code = AccessPointOperationStatusCode::InternalError;
-            status.Message = std::format("Failed to set operational state to 'enabled' for {} (unknown error)", GetInterfaceName());
+            status.Details = "failed to set operational state to 'enabled'";
         }
         break;
     }
     case AccessPointOperationalState::Disabled: {
         try {
             m_hostapd.Disable();
+            status.Code = AccessPointOperationStatusCode::Succeeded;
         } catch (const Wpa::HostapdException& ex) {
             status.Code = AccessPointOperationStatusCode::InternalError;
-            status.Message = std::format("Failed to set operational state to 'disabled' for {} (unknown error)", GetInterfaceName());
+            status.Details = "failed to set operational state to 'disabled'";
         }
         break;
     }
     default: {
         status.Code = AccessPointOperationStatusCode::InvalidParameter;
-        status.Message = std::format("Invalid operational state value '{}' for {}", magic_enum::enum_name(operationalState), GetInterfaceName());
+        status.Details = std::format("invalid target operational state value '{}'", magic_enum::enum_name(operationalState));
         break;
     }
     }
@@ -247,6 +249,10 @@ AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState oper
 AccessPointOperationStatus
 AccessPointControllerLinux::SetProtocol(Ieee80211Protocol ieeeProtocol)
 {
+    const auto ieeeProtocolName = std::format("802.11 {}", magic_enum::enum_name(ieeeProtocol));
+    AccessPointOperationStatus status{ GetInterfaceName(), std::format("SetProtocol {}", ieeeProtocolName).c_str() };
+    const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
+
     // Populate a list of required properties to set.
     std::vector<std::pair<std::string_view, std::string_view>> propertiesToSet{};
 
@@ -274,7 +280,6 @@ AccessPointControllerLinux::SetProtocol(Ieee80211Protocol ieeeProtocol)
         break;
     }
 
-    AccessPointOperationStatus status{};
     std::optional<std::string> errorDetails;
     std::string_view propertyKeyToSet;
     std::string_view propertyValueToSet;
@@ -294,27 +299,21 @@ AccessPointControllerLinux::SetProtocol(Ieee80211Protocol ieeeProtocol)
         errorDetails = ex.what();
     }
 
-    // If the required properties were set, reload the hostapd configuration to pick up the changes.
-    if (hostapdOperationSucceeded) {
-        hostapdOperationSucceeded = m_hostapd.Reload();
-        if (!hostapdOperationSucceeded) {
-            errorDetails = "failed to reload hostapd configuration";
-        }
-    } else {
-        errorDetails = std::format("failed to set hostapd property '{}' to '{}' for interface {} - {}", propertyKeyToSet, propertyValueToSet, GetInterfaceName(), errorDetails.value_or("unspecified error"));
-    }
-
-    const auto ieeeProtocolName = std::format("802.11 {}", magic_enum::enum_name(ieeeProtocol));
-
-    // Finalize return status.
     if (!hostapdOperationSucceeded) {
         status.Code = AccessPointOperationStatusCode::InternalError;
-        status.Message = std::format("Setting protocol {} for interface {} failed ({})", ieeeProtocolName, GetInterfaceName(), errorDetails.value_or("unspecified error"));
-        LOGE << status.Message;
-    } else {
-        status.Code = AccessPointOperationStatusCode::Succeeded;
-        LOGD << std::format("Set protocol {} for interface {}", ieeeProtocolName, GetInterfaceName());
+        status.Details = std::format("failed to set hostapd property '{}' to '{}' - {}", propertyKeyToSet, propertyValueToSet, errorDetails.value_or("unspecified error"));
+        return status;
     }
+
+    // Reload the hostapd configuration to pick up the changes.
+    hostapdOperationSucceeded = m_hostapd.Reload();
+    if (!hostapdOperationSucceeded) {
+        status.Code = AccessPointOperationStatusCode::InternalError;
+        status.Details = "failed to reload hostapd configuration";
+        return status;
+    }
+
+    status.Code = AccessPointOperationStatusCode::Succeeded;
 
     return status;
 }
@@ -322,15 +321,14 @@ AccessPointControllerLinux::SetProtocol(Ieee80211Protocol ieeeProtocol)
 AccessPointOperationStatus
 AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands)
 {
-    static constexpr auto FailureFormat = "Setting frequency bands for interface {} failed ({})";
-
-    AccessPointOperationStatus status{};
+    AccessPointOperationStatus status{ GetInterfaceName() };
+    AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
 
     // Ensure at least one band is requested.
     if (std::empty(frequencyBands)) {
         status.Code = AccessPointOperationStatusCode::InvalidParameter;
-        status.Message = std::format(FailureFormat, GetInterfaceName(), "No frequency bands specified");
-        LOGW << status.Message;
+        status.Details = "no frequency bands specified";
+        logStatusOnExit.SeverityOnError = plog::Severity::warning;
         return status;
     }
 
@@ -357,10 +355,8 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
     }
 
     if (!hostapdOperationSucceeded) {
-        errorDetails = std::format("failed to set hostapd property '{}' to '{}' - {}", propertyKeyToSet, propertyValueToSet, errorDetails.value_or("unspecified error"));
         status.Code = AccessPointOperationStatusCode::InternalError;
-        status.Message = std::format(FailureFormat, GetInterfaceName(), errorDetails.value());
-        LOGE << status.Message;
+        status.Details = std::format("failed to set hostapd property '{}' to '{}' - {}", propertyKeyToSet, propertyValueToSet, errorDetails.value_or("unspecified error"));
         return status;
     }
 
@@ -373,15 +369,12 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
     }
 
     if (!hostapdOperationSucceeded) {
-        errorDetails = std::format("failed to reload hostapd configuration - {}", errorDetails.value_or("unspecified error"));
         status.Code = AccessPointOperationStatusCode::InternalError;
-        status.Message = std::format(FailureFormat, GetInterfaceName(), errorDetails.value());
-        LOGE << status.Message;
+        status.Details = std::format("failed to reload hostapd configuration - {}", errorDetails.value_or("unspecified error"));
         return status;
     }
 
     status.Code = AccessPointOperationStatusCode::Succeeded;
-    LOGD << std::format("Set frequency bands for interface {}", GetInterfaceName());
 
     return status;
 }
@@ -389,49 +382,49 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
 AccessPointOperationStatus
 AccessPointControllerLinux::SetSssid(std::string_view ssid)
 {
-    AccessPointOperationStatus status{};
+    AccessPointOperationStatus status{ GetInterfaceName() };
+    const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
 
     // Ensure the ssid is not empty.
     if (std::empty(ssid)) {
         status.Code = AccessPointOperationStatusCode::InvalidParameter;
-        status.Message = "SSID cannot be empty";
-        LOGE << std::format("No SSID specified for interface {}", GetInterfaceName());
+        status.Details = "empty SSID specified";
         return status;
     }
 
+    bool hostapdOperationSucceeded{ false };
+    std::optional<std::string> errorDetails{};
+
     // Attempt to set the SSID.
     try {
-        const bool propertyWasSet = m_hostapd.SetProperty(Wpa::ProtocolHostapd::PropertyNameSsid, ssid);
-        if (!propertyWasSet) {
-            LOGE << std::format("Failed to set SSID '{}' for interface {} (rejected)", ssid, GetInterfaceName());
-            status.Code = AccessPointOperationStatusCode::InternalError;
-            status.Message = std::format("Access point rejected SSID value '{}'", ssid);
-            return status;
-        }
+        hostapdOperationSucceeded = m_hostapd.SetProperty(Wpa::ProtocolHostapd::PropertyNameSsid, ssid);
     } catch (Wpa::HostapdException& ex) {
-        LOGE << std::format("Failed to set SSID '{}' for interface {} ({})", ssid, GetInterfaceName(), ex.what());
+        hostapdOperationSucceeded = false;
+        errorDetails = ex.what();
+    }
+
+    if (!hostapdOperationSucceeded) {
         status.Code = AccessPointOperationStatusCode::InternalError;
-        status.Message = ex.what();
+        status.Details = std::format("failed to set 'ssid' property to {} - {}", ssid, errorDetails.value_or("unspecified error"));
         return status;
     }
 
     // Reload the configuration to pick up the changes.
     try {
-        const bool reloaded = m_hostapd.Reload();
-        if (!reloaded) {
-            LOGE << std::format("Failed to set SSID '{}' for interface {} (configuration reload failed)", ssid, GetInterfaceName());
-            status.Code = AccessPointOperationStatusCode::InternalError;
-            status.Message = "Failed to reload access point configuration";
-            return status;
-        }
+        hostapdOperationSucceeded = m_hostapd.Reload();
     } catch (Wpa::HostapdException& ex) {
-        LOGE << std::format("Failed to set SSID '{}' for interface {} ({})", ssid, GetInterfaceName(), ex.what());
+        hostapdOperationSucceeded = false;
+        errorDetails = ex.what();
+    }
+
+    if (!hostapdOperationSucceeded) {
         status.Code = AccessPointOperationStatusCode::InternalError;
-        status.Message = ex.what();
+        status.Details = "failed to reload access point configuration";
         return status;
     }
 
-    return AccessPointOperationStatus::MakeSucceeded();
+    status.Code = AccessPointOperationStatusCode::Succeeded;
+    return status;
 }
 
 std::unique_ptr<IAccessPointController>

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(${PROJECT_NAME}-test-unit
         ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteServer.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteServiceClient.cxx
         ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteDataStreamingServiceClient.cxx
+        ${CMAKE_CURRENT_LIST_DIR}/TestNetRemoteDataStreamingReactors.cxx
 )
 
 target_link_libraries(${PROJECT_NAME}-test-unit

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -1,0 +1,60 @@
+
+#include "TestNetRemoteDataStreamingReactors.hxx"
+
+using namespace Microsoft::Net::Remote::Service;
+using namespace Microsoft::Net::Remote::Test;
+using namespace Microsoft::Net::Remote::Wifi;
+
+DataStreamWriter::DataStreamWriter(NetRemoteDataStreaming::Stub* client, uint32_t numberOfDataBlocksToWrite) :
+    m_numberOfDataBlocksToWrite(numberOfDataBlocksToWrite)
+{
+    client->async()->WifiDataStreamUpload(&m_clientContext, &m_result, this);
+    StartCall();
+    NextWrite();
+}
+
+void
+DataStreamWriter::OnWriteDone(bool isOk)
+{
+    if (isOk) {
+        NextWrite();
+    } else {
+        StartWritesDone();
+    }
+}
+
+void
+DataStreamWriter::OnDone(const grpc::Status& status)
+{
+    std::unique_lock lock(m_writeStatusGate);
+
+    m_status = status;
+    m_done = true;
+    m_writesDone.notify_one();
+}
+
+grpc::Status
+DataStreamWriter::Await(WifiDataStreamUploadResult* result)
+{
+    std::unique_lock lock(m_writeStatusGate);
+    static constexpr auto timeoutValue = std::chrono::seconds(10);
+
+    m_writesDone.wait_for(lock, timeoutValue, [this] {
+        return m_done;
+    });
+    *result = m_result;
+
+    return m_status;
+}
+
+void
+DataStreamWriter::NextWrite()
+{
+    if (m_numberOfDataBlocksToWrite > 0) {
+        m_data.set_data(std::format("Data #{}", ++m_numberOfDataBlocksWritten));
+        StartWrite(&m_data);
+        m_numberOfDataBlocksToWrite--;
+    } else {
+        StartWritesDone();
+    }
+}

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -1,14 +1,14 @@
 
 #include "TestNetRemoteDataStreamingReactors.hxx"
 
+using namespace Microsoft::Net::Remote::DataStream;
 using namespace Microsoft::Net::Remote::Service;
 using namespace Microsoft::Net::Remote::Test;
-using namespace Microsoft::Net::Remote::Wifi;
 
 DataStreamWriter::DataStreamWriter(NetRemoteDataStreaming::Stub* client, uint32_t numberOfDataBlocksToWrite) :
     m_numberOfDataBlocksToWrite(numberOfDataBlocksToWrite)
 {
-    client->async()->WifiDataStreamUpload(&m_clientContext, &m_result, this);
+    client->async()->DataStreamUpload(&m_clientContext, &m_result, this);
     StartCall();
     NextWrite();
 }
@@ -34,7 +34,7 @@ DataStreamWriter::OnDone(const grpc::Status& status)
 }
 
 grpc::Status
-DataStreamWriter::Await(WifiDataStreamUploadResult* result)
+DataStreamWriter::Await(DataStreamUploadResult* result)
 {
     std::unique_lock lock(m_writeStatusGate);
     static constexpr auto timeoutValue = std::chrono::seconds(10);

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -15,7 +15,7 @@ using namespace std::chrono_literals;
  * @brief Implementation of the gRPC ClientWriteReactor for client-side data stream writing.
  */
 class DataStreamWriter :
-    public grpc::ClientWriteReactor<Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData>
+    public grpc::ClientWriteReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData>
 {
 public:
     /**
@@ -49,7 +49,7 @@ public:
      * @return grpc::Status
      */
     grpc::Status
-    Await(Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* result);
+    Await(Microsoft::Net::Remote::DataStream::DataStreamUploadResult* result);
 
 private:
     /**
@@ -60,8 +60,8 @@ private:
 
 private:
     grpc::ClientContext m_clientContext{};
-    Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData m_data{};
-    Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult m_result{};
+    Microsoft::Net::Remote::DataStream::DataStreamUploadData m_data{};
+    Microsoft::Net::Remote::DataStream::DataStreamUploadResult m_result{};
     uint32_t m_numberOfDataBlocksToWrite{};
     uint32_t m_numberOfDataBlocksWritten{};
     grpc::Status m_status{};

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -1,0 +1,75 @@
+
+#ifndef TEST_NET_REMOTE_DATA_STREAMING_REACTORS_HXX
+#define TEST_NET_REMOTE_DATA_STREAMING_REACTORS_HXX
+
+#include <condition_variable>
+#include <mutex>
+
+#include <microsoft/net/remote/protocol/NetRemoteDataStreamingService.grpc.pb.h>
+
+namespace Microsoft::Net::Remote::Test
+{
+using namespace std::chrono_literals;
+
+/**
+ * @brief Implementation of the gRPC ClientWriteReactor for client-side data stream writing.
+ */
+class DataStreamWriter :
+    public grpc::ClientWriteReactor<Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData>
+{
+public:
+    /**
+     * @brief Construct a new DataStreamWriter object with the client stub and specified number of data blocks to write.
+     *
+     * @param client The data streaming client stub.
+     * @param numberOfDataBlocksToWrite The number of data blocks to write.
+     */
+    explicit DataStreamWriter(Microsoft::Net::Remote::Service::NetRemoteDataStreaming::Stub* client, uint32_t numberOfDataBlocksToWrite);
+
+    /**
+     * @brief Callback that is executed when a write operation is completed.
+     *
+     * @param isOk Indicates whether a write was successfully sent.
+     */
+    void
+    OnWriteDone(bool isOk) override;
+
+    /**
+     * @brief Callback that is executed when all RPC operations are completed for a given RPC.
+     *
+     * @param status The status of the RPC sent by the server or provided by the library to indicate a failure.
+     */
+    void
+    OnDone(const grpc::Status& status) override;
+
+    /**
+     * @brief Wait for all operations to complete and transfer the result to the specific result output parameter.
+     *
+     * @param result The result of the data stream write operation.
+     * @return grpc::Status
+     */
+    grpc::Status
+    Await(Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult* result);
+
+private:
+    /**
+     * @brief Facilitate the next write operation.
+     */
+    void
+    NextWrite();
+
+private:
+    grpc::ClientContext m_clientContext{};
+    Microsoft::Net::Remote::Wifi::WifiDataStreamUploadData m_data{};
+    Microsoft::Net::Remote::Wifi::WifiDataStreamUploadResult m_result{};
+    uint32_t m_numberOfDataBlocksToWrite{};
+    uint32_t m_numberOfDataBlocksWritten{};
+    grpc::Status m_status{};
+    std::mutex m_writeStatusGate{};
+    std::condition_variable m_writesDone{};
+    bool m_done{ false };
+};
+
+} // namespace Microsoft::Net::Remote::Test
+
+#endif // TEST_NET_REMOTE_DATA_STREAMING_REACTORS_HXX

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -99,9 +99,10 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
         bool m_done{ false };
     };
 
+    static constexpr auto numberOfDataBlocksToWrite = 10;
+
     SECTION("Can be called with one client")
     {
-        static constexpr auto numberOfDataBlocksToWrite = 10;
         auto dataStreamWriter = std::make_unique<DataStreamWriter>(client.get(), numberOfDataBlocksToWrite);
 
         WifiDataStreamUploadResult result{};
@@ -113,7 +114,6 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
 
     SECTION("Can be called with multiple parallel clients")
     {
-        static constexpr auto numberOfDataBlocksToWrite = 10;
         static constexpr auto numberOfClients = 5;
 
         std::vector<std::unique_ptr<NetRemoteDataStreaming::Stub>> dataStreamingClients;

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -12,7 +12,7 @@
 
 #include "TestNetRemoteCommon.hxx"
 
-TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote]")
+TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote][stream]")
 {
     using namespace Microsoft::Net::Remote;
     using namespace Microsoft::Net::Remote::Service;

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -13,11 +13,11 @@
 #include "TestNetRemoteCommon.hxx"
 #include "TestNetRemoteDataStreamingReactors.hxx"
 
-TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote][stream]")
+TEST_CASE("DataStreamUpload API", "[basic][rpc][client][remote][stream]")
 {
     using namespace Microsoft::Net::Remote;
+    using namespace Microsoft::Net::Remote::DataStream;
     using namespace Microsoft::Net::Remote::Service;
-    using namespace Microsoft::Net::Remote::Wifi;
 
     using Microsoft::Net::Remote::Test::DataStreamWriter;
     using Microsoft::Net::Remote::Test::RemoteServiceAddressHttp;
@@ -38,11 +38,11 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote][stream]")
     {
         auto dataStreamWriter = std::make_unique<DataStreamWriter>(client.get(), numberOfDataBlocksToWrite);
 
-        WifiDataStreamUploadResult result{};
+        DataStreamUploadResult result{};
         grpc::Status status = dataStreamWriter->Await(&result);
         REQUIRE(status.ok());
         REQUIRE(result.numberofdatablocksreceived() == numberOfDataBlocksToWrite);
-        REQUIRE(result.status().code() == WifiDataStreamOperationStatusCodeSucceeded);
+        REQUIRE(result.status().code() == DataStreamOperationStatusCodeSucceeded);
     }
 
     SECTION("Can be called with multiple parallel clients")
@@ -57,11 +57,11 @@ TEST_CASE("WifiDataStreamUpload API", "[basic][rpc][client][remote][stream]")
             auto dataStreamWriter = std::make_unique<DataStreamWriter>(dataStreamingClients.back().get(), numberOfDataBlocksToWrite);
 
             clientThreads.emplace_back([dataStreamWriter = std::move(dataStreamWriter)]() {
-                WifiDataStreamUploadResult result{};
+                DataStreamUploadResult result{};
                 grpc::Status status = dataStreamWriter->Await(&result);
                 REQUIRE(status.ok());
                 REQUIRE(result.numberofdatablocksreceived() == numberOfDataBlocksToWrite);
-                REQUIRE(result.status().code() == WifiDataStreamOperationStatusCodeSucceeded);
+                REQUIRE(result.status().code() == DataStreamOperationStatusCodeSucceeded);
             });
         }
     }

--- a/tests/unit/wifi/core/CMakeLists.txt
+++ b/tests/unit/wifi/core/CMakeLists.txt
@@ -3,7 +3,9 @@ add_executable(wifi-core-test-unit)
 
 target_sources(wifi-core-test-unit
     PRIVATE
+        Main.cxx
         TestAccessPoint.cxx
+        TestAccessPointOperationStatus.cxx
         TestIeee80211.cxx
 )
 
@@ -14,8 +16,9 @@ target_include_directories(wifi-core-test-unit
 
 target_link_libraries(wifi-core-test-unit
     PRIVATE
-        Catch2::Catch2WithMain
+        Catch2::Catch2
         magic_enum::magic_enum
+        plog::plog
         strings
         wifi-core
         wifi-test-helpers

--- a/tests/unit/wifi/core/Main.cxx
+++ b/tests/unit/wifi/core/Main.cxx
@@ -1,0 +1,16 @@
+
+#include <catch2/catch_session.hpp>
+#include <plog/Appenders/ColorConsoleAppender.h>
+#include <plog/Formatters/MessageOnlyFormatter.h>
+#include <plog/Init.h>
+#include <plog/Severity.h>
+
+int
+main(int argc, char* argv[])
+{
+    static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
+
+    plog::init(plog::verbose, &colorConsoleAppender);
+
+    return Catch::Session().run(argc, argv);
+}

--- a/tests/unit/wifi/core/TestAccessPointOperationStatus.cxx
+++ b/tests/unit/wifi/core/TestAccessPointOperationStatus.cxx
@@ -1,0 +1,239 @@
+
+#include <optional>
+
+#include <catch2/catch_test_macros.hpp>
+#include <magic_enum.hpp>
+#include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
+#include <plog/Log.h>
+#include <plog/Severity.h>
+
+namespace Microsoft::Net::Wifi::Test
+{
+static constexpr auto AccessPointId{ "AP1" };
+static constexpr auto OperationName{ "Operation1" };
+static constexpr auto Details{ "Details1" };
+} // namespace Microsoft::Net::Wifi::Test
+
+TEST_CASE("Create an AccessPointOperationStatus instance", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("Create with args {accessPointId} doesn't cause a crash")
+    {
+        std::optional<AccessPointOperationStatus> status;
+        REQUIRE_NOTHROW(status.emplace(AccessPointId));
+    }
+
+    SECTION("Create with args {accessPointId,operationName} doesn't cause a crash")
+    {
+        std::optional<AccessPointOperationStatus> status;
+        REQUIRE_NOTHROW(status.emplace(AccessPointId, OperationName));
+    }
+
+    SECTION("Create with args {accessPointId,operationName,code[*]} doesn't cause a crash")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            std::optional<AccessPointOperationStatus> status;
+            REQUIRE_NOTHROW(status.emplace(AccessPointId, OperationName, statusCode));
+        }
+    }
+
+    SECTION("Create with args {accessPointId,operationName,code[*],details} doesn't cause a crash")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            std::optional<AccessPointOperationStatus> status;
+            REQUIRE_NOTHROW(status.emplace(AccessPointId, OperationName, statusCode, Details));
+        }
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus instance reflects basic properties", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("AccessPointId reflects the value passed to the constructor")
+    {
+        AccessPointOperationStatus status{ AccessPointId };
+        REQUIRE(status.AccessPointId == AccessPointId);
+    }
+
+    SECTION("OperationName reflects the value passed to the constructor")
+    {
+        AccessPointOperationStatus status{ AccessPointId, OperationName };
+        REQUIRE(status.OperationName == OperationName);
+    }
+
+    SECTION("Code reflects the value passed to the constructor")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            AccessPointOperationStatus status{ AccessPointId, OperationName, statusCode };
+            REQUIRE(status.Code == statusCode);
+        }
+    }
+
+    SECTION("Details reflects the value passed to the constructor")
+    {
+        AccessPointOperationStatus status{ AccessPointId, OperationName, AccessPointOperationStatusCode::Succeeded, Details };
+        REQUIRE(status.Details == Details);
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus instance reflects function name on empty operation name", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("OperationName reflects the function name when empty")
+    {
+        const AccessPointOperationStatus status{ AccessPointId };
+        REQUIRE(status.OperationName.contains(__func__)); // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+    }
+
+    SECTION("OperationName does not reflect the function name when non-empty")
+    {
+        const AccessPointOperationStatus status{ AccessPointId, OperationName };
+        REQUIRE_FALSE(status.OperationName.contains(__func__)); // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus::MakeSucceeded returns a status with the correct code", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("MakeSucceeded returns a status with the Succeeded code")
+    {
+        const auto status = AccessPointOperationStatus::MakeSucceeded(AccessPointId);
+        REQUIRE(status.Code == AccessPointOperationStatusCode::Succeeded);
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus::MakeSucceeded returns a status with the correct operation name", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("Returns a status with the calling function name when operation name is not specified")
+    {
+        const auto status = AccessPointOperationStatus::MakeSucceeded(AccessPointId);
+        REQUIRE(status.OperationName.contains(__func__)); // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+    }
+
+    SECTION("Returns a status wihout the calling function name when operation name is specified")
+    {
+        const auto status = AccessPointOperationStatus::MakeSucceeded(AccessPointId, OperationName);
+        REQUIRE(status.OperationName == OperationName);
+        REQUIRE_FALSE(status.OperationName.contains(__func__)); // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus::Succeeded() reflects the status code", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("Returns 'true' for a status with the Succeeded code")
+    {
+        const auto status = AccessPointOperationStatus::MakeSucceeded(AccessPointId);
+        REQUIRE(status.Succeeded());
+    }
+
+    SECTION("Returns 'false' for a status with a code other than Succeeded")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            if (statusCode != AccessPointOperationStatusCode::Succeeded) {
+                const auto status = AccessPointOperationStatus{ AccessPointId, OperationName, statusCode };
+                REQUIRE_FALSE(status.Succeeded());
+            }
+        }
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus::Failed() reflects the status code", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("Returns 'true' for a status with a code other than Succeeded")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            if (statusCode != AccessPointOperationStatusCode::Succeeded) {
+                const auto status = AccessPointOperationStatus{ AccessPointId, OperationName, statusCode };
+                REQUIRE(status.Failed());
+            }
+        }
+    }
+
+    SECTION("Returns 'false' for a status with the Succeeded code")
+    {
+        const auto status = AccessPointOperationStatus::MakeSucceeded(AccessPointId);
+        REQUIRE_FALSE(status.Failed());
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus::ToString() includes all properties", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("Returns a string with all properties when created with constructor")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            const auto status = AccessPointOperationStatus{ AccessPointId, OperationName, statusCode, Details };
+            const auto statusMessage = status.ToString();
+            REQUIRE(statusMessage.contains(AccessPointId));
+            REQUIRE(statusMessage.contains(OperationName));
+            REQUIRE(statusMessage.contains(Details));
+            if (statusCode != AccessPointOperationStatusCode::Succeeded) {
+                REQUIRE(statusMessage.contains(magic_enum::enum_name(statusCode)));
+            }
+        }
+    }
+
+    SECTION("Returns a string with all properties when created with MakeSucceeded with explicit operation name")
+    {
+        const auto status = AccessPointOperationStatus::MakeSucceeded(AccessPointId, OperationName);
+        const auto statusMessage = status.ToString();
+        REQUIRE(statusMessage.contains(AccessPointId));
+        REQUIRE(statusMessage.contains(OperationName));
+
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            if (statusCode != AccessPointOperationStatusCode::Succeeded) {
+                REQUIRE_FALSE(statusMessage.contains(magic_enum::enum_name(statusCode)));
+            }
+        }
+    }
+
+    SECTION("Returns a string with all properties when created with MakeSucceeded without explicit operation name")
+    {
+        const auto status = AccessPointOperationStatus::MakeSucceeded(AccessPointId);
+        const auto statusMessage = status.ToString();
+        REQUIRE(statusMessage.contains(AccessPointId));
+        REQUIRE(statusMessage.contains(__func__)); // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            if (statusCode != AccessPointOperationStatusCode::Succeeded) {
+                REQUIRE_FALSE(statusMessage.contains(magic_enum::enum_name(statusCode)));
+            }
+        }
+    }
+}
+
+TEST_CASE("AccessPointOperationStatus::ToString() result can be printed", "[wifi][core][ap][log]")
+{
+    using namespace Microsoft::Net::Wifi;
+    using namespace Microsoft::Net::Wifi::Test;
+
+    SECTION("Returns a string with all properties")
+    {
+        for (const auto statusCode : magic_enum::enum_values<AccessPointOperationStatusCode>()) {
+            const auto status = AccessPointOperationStatus{ AccessPointId, OperationName, statusCode, Details };
+            const auto logSeverity = status.Succeeded() ? plog::debug : plog::error;
+            REQUIRE_NOTHROW([&]() {
+                LOG(logSeverity) << status.ToString();
+            }());
+        }
+    }
+}

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -15,7 +15,6 @@
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
 #include <microsoft/net/wifi/test/AccessPointControllerTest.hxx>
 #include <microsoft/net/wifi/test/AccessPointTest.hxx>
-#include <plog/Log.h>
 
 using namespace Microsoft::Net::Wifi;
 using namespace Microsoft::Net::Wifi::Test;
@@ -42,7 +41,7 @@ AccessPointControllerTest::GetOperationalState(AccessPointOperationalState &oper
     }
 
     operationalState = AccessPoint->OperationalState;
-    return AccessPointOperationStatus::MakeSucceeded();
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 
 AccessPointOperationStatus
@@ -53,7 +52,7 @@ AccessPointControllerTest::GetCapabilities(Ieee80211AccessPointCapabilities &iee
     }
 
     ieee80211AccessPointCapabilities = AccessPoint->Capabilities;
-    return AccessPointOperationStatus::MakeSucceeded();
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 
 AccessPointOperationStatus
@@ -64,7 +63,7 @@ AccessPointControllerTest::SetOperationalState(AccessPointOperationalState opera
     }
 
     AccessPoint->OperationalState = operationalState;
-    return AccessPointOperationStatus::MakeSucceeded();
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 
 AccessPointOperationStatus
@@ -75,7 +74,7 @@ AccessPointControllerTest::SetProtocol(Ieee80211Protocol ieeeProtocol)
     }
 
     AccessPoint->Protocol = ieeeProtocol;
-    return AccessPointOperationStatus::MakeSucceeded();
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 
 AccessPointOperationStatus
@@ -88,6 +87,8 @@ AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand>
     for (const auto &frequencyBandToSet : frequencyBands) {
         if (std::ranges::find(AccessPoint->Capabilities.FrequencyBands, frequencyBandToSet) == std::cend(AccessPoint->Capabilities.FrequencyBands)) {
             return {
+                AccessPoint->InterfaceName,
+                {},
                 AccessPointOperationStatusCode::InvalidParameter,
                 std::format("AccessPointControllerTest::SetFrequencyBands called with unsupported frequency band {}", magic_enum::enum_name(frequencyBandToSet))
             };
@@ -95,7 +96,7 @@ AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand>
     }
 
     AccessPoint->FrequencyBands = std::move(frequencyBands);
-    return AccessPointOperationStatus::MakeSucceeded();
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 
 AccessPointOperationStatus
@@ -106,7 +107,7 @@ AccessPointControllerTest::SetSssid(std::string_view ssid)
     }
 
     AccessPoint->Ssid = ssid;
-    return AccessPointOperationStatus::MakeSucceeded();
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 
 AccessPointControllerFactoryTest::AccessPointControllerFactoryTest(AccessPointTest *accessPoint) :


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

Addresses review comments before `feature/dataStreaming` merges into `develop`.

### Technical Details

* Improve unit test code.
* Move test client reactor into separate files.
* Move data streaming RPC and data types out of Wi-Fi and into own protocol.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

* Avoid manual memory management for `ServerReadReactor`.
* Add tracing (`NetRemoteDataStreamApiTrace`).

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
