### PR TITLE
Add basic API trace

### DIFF
--- a/src/common/service/NetRemoteDataStreamingService.cxx
+++ b/src/common/service/NetRemoteDataStreamingService.cxx
@@ -1,12 +1,16 @@
 
+#include "NetRemoteApiTrace.hxx"
 #include "NetRemoteDataStreamingReactors.hxx"
 #include <microsoft/net/remote/NetRemoteDataStreamingService.hxx>
 
 using namespace Microsoft::Net::Remote::DataStream;
 using namespace Microsoft::Net::Remote::Service;
+using namespace Microsoft::Net::Remote::Service::Tracing;
 
 grpc::ServerReadReactor<DataStreamUploadData>*
 NetRemoteDataStreamingService::DataStreamUpload([[maybe_unused]] grpc::CallbackServerContext* context, DataStreamUploadResult* result)
 {
+    const NetRemoteApiTrace traceMe{};
+
     return new Reactors::DataStreamReader(result);
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

Add tracing to data streaming API.

### Technical Details

* Add usage of `NetRemoteApiTrace` to `DataStreamUpload` API.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

Ideally, more advanced tracing specific to data streaming (like `NetRemoteWifiApiTrace` for Wi-Fi) would be added. However, since the `DataStreamUpload` API (and future APIs) pass most of the handling to the appropriate Reactor, the API tracing doesn't really do much.

Could perhaps add tracing within the reactor classes themselves.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
