### PR TITLE
Add initial DataStreamDownload API implementation

### DIFF
--- a/protocol/protos/NetRemoteDataStream.proto
+++ b/protocol/protos/NetRemoteDataStream.proto
@@ -23,8 +23,52 @@ message DataStreamUploadData
     bytes Data = 1;
 }
 
+message DataStreamDownloadData
+{
+    bytes Data = 1;
+    uint32 SequenceNumber = 2;
+    DataStreamOperationStatus Status = 3;
+}
+
 message DataStreamUploadResult
 {
     uint32 NumberOfDataBlocksReceived = 1;
     DataStreamOperationStatus Status = 2;
+}
+
+enum DataStreamType
+{
+    Fixed = 0;
+    Continuous = 1;
+}
+
+enum DataStreamPattern
+{
+    Constant = 0;
+}
+
+message DataStreamFixedTypeProperties
+{
+    uint32 NumberOfDataBlocksToStream = 1;
+}
+
+message DataStreamContinuousTypeProperties
+{
+
+}
+
+message DataStreamProperties
+{
+    DataStreamType Type = 1;
+    DataStreamPattern Pattern = 2;
+    oneof Properties
+    {
+        DataStreamFixedTypeProperties FixedTypeProperties = 3;
+        DataStreamContinuousTypeProperties ContinuousTypeProperties = 4;
+    }
+}
+
+message DataStreamDownloadRequest
+{
+    DataStreamProperties Properties = 1;
 }

--- a/protocol/protos/NetRemoteDataStream.proto
+++ b/protocol/protos/NetRemoteDataStream.proto
@@ -38,13 +38,15 @@ message DataStreamUploadResult
 
 enum DataStreamType
 {
-    Fixed = 0;
-    Continuous = 1;
+    DataStreamTypeUnknown = 0;
+    DataStreamTypeFixed = 1;
+    DataStreamTypeContinuous = 2;
 }
 
 enum DataStreamPattern
 {
-    Constant = 0;
+    DataStreamPatternUnknown = 0;
+    DataStreamPatternConstant = 1;
 }
 
 message DataStreamFixedTypeProperties

--- a/protocol/protos/NetRemoteDataStreamingService.proto
+++ b/protocol/protos/NetRemoteDataStreamingService.proto
@@ -9,4 +9,5 @@ import "NetRemoteDataStream.proto";
 service NetRemoteDataStreaming
 {
     rpc DataStreamUpload (stream Microsoft.Net.Remote.DataStream.DataStreamUploadData) returns (Microsoft.Net.Remote.DataStream.DataStreamUploadResult);
+    rpc DataStreamDownload (Microsoft.Net.Remote.DataStream.DataStreamDownloadRequest) returns (stream Microsoft.Net.Remote.DataStream.DataStreamDownloadData);
 }

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -102,6 +102,8 @@ DataStreamWriter::OnWriteDone(bool isOk)
 void
 DataStreamWriter::OnCancel()
 {
+    // The RPC is cancelled, so call Finish to complete it.
+    Finish(grpc::Status::CANCELLED);
 }
 
 void

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -107,7 +107,7 @@ DataStreamWriter::OnWriteDone(bool isOk)
 void
 DataStreamWriter::OnCancel()
 {
-    // The RPC is cancelled, so call Finish to complete it.
+    // The RPC is cancelled by the client, so call Finish to complete it from the server perspective.
     Finish(grpc::Status::CANCELLED);
 }
 

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -43,6 +43,7 @@ DataStreamReader::OnCancel()
 void
 DataStreamReader::OnDone()
 {
+    delete this;
 }
 
 DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request)
