### PR TITLE
Update Docker file for package-based LLVM/Clang install

### DIFF
--- a/.docker/netremote-dev/Dockerfile
+++ b/.docker/netremote-dev/Dockerfile
@@ -19,10 +19,10 @@ LABEL org.label-schema.schema-version = "1.0"
 #############################
 #
 # 1. Update package cache.
-# sudo apt-get update
+# sudo apt -y update && sudo apt -y upgrade
 #
 # 2. Install core build tools and dependencies:
-# sudo apt-get install -y --no-install-recommends build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip libnl-3-200-dbg libnl-3-dev libssl-dev libnl-genl-3-dev libdbus-c++-dev libnl-route-3-dev
+# sudo apt install -y --no-install-recommends build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip libnl-3-200-dbg libnl-3-dev libssl-dev libnl-genl-3-dev libdbus-c++-dev libnl-route-3-dev
 #
 # 3. Install complete LLVM 17  + clang 17 toolchain:
 # sudo apt install -y --no-install-recommends libllvm-17-ocaml-dev libllvm17 llvm-17 llvm-17-dev llvm-17-doc llvm-17-examples llvm-17-runtime clang-17 clang-tools-17 clang-17-doc libclang-common-17-dev libclang-17-dev libclang1-17 clang-format-17 python3-clang-17 clangd-17 clang-tidy-17 libclang-rt-17-dev libpolly-17-dev libfuzzer-17-dev lldb-17 lld-17 libc++-17-dev libc++abi-17-dev libomp-17-dev libclc-17-dev libunwind-17-dev libmlir-17-dev mlir-17-tools libbolt-17-dev bolt-17 flang-17 libclang-rt-17-dev-wasm32 libclang-rt-17-dev-wasm64 libc++-17-dev-wasm32 libc++abi-17-dev-wasm32 libclang-rt-17-dev-wasm32 libclang-rt-17-dev-wasm64
@@ -31,12 +31,13 @@ LABEL org.label-schema.schema-version = "1.0"
 # sudo apt install -y --no-install-recommends bc bison dwarves flex libelf-dev dos2unix file gnupg2 iproute2 mtools neofetch rsync ssh sudo emacs gdb kmod nano policycoreutils-python-utils python-is-python3 vim
 #
 # 5. Install hostapd development dependencies:
-# sudo apt-get install -y libnl-3-dev libssl-dev libnl-genl-3-dev libnl-3-dev libdbus-c++-dev libnl-route-3-dev flex bison dwarves libelf-dev bc
+# sudo apt install -y libnl-3-dev libssl-dev libnl-genl-3-dev libnl-3-dev libdbus-c++-dev libnl-route-3-dev flex bison dwarves libelf-dev bc
 #
 
 # Install packages.
-RUN apt-get update && \
-    apt-get install -qq -y --no-install-recommends \
+RUN apt -y update && \
+    apt -y upgrade && \
+    apt install -qq -y --no-install-recommends \
         # Core project build dependencies.
         # build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip
         build-essential \
@@ -103,7 +104,7 @@ RUN apt-get update && \
         libnl-route-3-dev
 
 # Reduce image size by removing package cache
-RUN apt-get clean && \
+RUN apt clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Set environment variables for external vcpkg to support binary caching
@@ -132,8 +133,8 @@ ENTRYPOINT [ "/bin/entrypoint-build.sh" ]
 FROM netremote-build as netremote-dev
 
 # Install packages.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt update && \
+    apt install -y --no-install-recommends \
         # WSL2 kernel development dependencies.
         # build-essential flex bison dwarves libssl-dev libelf-dev bc
         bc \
@@ -163,7 +164,7 @@ RUN apt-get update && \
         vim \
         && \
     # Reduce image size by removing package cache.
-    apt-get clean && \
+    apt clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy outside content into container.

--- a/.docker/netremote-dev/Dockerfile
+++ b/.docker/netremote-dev/Dockerfile
@@ -24,18 +24,14 @@ LABEL org.label-schema.schema-version = "1.0"
 # 2. Install core build tools and dependencies:
 # sudo apt-get install -y --no-install-recommends build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip libnl-3-200-dbg libnl-3-dev libssl-dev libnl-genl-3-dev libdbus-c++-dev libnl-route-3-dev
 #
