### PR TITLE
Use smart pointers for memory management

### DIFF
--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -40,5 +40,4 @@ DataStreamReader::OnCancel()
 void
 DataStreamReader::OnDone()
 {
-    delete this;
 }

--- a/src/common/service/NetRemoteDataStreamingService.cxx
+++ b/src/common/service/NetRemoteDataStreamingService.cxx
@@ -12,5 +12,7 @@ NetRemoteDataStreamingService::DataStreamUpload([[maybe_unused]] grpc::CallbackS
 {
     const NetRemoteApiTrace traceMe{};
 
-    return new Reactors::DataStreamReader(result);
+    m_dataStreamReaders.push_back(std::make_unique<Reactors::DataStreamReader>(result));
+
+    return m_dataStreamReaders.back().get();
 }

--- a/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
@@ -2,6 +2,8 @@
 #ifndef NET_REMOTE_DATA_STREAMING_SERVICE_HXX
 #define NET_REMOTE_DATA_STREAMING_SERVICE_HXX
 
+#include <vector>
+
 #include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
 #include <microsoft/net/remote/protocol/NetRemoteDataStreamingService.grpc.pb.h>
 
@@ -29,6 +31,9 @@ private:
      */
     grpc::ServerReadReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData>*
     DataStreamUpload(grpc::CallbackServerContext* context, Microsoft::Net::Remote::DataStream::DataStreamUploadResult* result) override;
+
+private:
+    std::vector<std::unique_ptr<grpc::ServerReadReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData>>> m_dataStreamReaders{};
 };
 } // namespace Microsoft::Net::Remote::Service
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

Addresses #179 . Manual memory management with `new` and `delete` should be avoided. Memory should be managed with smart pointers instead.

### Technical Details

* Replace `new` in `DataStreamUpload` implementation and instead use `std::unique_ptr`.
* Remove `delete this` from `DataStreamReader` reactor class `OnDone` callback.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

This currently uses a `std::vector` to store a new reactor for each invocation of `DataStreamUpload` in order to separate clients. However, this would ideally be stored in a `std::unordered_map` instead, with a unique key for each client. Unfortunately, there is no clear way for the service to uniquely identify a client (`context->peer()` returns the same URI for all clients in the unit test).

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