@@ -109,6 +110,7 @@ DataStreamWriter::OnCancel()
 void
 DataStreamWriter::OnDone()
 {
+    delete this;
 }
 
 void

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -45,7 +45,7 @@ DataStreamReader::OnDone()
 DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request)
 {
     m_dataStreamProperties = request->properties();
-    if (m_dataStreamProperties.type() == DataStreamType::Fixed) {
+    if (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeFixed) {
         // TODO: Ensure that m_dataStreamProperties.Value_case() == WifiDataStreamProperties.kFixedTypeProperties
         m_numberOfDataBlocksToStream = m_dataStreamProperties.fixedtypeproperties().numberofdatablockstostream();
     }
@@ -64,7 +64,7 @@ DataStreamWriter::OnWriteDone(bool ok)
     }
 
     if (ok) {
-        if (m_dataStreamProperties.type() == DataStreamType::Fixed) {
+        if (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeFixed) {
             m_numberOfDataBlocksToStream--;
         }
         m_writeStatus.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeSucceeded);
@@ -88,7 +88,7 @@ DataStreamWriter::OnDone()
 void
 DataStreamWriter::NextWrite()
 {
-    if (m_dataStreamProperties.type() == DataStreamType::Continuous || m_numberOfDataBlocksToStream > 0) {
+    if (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeContinuous || m_numberOfDataBlocksToStream > 0) {
         const auto data = std::format("Data #{}", ++m_numberOfDataBlocksWritten);
         m_data.set_data(data);
         m_data.set_sequencenumber(m_numberOfDataBlocksWritten);

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -1,5 +1,8 @@
 
+#include <format>
+
 #include "NetRemoteDataStreamingReactors.hxx"
+#include <magic_enum.hpp>
 
 using namespace Microsoft::Net::Remote::DataStream;
 using namespace Microsoft::Net::Remote::Service::Reactors;
@@ -45,17 +48,37 @@ DataStreamReader::OnDone()
 DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request)
 {
     m_dataStreamProperties = request->properties();
-    if (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeFixed) {
-        // TODO: Ensure that m_dataStreamProperties.Value_case() == WifiDataStreamProperties.kFixedTypeProperties
-        m_numberOfDataBlocksToStream = m_dataStreamProperties.fixedtypeproperties().numberofdatablockstostream();
+
+    switch (m_dataStreamProperties.type()) {
+    case DataStreamType::DataStreamTypeFixed: {
+        if (m_dataStreamProperties.Properties_case() == DataStreamProperties::kFixedTypeProperties) {
+            m_numberOfDataBlocksToStream = m_dataStreamProperties.fixedtypeproperties().numberofdatablockstostream();
+        } else {
+            HandleFailure("Invalid properties for this streaming type. Expected FixedTypeProperties for DataStreamTypeFixed");
+            return;
+        }
     }
+    case DataStreamType::DataStreamTypeContinuous: {
+        if (m_dataStreamProperties.Properties_case() == DataStreamProperties::kContinuousTypeProperties) {
+            m_numberOfDataBlocksToStream = 0;
+        } else {
+            HandleFailure("Invalid properties for this streaming type. Expected ContinuousTypeProperties for DataStreamTypeContinuous");
+            return;
+        }
+    }
+    default: {
+        HandleFailure(std::format("Invalid streaming type: {}", magic_enum::enum_name(m_dataStreamProperties.type())));
+        return;
+    }
+    };
+
     m_writeStatus.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeUnknown);
     m_writeStatus.set_message("No data sent yet");
     NextWrite();
 }
 
 void
-DataStreamWriter::OnWriteDone(bool ok)
+DataStreamWriter::OnWriteDone(bool isOk)
 {
     // Check for a failed status code from HandleWriteFailure since that invoked a final write, thus causing this callback to be invoked.
     if (m_writeStatus.code() == DataStreamOperationStatusCode::DataStreamOperationStatusCodeFailed) {
@@ -63,7 +86,8 @@ DataStreamWriter::OnWriteDone(bool ok)
         return;
     }
 
-    if (ok) {
+    // Continue writing if previous write was successful, otherwise handle the failure.
+    if (isOk) {
         if (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeFixed) {
             m_numberOfDataBlocksToStream--;
         }
@@ -71,7 +95,7 @@ DataStreamWriter::OnWriteDone(bool ok)
         m_writeStatus.set_message("Data write successful");
         NextWrite();
     } else {
-        HandleWriteFailure();
+        HandleFailure("Data write failed");
     }
 }
 
@@ -88,22 +112,30 @@ DataStreamWriter::OnDone()
 void
 DataStreamWriter::NextWrite()
 {
-    if (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeContinuous || m_numberOfDataBlocksToStream > 0) {
+    if (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeContinuous ||
+        (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeFixed && m_numberOfDataBlocksToStream > 0)) {
+        // Create data to write to the client.
         const auto data = std::format("Data #{}", ++m_numberOfDataBlocksWritten);
+
+        // Write data to the client.
         m_data.set_data(data);
         m_data.set_sequencenumber(m_numberOfDataBlocksWritten);
         *m_data.mutable_status() = m_writeStatus;
         StartWrite(&m_data);
     } else {
-        // No more data to write
+        // No more data to write.
         Finish(::grpc::Status::OK);
     }
 }
 
 void
-DataStreamWriter::HandleWriteFailure()
+DataStreamWriter::HandleFailure(const std::string errorMessage)
 {
     m_writeStatus.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeFailed);
-    m_writeStatus.set_message("Data write failed");
+    m_writeStatus.set_message(errorMessage);
+    *m_data.mutable_status() = m_writeStatus;
+
+    // Write a final message to the client. The OnWriteDone() callback will check for the
+    // DataStreamOperationStatusCodeFailed status code set here to know to complete the RPC.
     StartWrite(&m_data);
 }

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -58,6 +58,8 @@ DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request)
             HandleFailure("Invalid properties for this streaming type. Expected FixedTypeProperties for DataStreamTypeFixed");
             return;
         }
+
+        break;
     }
     case DataStreamType::DataStreamTypeContinuous: {
         if (m_dataStreamProperties.Properties_case() == DataStreamProperties::kContinuousTypeProperties) {
@@ -66,6 +68,8 @@ DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request)
             HandleFailure("Invalid properties for this streaming type. Expected ContinuousTypeProperties for DataStreamTypeContinuous");
             return;
         }
+
+        break;
     }
     default: {
         HandleFailure(std::format("Invalid streaming type: {}", magic_enum::enum_name(m_dataStreamProperties.type())));

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -94,7 +94,7 @@ private:
 
     /**
      * @brief Handle a failed operation.
-     * 
+     *
      * @param errorMessage The error message associated with the failed operation.
      */
     void

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -3,6 +3,7 @@
 #define NET_REMOTE_DATA_STREAMING_REACTORS_HXX
 
 #include <cstdint>
+#include <string>
 
 #include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
 #include <microsoft/net/remote/protocol/NetRemoteDataStreamingService.grpc.pb.h>
@@ -92,10 +93,12 @@ private:
     NextWrite();
 
     /**
-     * @brief Handle a failed write operation.
+     * @brief Handle a failed operation.
+     * 
+     * @param errorMessage The error message associated with the failed operation.
      */
     void
-    HandleWriteFailure();
+    HandleFailure(const std::string errorMessage);
 
 private:
     Microsoft::Net::Remote::DataStream::DataStreamDownloadData m_data{};

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -49,6 +49,61 @@ private:
     uint32_t m_numberOfDataBlocksReceived{};
     Microsoft::Net::Remote::DataStream::DataStreamOperationStatus m_readStatus{};
 };
+
+/**
+ * @brief Implementation of the gRPC ServerWriteReactor for server-side data stream writing.
+ */
+class DataStreamWriter :
+    public grpc::ServerWriteReactor<Microsoft::Net::Remote::DataStream::DataStreamDownloadData>
+{
+public:
+    /**
+     * @brief Construct a new DataStreamWriter object with the specified download request.
+     *
+     * @param request The download request from the client.
+     */
+    explicit DataStreamWriter(const Microsoft::Net::Remote::DataStream::DataStreamDownloadRequest* request);
+
+    /**
+     * @brief Callback that is executed when a write operation is completed.
+     *
+     * @param isOk Indicates whether a write was successfully sent.
+     */
+    void
+    OnWriteDone(bool isOk) override;
+
+    /**
+     * @brief Callback that is executed when an RPC is cancelled before successfully sending a status to the client.
+     */
+    void
+    OnCancel() override;
+
+    /**
+     * @brief Callback that is executed when all RPC operations are completed for a given RPC.
+     */
+    void
+    OnDone() override;
+
+private:
+    /**
+     * @brief Facilitate the next write operation.
+     */
+    void
+    NextWrite();
+
+    /**
+     * @brief Handle a failed write operation.
+     */
+    void
+    HandleWriteFailure();
+
+private:
+    Microsoft::Net::Remote::DataStream::DataStreamDownloadData m_data{};
+    Microsoft::Net::Remote::DataStream::DataStreamProperties m_dataStreamProperties{};
+    uint32_t m_numberOfDataBlocksToStream{};
+    uint32_t m_numberOfDataBlocksWritten{};
+    Microsoft::Net::Remote::DataStream::DataStreamOperationStatus m_writeStatus{};
+};
 } // namespace Microsoft::Net::Remote::Service::Reactors
 
 #endif // NET_REMOTE_DATA_STREAMING_REACTORS_HXX