-# 3. Remove llvm 16 toolchain packages to avoid conflicts with llvm 17 toolchain.
-# sudo apt-get remove -y --purge clang-16* lldb-16* llvm-16*
+# 3. Install complete LLVM 17  + clang 17 toolchain:
+# sudo apt install -y --no-install-recommends libllvm-17-ocaml-dev libllvm17 llvm-17 llvm-17-dev llvm-17-doc llvm-17-examples llvm-17-runtime clang-17 clang-tools-17 clang-17-doc libclang-common-17-dev libclang-17-dev libclang1-17 clang-format-17 python3-clang-17 clangd-17 clang-tidy-17 libclang-rt-17-dev libpolly-17-dev libfuzzer-17-dev lldb-17 lld-17 libc++-17-dev libc++abi-17-dev libomp-17-dev libclc-17-dev libunwind-17-dev libmlir-17-dev mlir-17-tools libbolt-17-dev bolt-17 flang-17 libclang-rt-17-dev-wasm32 libclang-rt-17-dev-wasm64 libc++-17-dev-wasm32 libc++abi-17-dev-wasm32 libclang-rt-17-dev-wasm32 libclang-rt-17-dev-wasm64
 # 
-# 4. Install complete llvm toolchain using automatic installation script:
-# sudo apt-get install -y --no-install-recommends lsb-release software-properties-common wget
-# wget https://apt.llvm.org/llvm.sh
-# chmod +x llvm.sh
-# sudo ./llvm.sh 17 all
-# rm llvm.sh
+# 4. Install other development dependencies and helpful tools:
+# sudo apt install -y --no-install-recommends bc bison dwarves flex libelf-dev dos2unix file gnupg2 iproute2 mtools neofetch rsync ssh sudo emacs gdb kmod nano policycoreutils-python-utils python-is-python3 vim
 #
-# 5. Install development dependency packages:
-# sudo apt-get install -y --no-install-recommends bc bison dwarves flex libelf-dev dos2unix file gnupg2 iproute2 mtools neofetch rsync ssh sudo emacs gdb kmod nano policycoreutils-python-utils python-is-python3 vim
+# 5. Install hostapd development dependencies:
+# sudo apt-get install -y libnl-3-dev libssl-dev libnl-genl-3-dev libnl-3-dev libdbus-c++-dev libnl-route-3-dev flex bison dwarves libelf-dev bc
 #
 
 # Install packages.
@@ -56,6 +52,45 @@ RUN apt-get update && \
         tar \
         unzip \
         zip \
+        # LLVM + Clang toolchain.
+        libllvm-17-ocaml-dev \
+        libllvm17 \
+        llvm-17 \
+        llvm-17-dev \
+        llvm-17-doc \
+        llvm-17-examples \
+        llvm-17-runtime \
+        clang-17 \
+        clang-tools-17 \
+        clang-17-doc \
+        libclang-common-17-dev \
+        libclang-17-dev \
+        libclang1-17 \
+        clang-format-17 \
+        python3-clang-17 \
+        clangd-17 \
+        clang-tidy-17 \
+        libclang-rt-17-dev \
+        libpolly-17-dev \
+        libfuzzer-17-dev \
+        lldb-17 \
+        lld-17 \
+        libc++-17-dev \
+        libc++abi-17-dev \
+        libomp-17-dev \
+        libclc-17-dev \
+        libunwind-17-dev \
+        libmlir-17-dev \
+        mlir-17-tools \
+        libbolt-17-dev \
+        bolt-17 \
+        flang-17 \
+        libclang-rt-17-dev-wasm32 \
+        libclang-rt-17-dev-wasm64 \
+        libc++-17-dev-wasm32 \
+        libc++abi-17-dev-wasm32 \
+        libclang-rt-17-dev-wasm32 \
+        libclang-rt-17-dev-wasm64 \
         # hostapd build dependencies.
         # libnl-3-200-dbg libnl-3-dev libssl-dev libnl-genl-3-dev
         libnl-3-200-dbg \
@@ -66,21 +101,6 @@ RUN apt-get update && \
         # libnl-3-dev libssl-dev libnl-genl-3-dev libdbus-c++-dev libnl-route-3-dev
         libdbus-c++-dev \
         libnl-route-3-dev
-
-# Install complete llvm toolchain using automatic installation script.
-# lsb-release, software-properties-common, and wget are required by the script.
-RUN apt-get install -qq -y --no-install-recommends \
-        lsb-release \
-        software-properties-common \
-        wget && \
-    # Remove llvm 16 toolchain packages to avoid conflicts with llvm 17 toolchain.
-    apt-get remove -y --purge clang-16* lldb-16* llvm-16* && \
-    # Use automatic installation script to install llvm 17 toolchain.
-    wget https://apt.llvm.org/llvm.sh && \
-    chmod +x llvm.sh && \
-    ./llvm.sh ${LLVM_VERSION} all && \
-    # Delete the script.
-    rm llvm.sh
 
 # Reduce image size by removing package cache
 RUN apt-get clean && \

