### PR TITLE
DataStreamDownload API improvements

### DIFF
--- a/protocol/protos/NetRemoteDataStream.proto
+++ b/protocol/protos/NetRemoteDataStream.proto
@@ -65,8 +65,8 @@ message DataStreamProperties
     DataStreamPattern Pattern = 2;
     oneof Properties
     {
-        DataStreamFixedTypeProperties FixedTypeProperties = 3;
-        DataStreamContinuousTypeProperties ContinuousTypeProperties = 4;
+        DataStreamFixedTypeProperties Fixed = 3;
+        DataStreamContinuousTypeProperties Continuous = 4;
     }
 }
 

--- a/protocol/protos/NetRemoteDataStream.proto
+++ b/protocol/protos/NetRemoteDataStream.proto
@@ -25,15 +25,15 @@ message DataStreamUploadData
 
 message DataStreamDownloadData
 {
-    bytes Data = 1;
-    uint32 SequenceNumber = 2;
-    DataStreamOperationStatus Status = 3;
+    DataStreamOperationStatus Status = 1;
+    bytes Data = 2;
+    uint32 SequenceNumber = 3;
 }
 
 message DataStreamUploadResult
 {
-    uint32 NumberOfDataBlocksReceived = 1;
-    DataStreamOperationStatus Status = 2;
+    DataStreamOperationStatus Status = 1;
+    uint32 NumberOfDataBlocksReceived = 2;
 }
 
 enum DataStreamType

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -52,20 +52,20 @@ DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request)
 
     switch (m_dataStreamProperties.type()) {
     case DataStreamType::DataStreamTypeFixed: {
-        if (m_dataStreamProperties.Properties_case() == DataStreamProperties::kFixedTypeProperties) {
-            m_numberOfDataBlocksToStream = m_dataStreamProperties.fixedtypeproperties().numberofdatablockstostream();
+        if (m_dataStreamProperties.Properties_case() == DataStreamProperties::kFixed) {
+            m_numberOfDataBlocksToStream = m_dataStreamProperties.fixed().numberofdatablockstostream();
         } else {
-            HandleFailure("Invalid properties for this streaming type. Expected FixedTypeProperties for DataStreamTypeFixed");
+            HandleFailure("Invalid properties for this streaming type. Expected Fixed for DataStreamTypeFixed");
             return;
         }
 
         break;
     }
     case DataStreamType::DataStreamTypeContinuous: {
-        if (m_dataStreamProperties.Properties_case() == DataStreamProperties::kContinuousTypeProperties) {
+        if (m_dataStreamProperties.Properties_case() == DataStreamProperties::kContinuous) {
             m_numberOfDataBlocksToStream = 0;
         } else {
-            HandleFailure("Invalid properties for this streaming type. Expected ContinuousTypeProperties for DataStreamTypeContinuous");
+            HandleFailure("Invalid properties for this streaming type. Expected Continuous for DataStreamTypeContinuous");
             return;
         }
 

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -137,7 +137,7 @@ DataStreamWriter::NextWrite()
 }
 
 void
-DataStreamWriter::HandleFailure(const std::string errorMessage)
+DataStreamWriter::HandleFailure(const std::string& errorMessage)
 {
     m_writeStatus.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeFailed);
     m_writeStatus.set_message(errorMessage);

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -98,7 +98,7 @@ private:
      * @param errorMessage The error message associated with the failed operation.
      */
     void
-    HandleFailure(const std::string errorMessage);
+    HandleFailure(const std::string& errorMessage);
 
 private:
     Microsoft::Net::Remote::DataStream::DataStreamDownloadData m_data{};

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -8,8 +8,6 @@ using namespace Microsoft::Net::Remote::DataStream;
 using namespace Microsoft::Net::Remote::Service;
 using namespace Microsoft::Net::Remote::Test;
 
-using namespace std::chrono_literals;
-
 DataStreamWriter::DataStreamWriter(NetRemoteDataStreaming::Stub* client, uint32_t numberOfDataBlocksToWrite) :
     m_numberOfDataBlocksToWrite(numberOfDataBlocksToWrite)
 {
@@ -42,9 +40,8 @@ grpc::Status
 DataStreamWriter::Await(DataStreamUploadResult* result)
 {
     std::unique_lock lock(m_writeStatusGate);
-    static constexpr auto timeoutValue = 10s;
 
-    const auto isDone = m_writesDone.wait_for(lock, timeoutValue, [this] {
+    const auto isDone = m_writesDone.wait_for(lock, m_writesDoneTimeoutValue, [this] {
         return m_done;
     });
 
@@ -102,9 +99,8 @@ grpc::Status
 DataStreamReader::Await(uint32_t* numberOfDataBlocksReceived, DataStreamOperationStatus* operationStatus)
 {
     std::unique_lock lock(m_readStatusGate);
-    static constexpr auto timeoutValue = 10s;
 
-    const auto isDone = m_readsDone.wait_for(lock, timeoutValue, [this] {
+    const auto isDone = m_readsDone.wait_for(lock, m_readsDoneTimeoutValue, [this] {
         return m_done;
     });
 

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -2,6 +2,7 @@
 #ifndef TEST_NET_REMOTE_DATA_STREAMING_REACTORS_HXX
 #define TEST_NET_REMOTE_DATA_STREAMING_REACTORS_HXX
 
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <mutex>

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -9,6 +9,8 @@
 #include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
 #include <microsoft/net/remote/protocol/NetRemoteDataStreamingService.grpc.pb.h>
 
+using namespace std::chrono_literals;
+
 namespace Microsoft::Net::Remote::Test
 {
 /**
@@ -59,6 +61,8 @@ private:
     NextWrite();
 
 private:
+    static inline constexpr auto c_defaultTimeoutValue{ 10s };
+
     grpc::ClientContext m_clientContext{};
     Microsoft::Net::Remote::DataStream::DataStreamUploadData m_data{};
     Microsoft::Net::Remote::DataStream::DataStreamUploadResult m_result{};
@@ -68,6 +72,7 @@ private:
     std::mutex m_writeStatusGate{};
     std::condition_variable m_writesDone{};
     bool m_done{ false };
+    std::chrono::duration<uint32_t> m_writesDoneTimeoutValue{ c_defaultTimeoutValue };
 };
 
 /**
@@ -112,6 +117,8 @@ public:
     Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus);
 
 private:
+    static inline constexpr auto c_defaultTimeoutValue{ 10s };
+
     grpc::ClientContext m_clientContext{};
     Microsoft::Net::Remote::DataStream::DataStreamDownloadData m_data{};
     uint32_t m_numberOfDataBlocksReceived{};
@@ -119,6 +126,7 @@ private:
     std::mutex m_readStatusGate{};
     std::condition_variable m_readsDone{};
     bool m_done{ false };
+    std::chrono::duration<uint32_t> m_readsDoneTimeoutValue{ c_defaultTimeoutValue };
 };
 
 } // namespace Microsoft::Net::Remote::Test

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -107,11 +107,11 @@ TEST_CASE("DataStreamDownload API", "[basic][rpc][client][remote][stream]")
         DataStreamDownloadRequest request{};
         *request.mutable_properties() = std::move(properties);
 
-        auto dataStreamReader = std::make_unique<DataStreamReader>(client.get(), &request);
+        DataStreamReader dataStreamReader{ client.get(), &request };
 
         uint32_t numberOfDataBlocksReceived{};
         DataStreamOperationStatus operationStatus{};
-        grpc::Status status = dataStreamReader->Await(&numberOfDataBlocksReceived, &operationStatus);
+        grpc::Status status = dataStreamReader.Await(&numberOfDataBlocksReceived, &operationStatus);
         REQUIRE(status.ok());
         REQUIRE(numberOfDataBlocksReceived == fixedNumberOfDataBlocksToStream);
         REQUIRE(operationStatus.code() == DataStreamOperationStatusCodeSucceeded);

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -102,7 +102,7 @@ TEST_CASE("DataStreamDownload API", "[basic][rpc][client][remote][stream]")
         DataStreamProperties properties{};
         properties.set_type(DataStreamType::DataStreamTypeFixed);
         properties.set_pattern(DataStreamPattern::DataStreamPatternConstant);
-        *properties.mutable_fixedtypeproperties() = std::move(fixedTypeProperties);
+        *properties.mutable_fixed() = std::move(fixedTypeProperties);
 
         DataStreamDownloadRequest request{};
         *request.mutable_properties() = std::move(properties);


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

Address PR comments.

### Technical Details

* Simplify `oneof` field names in `Properties`.
* Use `const std::string&` instead of `const std::string`.
* Add class member for client reactor timeout values.
* Re-order message fields so always present fields are first.
* Allocate `DataStreamReader` on stack in test client code.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