--- a/src/common/service/NetRemoteDataStreamingService.cxx
+++ b/src/common/service/NetRemoteDataStreamingService.cxx
@@ -16,3 +16,13 @@ NetRemoteDataStreamingService::DataStreamUpload([[maybe_unused]] grpc::CallbackS
 
     return m_dataStreamReaders.back().get();
 }
+
+grpc::ServerWriteReactor<DataStreamDownloadData>*
+NetRemoteDataStreamingService::DataStreamDownload([[maybe_unused]] grpc::CallbackServerContext* context, const DataStreamDownloadRequest* request)
+{
+    const NetRemoteApiTrace traceMe{};
+
+    m_dataStreamWriter = std::make_unique<Reactors::DataStreamWriter>(request);
+
+    return m_dataStreamWriter.get();
+}

--- a/src/common/service/NetRemoteDataStreamingService.cxx
+++ b/src/common/service/NetRemoteDataStreamingService.cxx
@@ -12,9 +12,7 @@ NetRemoteDataStreamingService::DataStreamUpload([[maybe_unused]] grpc::CallbackS
 {
     const NetRemoteApiTrace traceMe{};
 
-    m_dataStreamReaders.push_back(std::make_unique<Reactors::DataStreamReader>(result));
-
-    return m_dataStreamReaders.back().get();
+    return new Reactors::DataStreamReader(result);
 }
 
 grpc::ServerWriteReactor<DataStreamDownloadData>*
@@ -22,7 +20,5 @@ NetRemoteDataStreamingService::DataStreamDownload([[maybe_unused]] grpc::Callbac
 {
     const NetRemoteApiTrace traceMe{};
 
-    m_dataStreamWriter = std::make_unique<Reactors::DataStreamWriter>(request);
-
-    return m_dataStreamWriter.get();
+    return new Reactors::DataStreamWriter(request);
 }

--- a/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
@@ -2,6 +2,7 @@
 #ifndef NET_REMOTE_DATA_STREAMING_SERVICE_HXX
 #define NET_REMOTE_DATA_STREAMING_SERVICE_HXX
 
+#include <memory>
 #include <vector>
 
 #include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
@@ -32,8 +33,19 @@ private:
     grpc::ServerReadReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData>*
     DataStreamUpload(grpc::CallbackServerContext* context, Microsoft::Net::Remote::DataStream::DataStreamUploadResult* result) override;
 
+    /**
+     * @brief Stream data from the server to the client.
+     *
+     * @param context
+     * @param request
+     * @return grpc::ServerWriteReactor<Microsoft::Net::Remote::DataStream::DataStreamDownloadData>*
+     */
+    grpc::ServerWriteReactor<Microsoft::Net::Remote::DataStream::DataStreamDownloadData>*
+    DataStreamDownload(grpc::CallbackServerContext* context, const Microsoft::Net::Remote::DataStream::DataStreamDownloadRequest* request) override;
+
 private:
     std::vector<std::unique_ptr<grpc::ServerReadReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData>>> m_dataStreamReaders{};
+    std::unique_ptr<grpc::ServerWriteReactor<Microsoft::Net::Remote::DataStream::DataStreamDownloadData>> m_dataStreamWriter{};
 };
 } // namespace Microsoft::Net::Remote::Service
 