--- a/src/linux/README.md
+++ b/src/linux/README.md
@@ -11,76 +11,85 @@ As described in the main project [`README`](/README.md), a C++ 20 compiler and C
 If development on Windows is desired, ubuntu may be installed in WSL using a rootfs image. To install WSL, on newer versions of Windows 11, use the following command: `wsl --install --no-distribution`. For complete instructions, refer to [https://learn.microsoft.com/en-us/windows/wsl/install](https://learn.microsoft.com/en-us/windows/wsl/install). Then follow these steps to install mantic on WSL:
 
 1. Download the ubuntu 23.10 wsl rootfs archive [https://cloud-images.ubuntu.com/wsl/mantic/current/ubuntu-mantic-wsl-amd64-wsl.rootfs.tar.gz](https://cloud-images.ubuntu.com/wsl/mantic/current/ubuntu-mantic-wsl-amd64-wsl.rootfs.tar.gz).
+
 2. Choose a location to store the WSL ubuntu filesystem image. A good way to keep organized is to use a top-level directory for all wsl filesystem images such as `c:\wsl`, then add a sub-directory for each distribution installed, such as `c:\wsl\mantic`, `c:\wsl\fedora35`, etc. It's also recommended to do this on a non-system drive if one is available for performance reasons.
 
 3. Start an elevated command-prompt, and enter the following series of commands:
 
-```Shell
-mkdir c:\wsl\mantic
-wsl --import mantic c:\wsl\mantic c:\users\myusername\Downloads\ubuntu-mantic-wsl-amd64-wsl.rootfs.tar.gz
-wsl -d mantic
-```
+    ```Shell
+    mkdir c:\wsl\mantic
+    wsl --import mantic c:\wsl\mantic c:\users\myusername\Downloads\ubuntu-mantic-wsl-amd64-wsl.rootfs.tar.gz
+    wsl -d mantic
+    ```
 
 4. You are now running in a root shell on a fresh ubuntu 23.10 installation. Set up a non-root user to use by default:
 
-```bash
-adduser mycoolusername
-# <accept all defaults by successively hitting 'Enter', and set a password>
-usermod -G sudo mycoolusername
-# install an editor if you don't like the ones pre-installed (vi and nano are available out of the box)
-```
+    ```bash
+    adduser mycoolusername
+    # <accept all defaults by successively hitting 'Enter', and set a password>
+    usermod -G sudo mycoolusername
+    # install an editor if you don't like the ones pre-installed (vi and nano are available out of the box)
+    ```
 
 5. Create the file `/etc/wsl.conf` (need sudo), and save the following contents to it:
 
-```ini 
-[user]
-default=mycoolusername
-```
+    ```ini
+    [user]
+    default=mycoolusername
+    ```
 
 6. Exit ubuntu:
 
-```bash
-exit
-```
+    ```bash
+    exit
+    ```
 
 7. Shutdown WSL so it can pick up the new default user changes, and re-run ubuntu:
 
-```Shell
-wsl --shutdown
-wsl -d mantic
-```
+    ```Shell
+    wsl --shutdown
+    wsl -d mantic
+    ```
 
 You should now be logged on as `mycoolusername`.
 
 ### 2. Install Linux Development Dependencies
 
-Execute the following commands in a shell:
+Execute the following commands in a shell to install all the tools required to compile, lint, and debug the project:
 
-```bash
-sudo apt update
-sudo apt-get install -y build-essential ca-certificates cmake curl dotnet7 git gnupg2 linux-libc-dev ninja-build pkg-config tar unzip zip
-```
+1. Update the package cache:
 
-Then remove the pre-installed version of llvm-16, and install llvm-17 with the automated install script:
+    ```bash
+    sudo apt update
+    ```
 
-```bash
-sudo apt-get remove -y --purge clang-16* lldb-16* llvm-16*
-sudo apt-get install -y --no-install-recommends lsb-release software-properties-common wget
-wget https://apt.llvm.org/llvm.sh
-chmod +x llvm.sh
-./llvm.sh 17 all
-rm llvm.sh
-```
+2. Install core build tools and dependencies:
 
-The above will install all the tools required to compile, lint, and debug the project. If hostapd will also be compiled ([git://w1.fi/hostap.git](git://w1.fi/hostap.git)), install the following additional development dependencies:
+    ```bash
+    sudo apt install -y --no-install-recommends build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip libnl-3-200-dbg libnl-3-dev libssl-dev libnl-genl-3-dev libdbus-c++-dev libnl-route-3-dev clang-17 clang-tools-17 clang-format-17 clangd-17 clang-tidy-17 lldb-17 lld-17 libbolt-17-dev bolt-17 libunwind-17-dev
+    ```
 
-```bash
-sudo apt-get install -y libnl-3-dev libssl-dev libnl-genl-3-dev libnl-3-dev libdbus-c++-dev libnl-route-3-dev flex bison dwarves libelf-dev bc
-```
+3. Install LLVM compiler dependencies:
+
+    ```bash
+    sudo apt install -y --no-install-recommends libllvm-17-ocaml-dev libllvm17 llvm-17 llvm-17-dev llvm-17-doc llvm-17-examples llvm-17-runtime clang-17 clang-tools-17 clang-17-doc libclang-common-17-dev libclang-17-dev libclang1-17 clang-format-17 python3-clang-17 clangd-17 clang-tidy-17 libclang-rt-17-dev libpolly-17-dev libfuzzer-17-dev lldb-17 lld-17 libc++-17-dev libc++abi-17-dev libomp-17-dev libclc-17-dev libunwind-17-dev libmlir-17-dev mlir-17-tools libbolt-17-dev bolt-17 flang-17 libclang-rt-17-dev-wasm32 libclang-rt-17-dev-wasm64 libc++-17-dev-wasm32 libc++abi-17-dev-wasm32 libclang-rt-17-dev-wasm32 libclang-rt-17-dev-wasm64
+    ```
+
+4. Install other development dependencies and helpful tools:
+
+    ```bash
+    sudo apt install -y --no-install-recommends bc bison dwarves flex libelf-dev dos2unix file gnupg2 iproute2 mtools neofetch rsync ssh sudo emacs gdb kmod nano policycoreutils-python-utils python-is-python3 vim
+    ```
+
+5. Install [hostapd](git://w1.fi/hostap.git) development dependencies:
+
+    ```bash
+    sudo apt-get install -y libnl-3-dev libssl-dev libnl-genl-3-dev libnl-3-dev libdbus-c++-dev libnl-route-3-dev flex bison dwarves libelf-dev bc
+    ```
 
 > [!NOTE]
 > The source of truth for installing development dependencies is found in the development environment [Dockerfile](/.docker/netremote-dev/Dockerfile). The instructions there always trump the instructions here as the contianer described by the `Dockerfile` is used to build the official package.
 
-### 3. Install Docker on Windows
+### 3. Install Docker on Windows (optional)
 
 Download and install docker from [https://docs.docker.com/desktop/install/windows-install](https://docs.docker.com/desktop/install/windows-install) ([amd64](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe)). During the installation, ensure the `Use WSL 2 instead of Hyper-V (recommended)` box is checked.

--- a/src/linux/README.md
+++ b/src/linux/README.md
@@ -57,10 +57,10 @@ You should now be logged on as `mycoolusername`.
 
 Execute the following commands in a shell to install all the tools required to compile, lint, and debug the project:
 
-1. Update the package cache:
+1. Update the package cache and upgrade to latest packages:
 
     ```bash
-    sudo apt update
+    sudo apt update && sudo apt upgrade
     ```
 
 2. Install core build tools and dependencies:
@@ -84,7 +84,7 @@ Execute the following commands in a shell to install all the tools required to c
 5. Install [hostapd](git://w1.fi/hostap.git) development dependencies:
 
     ```bash
-    sudo apt-get install -y libnl-3-dev libssl-dev libnl-genl-3-dev libnl-3-dev libdbus-c++-dev libnl-route-3-dev flex bison dwarves libelf-dev bc
+    sudo apt install -y libnl-3-dev libssl-dev libnl-genl-3-dev libnl-3-dev libdbus-c++-dev libnl-route-3-dev flex bison dwarves libelf-dev bc
     ```
 
 > [!NOTE]


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [X] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Minimize Docker image build time and simplify server controller setup, taking advantage of LLVM and Clang 17 now being available in the main package repository for Ubuntu 23.10 mantic.

### Technical Details

* Replace manual llvm installation script with use of `clang-*-17` and `llvm-*-17` packages.
* Update Linux `README` for how to set up a development machine using package-based LLVM+Clang installation.
* Fix fenced code appearing in lists in Linux `README`.
* Replace use of `apt-get <command>` with `apt <command>`.
* Ad `apt upgrade` to bring packages to newest versions.

### Test Results

* Built and published both docker images `netremote-build` and netremote-dev` on Windows.
* Set up a new server afresh, followed the Linux `README` instructions by copy-and-pasting the commands, then pulled and built the project successfully.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