--- a/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
@@ -2,9 +2,6 @@
 #ifndef NET_REMOTE_DATA_STREAMING_SERVICE_HXX
 #define NET_REMOTE_DATA_STREAMING_SERVICE_HXX
 
-#include <memory>
-#include <vector>
-
 #include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
 #include <microsoft/net/remote/protocol/NetRemoteDataStreamingService.grpc.pb.h>
 
@@ -42,10 +39,6 @@ private:
      */
     grpc::ServerWriteReactor<Microsoft::Net::Remote::DataStream::DataStreamDownloadData>*
     DataStreamDownload(grpc::CallbackServerContext* context, const Microsoft::Net::Remote::DataStream::DataStreamDownloadRequest* request) override;
-
-private:
-    std::vector<std::unique_ptr<grpc::ServerReadReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData>>> m_dataStreamReaders{};
-    std::unique_ptr<grpc::ServerWriteReactor<Microsoft::Net::Remote::DataStream::DataStreamDownloadData>> m_dataStreamWriter{};
 };
 } // namespace Microsoft::Net::Remote::Service
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

This PR adds the initial implementation of the `DataStreamDownload` API, including the API itself, the foundational service implementation and reactor class, a test client reactor class, and a basic unit test.

### Technical Details

* Added `DataStreamDownload` API to `NetRemoteDataStreamingService.proto`, along with applicable types into `NetRemoteDataStream.proto`.
* Added `DataStreamWriter` implementation of the gRPC `ServerWriteReactor` reactor class to `NetRemoteDataStreamingReactors`.
* Added test client implementation of the gRPC `ClientReadReactor` reactor class.
* Added basic unit test.
* Reverted smart pointer memory management back to `new`/`delete`.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

* Handle `DataStreamPattern` options from the client's `DataStreamDownloadRequest`.
* Add additional unit test for `DataStreamTypeContinuous` with `DataStreamPatternConstant`.
* Add a better mechanism for data creation.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
