### PR TITLE
Remove exception handling for SetProtocol call.

### DIFF
--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -351,7 +351,7 @@ NetRemoteService::WifiAccessPointSetPhyType([[maybe_unused]] grpc::ServerContext
     Ieee80211AccessPointCapabilities accessPointCapabilities{};
     auto operationStatus = accessPointController->GetCapabilities(accessPointCapabilities);
     if (!operationStatus) {
-        return HandleFailure(request, result, operationStatus.Code, std::format("Failed to get capabilities for access point {}", request->accesspointid()));
+        return HandleFailure(request, result, operationStatus.Code, std::format("Failed to get capabilities for access point {} ({})", request->accesspointid(), operationStatus.ToString()));
     }
 
     const auto& supportedIeee80211Protocols = accessPointCapabilities.Protocols;
@@ -360,12 +360,9 @@ NetRemoteService::WifiAccessPointSetPhyType([[maybe_unused]] grpc::ServerContext
     }
 
     // Set the Ieee80211 protocol.
-    try {
-        if (!accessPointController->SetProtocol(ieee80211Protocol)) {
-            return HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInternalError, std::format("Failed to set PHY type for access point {}", request->accesspointid()));
-        }
-    } catch (const AccessPointControllerException& apce) {
-        return HandleFailure(request, result, WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInternalError, std::format("Failed to set PHY type for access point {} ({})", request->accesspointid(), apce.what()));
+    operationStatus = accessPointController->SetProtocol(ieee80211Protocol);
+    if (!operationStatus) {
+        return HandleFailure(request, result, operationStatus.Code, std::format("Failed to set PHY type for access point {} ({})", request->accesspointid(), operationStatus.ToString()));
     }
 
     status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
@@ -427,7 +424,7 @@ NetRemoteService::WifiAccessPointSetFrequencyBands([[maybe_unused]] grpc::Server
     // Attempt to set the frequency bands.
     operationStatus = accessPointController->SetFrequencyBands(std::move(ieee80211FrequencyBands));
     if (!operationStatus) {
-        return HandleFailure(request, result, operationStatus.Code, std::format("Failed to set frequency bands for access point {} ({})", request->accesspointid(), operationStatus.Details)); // FIXME
+        return HandleFailure(request, result, operationStatus.Code, std::format("Failed to set frequency bands for access point {} ({})", request->accesspointid(), operationStatus.ToString()));
     }
 
     // Prepare result with success indication.

--- a/src/common/wifi/core/AccessPoint.cxx
+++ b/src/common/wifi/core/AccessPoint.cxx
@@ -15,7 +15,7 @@ AccessPoint::AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccess
 {}
 
 std::string_view
-AccessPoint::GetInterfaceName() const
+AccessPoint::GetInterfaceName() const noexcept
 {
     return m_interfaceName;
 }

--- a/src/common/wifi/core/AccessPointController.cxx
+++ b/src/common/wifi/core/AccessPointController.cxx
@@ -11,7 +11,7 @@ AccessPointController::AccessPointController(std::string_view interface) :
 }
 
 std::string_view
-AccessPointController::GetInterfaceName() const
+AccessPointController::GetInterfaceName() const noexcept
 {
     return m_interfaceName;
 }

--- a/src/common/wifi/core/AccessPointOperationStatus.cxx
+++ b/src/common/wifi/core/AccessPointOperationStatus.cxx
@@ -23,6 +23,19 @@ AccessPointOperationStatus::MakeSucceeded(std::string_view accessPointId, std::s
     };
 }
 
+/* static */
+AccessPointOperationStatus
+AccessPointOperationStatus::InvalidAccessPoint(std::string_view operationName, std::string_view details, std::source_location sourceLocation) noexcept
+{
+    return AccessPointOperationStatus{
+        {},
+        operationName,
+        AccessPointOperationStatusCode::AccessPointInvalid,
+        details,
+        sourceLocation
+    };
+}
+
 bool
 AccessPointOperationStatus::Succeeded() const noexcept
 {

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
@@ -19,7 +19,7 @@ struct AccessPoint :
 {
     /**
      * @brief Construct a new AccessPoint object with the given network interface name.
-     * 
+     *
      * @param interfaceName The network interface name representing the access point.
      * @param accessPointControllerFactory The factory used to create controller objects.
      */
@@ -31,7 +31,7 @@ struct AccessPoint :
      * @return std::string_view
      */
     std::string_view
-    GetInterfaceName() const override;
+    GetInterfaceName() const noexcept override;
 
     /**
      * @brief Create a controller object.
@@ -54,26 +54,26 @@ struct AccessPointFactory :
 {
     /**
      * @brief Construct a new Access Point Factory object
-     * 
-     * @param accessPointControllerFactory 
+     *
+     * @param accessPointControllerFactory
      */
     AccessPointFactory(std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory);
 
-     /**
+    /**
      * @brief Create a new access point object for the given network interface.
-     * 
-     * @param interfaceName 
-     * @return std::shared_ptr<IAccessPoint> 
+     *
+     * @param interfaceName
+     * @return std::shared_ptr<IAccessPoint>
      */
     virtual std::shared_ptr<IAccessPoint>
     Create(std::string_view interfaceName) override;
 
     /**
      * @brief Create a new access point object for the given network interface with the specified creation arguments.
-     * 
+     *
      * @param interfaceName The name of the interface.
      * @param createArgs Arguments to be passed to the access point during creation.
-     * @return std::shared_ptr<IAccessPoint> 
+     * @return std::shared_ptr<IAccessPoint>
      */
     virtual std::shared_ptr<IAccessPoint>
     Create(std::string_view interfaceName, std::unique_ptr<IAccessPointCreateArgs> createArgs) override;
@@ -81,8 +81,8 @@ struct AccessPointFactory :
 protected:
     /**
      * @brief Get the ControllerFactory object.
-     * 
-     * @return std::shared_ptr<IAccessPointControllerFactory> 
+     *
+     * @return std::shared_ptr<IAccessPointControllerFactory>
      */
     std::shared_ptr<IAccessPointControllerFactory>
     GetControllerFactory() const noexcept;

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointController.hxx
@@ -20,8 +20,8 @@ struct AccessPointController :
 
     /**
      * @brief Construct a new AccessPointController object to control the specified interface.
-     * 
-     * @param interfaceName 
+     *
+     * @param interfaceName
      */
     AccessPointController(std::string_view interfaceName);
 
@@ -31,7 +31,7 @@ struct AccessPointController :
      * @return std::string_view
      */
     std::string_view
-    GetInterfaceName() const override;
+    GetInterfaceName() const noexcept override;
 
 private:
     std::string m_interfaceName;

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
@@ -54,7 +54,7 @@ struct AccessPointOperationStatus
     {
         if (std::empty(OperationName)) {
             OperationName = SourceLocation.function_name();
-            auto pos = OperationName.find_first_of('('); 
+            auto pos = OperationName.find_first_of('(');
             if (pos != std::string::npos) {
                 OperationName.erase(pos);
             }
@@ -94,6 +94,17 @@ struct AccessPointOperationStatus
      */
     static AccessPointOperationStatus
     MakeSucceeded(std::string_view accessPointId, std::string_view operationName = {}, std::string_view details = {}, std::source_location sourceLocation = std::source_location::current()) noexcept;
+
+    /**
+     * @brief Create an AccessPointOperationStatus description an operation that referred to an invalid access point.
+     *
+     * @param operationName The name of the operation.
+     * @param details Additional details about the operation.
+     * @param sourceLocation The source location of the operation.
+     * @return AccessPointOperationStatus
+     */
+    static AccessPointOperationStatus
+    InvalidAccessPoint(std::string_view operationName = {}, std::string_view details = {}, std::source_location sourceLocation = std::source_location::current()) noexcept;
 
     /**
      * @brief Determine whether the operation succeeded.

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
@@ -25,9 +25,14 @@ struct IAccessPoint
      * Prevent copying and moving of IAccessPoint objects.
      */
     IAccessPoint(const IAccessPoint&) = delete;
-    IAccessPoint& operator=(const IAccessPoint&) = delete;
+
     IAccessPoint(IAccessPoint&&) = delete;
-    IAccessPoint& operator=(IAccessPoint&&) = delete;
+
+    IAccessPoint&
+    operator=(const IAccessPoint&) = delete;
+
+    IAccessPoint&
+    operator=(IAccessPoint&&) = delete;
 
     /**
      * @brief Get the network interface name representing the access point.
@@ -35,7 +40,7 @@ struct IAccessPoint
      * @return std::string_view
      */
     virtual std::string_view
-    GetInterfaceName() const = 0;
+    GetInterfaceName() const noexcept = 0;
 
     /**
      * @brief Create a new instance that can control the access point.
@@ -49,7 +54,7 @@ struct IAccessPoint
 /**
  * @brief Arguments to be passed to the Create method of IAccessPointFactory.
  */
-struct IAccessPointCreateArgs 
+struct IAccessPointCreateArgs
 {
     IAccessPointCreateArgs() = default;
 
@@ -59,9 +64,14 @@ struct IAccessPointCreateArgs
      * Prevent copying and moving of IAccessPointCreateArgs objects.
      */
     IAccessPointCreateArgs(const IAccessPointCreateArgs&) = delete;
-    IAccessPointCreateArgs& operator=(const IAccessPointCreateArgs&) = delete;
+
     IAccessPointCreateArgs(IAccessPointCreateArgs&&) = delete;
-    IAccessPointCreateArgs& operator=(IAccessPointCreateArgs&&) = delete;
+
+    IAccessPointCreateArgs&
+    operator=(const IAccessPointCreateArgs&) = delete;
+
+    IAccessPointCreateArgs&
+    operator=(IAccessPointCreateArgs&&) = delete;
 };
 
 /**
@@ -77,28 +87,33 @@ struct IAccessPointFactory
     virtual ~IAccessPointFactory() = default;
 
     /**
-     * Prevent copying and moving of IAccessPointFactory objects. 
+     * Prevent copying and moving of IAccessPointFactory objects.
      */
     IAccessPointFactory(const IAccessPointFactory&) = delete;
-    IAccessPointFactory& operator=(const IAccessPointFactory&) = delete;
+
     IAccessPointFactory(IAccessPointFactory&&) = delete;
-    IAccessPointFactory& operator=(IAccessPointFactory&&) = delete;
+
+    IAccessPointFactory&
+    operator=(const IAccessPointFactory&) = delete;
+
+    IAccessPointFactory&
+    operator=(IAccessPointFactory&&) = delete;
 
     /**
      * @brief Create a new access point object for the given network interface.
-     * 
+     *
      * @param interfaceName The name of the interface.
-     * @return std::shared_ptr<IAccessPoint> 
+     * @return std::shared_ptr<IAccessPoint>
      */
     virtual std::shared_ptr<IAccessPoint>
     Create(std::string_view interfaceName) = 0;
 
     /**
      * @brief Create a new access point object for the given network interface with the specified creation arguments.
-     * 
+     *
      * @param interfaceName The name of the interface.
      * @param createArgs Arguments to be passed to the access point during creation.
-     * @return std::shared_ptr<IAccessPoint> 
+     * @return std::shared_ptr<IAccessPoint>
      */
     virtual std::shared_ptr<IAccessPoint>
     Create(std::string_view interfaceName, std::unique_ptr<IAccessPointCreateArgs> createArgs) = 0;

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -60,7 +60,7 @@ struct IAccessPointController
      * @return std::string_view
      */
     virtual std::string_view
-    GetInterfaceName() const = 0;
+    GetInterfaceName() const noexcept = 0;
 
     /**
      * @brief Get the access point operational state.
@@ -69,7 +69,7 @@ struct IAccessPointController
      * @return AccessPointOperationStatus
      */
     virtual AccessPointOperationStatus
-    GetOperationalState(AccessPointOperationalState& operationalState) = 0;
+    GetOperationalState(AccessPointOperationalState& operationalState) noexcept = 0;
 
     /**
      * @brief Get the capabilities of the access point.
@@ -78,7 +78,7 @@ struct IAccessPointController
      * @return AccessPointOperationStatus
      */
     virtual AccessPointOperationStatus
-    GetCapabilities(Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) = 0;
+    GetCapabilities(Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) noexcept = 0;
 
     /**
      * @brief Set the operational state of the access point.
@@ -87,7 +87,7 @@ struct IAccessPointController
      * @return AccessPointOperationStatus
      */
     virtual AccessPointOperationStatus
-    SetOperationalState(AccessPointOperationalState operationalState) = 0;
+    SetOperationalState(AccessPointOperationalState operationalState) noexcept = 0;
 
     /**
      * @brief Set the Ieee80211 protocol of the access point.
@@ -96,7 +96,7 @@ struct IAccessPointController
      * @return AccessPointOperationStatus
      */
     virtual AccessPointOperationStatus
-    SetProtocol(Ieee80211Protocol ieeeProtocol) = 0;
+    SetProtocol(Ieee80211Protocol ieeeProtocol) noexcept = 0;
 
     /**
      * @brief Set the frquency bands the access point should enable.
@@ -105,7 +105,7 @@ struct IAccessPointController
      * @return AccessPointOperationStatus
      */
     virtual AccessPointOperationStatus
-    SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands) = 0;
+    SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands) noexcept = 0;
 
     /**
      * @brief Set the SSID of the access point.
@@ -114,7 +114,7 @@ struct IAccessPointController
      * @return AccessPointOperationStatus
      */
     virtual AccessPointOperationStatus
-    SetSssid(std::string_view ssid) = 0;
+    SetSssid(std::string_view ssid) noexcept = 0;
 };
 
 /**

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -153,7 +153,7 @@ IeeeFrequencyBandToHostapdBand(Ieee80211FrequencyBand ieeeFrequencyBand)
 } // namespace detail
 
 AccessPointOperationStatus
-AccessPointControllerLinux::GetCapabilities(Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities)
+AccessPointControllerLinux::GetCapabilities(Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) noexcept
 {
     AccessPointOperationStatus status{ GetInterfaceName() };
     const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
@@ -190,7 +190,7 @@ AccessPointControllerLinux::GetCapabilities(Ieee80211AccessPointCapabilities& ie
 }
 
 AccessPointOperationStatus
-AccessPointControllerLinux::GetOperationalState(AccessPointOperationalState& operationalState)
+AccessPointControllerLinux::GetOperationalState(AccessPointOperationalState& operationalState) noexcept
 {
     AccessPointOperationStatus status{ GetInterfaceName() };
     const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
@@ -210,7 +210,7 @@ AccessPointControllerLinux::GetOperationalState(AccessPointOperationalState& ope
 }
 
 AccessPointOperationStatus
-AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState operationalState)
+AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState operationalState) noexcept
 {
     AccessPointOperationStatus status{ GetInterfaceName() };
     const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
@@ -247,7 +247,7 @@ AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState oper
 }
 
 AccessPointOperationStatus
-AccessPointControllerLinux::SetProtocol(Ieee80211Protocol ieeeProtocol)
+AccessPointControllerLinux::SetProtocol(Ieee80211Protocol ieeeProtocol) noexcept
 {
     const auto ieeeProtocolName = std::format("802.11 {}", magic_enum::enum_name(ieeeProtocol));
     AccessPointOperationStatus status{ GetInterfaceName(), std::format("SetProtocol {}", ieeeProtocolName).c_str() };
@@ -319,7 +319,7 @@ AccessPointControllerLinux::SetProtocol(Ieee80211Protocol ieeeProtocol)
 }
 
 AccessPointOperationStatus
-AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands)
+AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands) noexcept
 {
     AccessPointOperationStatus status{ GetInterfaceName() };
     AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
@@ -380,7 +380,7 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
 }
 
 AccessPointOperationStatus
-AccessPointControllerLinux::SetSssid(std::string_view ssid)
+AccessPointControllerLinux::SetSssid(std::string_view ssid) noexcept
 {
     AccessPointOperationStatus status{ GetInterfaceName() };
     const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -36,9 +36,12 @@ struct AccessPointControllerLinux :
      * Prevent copying and moving of this object.
      */
     AccessPointControllerLinux(const AccessPointControllerLinux&) = delete;
+
+    AccessPointControllerLinux(AccessPointControllerLinux&&) = delete;
+
     AccessPointControllerLinux&
     operator=(const AccessPointControllerLinux&) = delete;
-    AccessPointControllerLinux(AccessPointControllerLinux&&) = delete;
+
     AccessPointControllerLinux&
     operator=(AccessPointControllerLinux&&) = delete;
 
@@ -49,7 +52,7 @@ struct AccessPointControllerLinux :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    GetOperationalState(AccessPointOperationalState& operationalState) override;
+    GetOperationalState(AccessPointOperationalState& operationalState) noexcept override;
 
     /**
      * @brief Get the capabilities of the access point.
@@ -58,7 +61,7 @@ struct AccessPointControllerLinux :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    GetCapabilities(Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) override;
+    GetCapabilities(Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) noexcept override;
 
     /**
      * @brief Set the operational state of the access point.
@@ -67,7 +70,7 @@ struct AccessPointControllerLinux :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    SetOperationalState(AccessPointOperationalState operationalState) override;
+    SetOperationalState(AccessPointOperationalState operationalState) noexcept override;
 
     /**
      * @brief Set the Ieee80211 protocol.
@@ -76,7 +79,7 @@ struct AccessPointControllerLinux :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    SetProtocol(Ieee80211Protocol ieeeProtocol) override;
+    SetProtocol(Ieee80211Protocol ieeeProtocol) noexcept override;
 
     /**
      * @brief Set the frquency bands the access point should enable.
@@ -85,7 +88,7 @@ struct AccessPointControllerLinux :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands) override;
+    SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands) noexcept override;
 
     /**
      * @brief Set the SSID of the access point.
@@ -94,7 +97,7 @@ struct AccessPointControllerLinux :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    SetSssid(std::string_view ssid) override;
+    SetSssid(std::string_view ssid) noexcept override;
 
 private:
     Wpa::Hostapd m_hostapd;

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -1,5 +1,6 @@
 
 #include <algorithm>
+#include <cassert>
 #include <format>
 #include <iterator>
 #include <memory>
@@ -24,20 +25,18 @@ AccessPointControllerTest::AccessPointControllerTest(AccessPointTest *accessPoin
 {}
 
 std::string_view
-AccessPointControllerTest::GetInterfaceName() const
+AccessPointControllerTest::GetInterfaceName() const noexcept
 {
-    if (AccessPoint == nullptr) {
-        throw std::runtime_error("AccessPointControllerTest::GetInterfaceName called with null AccessPoint");
-    }
-
+    assert(AccessPoint != nullptr);
     return AccessPoint->InterfaceName;
 }
 
 AccessPointOperationStatus
-AccessPointControllerTest::GetOperationalState(AccessPointOperationalState &operationalState)
+AccessPointControllerTest::GetOperationalState(AccessPointOperationalState &operationalState) noexcept
 {
+    assert(AccessPoint != nullptr);
     if (AccessPoint == nullptr) {
-        throw std::runtime_error("AccessPointControllerTest::GetOperationalState called with null AccessPoint");
+        return AccessPointOperationStatus::InvalidAccessPoint("null AccessPoint");
     }
 
     operationalState = AccessPoint->OperationalState;
@@ -45,10 +44,11 @@ AccessPointControllerTest::GetOperationalState(AccessPointOperationalState &oper
 }
 
 AccessPointOperationStatus
-AccessPointControllerTest::GetCapabilities(Ieee80211AccessPointCapabilities &ieee80211AccessPointCapabilities)
+AccessPointControllerTest::GetCapabilities(Ieee80211AccessPointCapabilities &ieee80211AccessPointCapabilities) noexcept
 {
+    assert(AccessPoint != nullptr);
     if (AccessPoint == nullptr) {
-        throw std::runtime_error("AccessPointControllerTest::GetCapabilities called with null AccessPoint");
+        return AccessPointOperationStatus::InvalidAccessPoint("null AccessPoint");
     }
 
     ieee80211AccessPointCapabilities = AccessPoint->Capabilities;
@@ -56,10 +56,12 @@ AccessPointControllerTest::GetCapabilities(Ieee80211AccessPointCapabilities &iee
 }
 
 AccessPointOperationStatus
-AccessPointControllerTest::SetOperationalState(AccessPointOperationalState operationalState)
+AccessPointControllerTest::SetOperationalState(AccessPointOperationalState operationalState) noexcept
 {
+    assert(AccessPoint != nullptr);
+
     if (AccessPoint == nullptr) {
-        throw std::runtime_error("AccessPointControllerTest::SetOperationalState called with null AccessPoint");
+        return AccessPointOperationStatus::InvalidAccessPoint("null AccessPoint");
     }
 
     AccessPoint->OperationalState = operationalState;
@@ -67,10 +69,12 @@ AccessPointControllerTest::SetOperationalState(AccessPointOperationalState opera
 }
 
 AccessPointOperationStatus
-AccessPointControllerTest::SetProtocol(Ieee80211Protocol ieeeProtocol)
+AccessPointControllerTest::SetProtocol(Ieee80211Protocol ieeeProtocol) noexcept
 {
+    assert(AccessPoint != nullptr);
+
     if (AccessPoint == nullptr) {
-        throw std::runtime_error("AccessPointControllerTest::SetIeeeProtocol called with null AccessPoint");
+        return AccessPointOperationStatus::InvalidAccessPoint("null AccessPoint");
     }
 
     AccessPoint->Protocol = ieeeProtocol;
@@ -78,10 +82,12 @@ AccessPointControllerTest::SetProtocol(Ieee80211Protocol ieeeProtocol)
 }
 
 AccessPointOperationStatus
-AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands)
+AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand> frequencyBands) noexcept
 {
+    assert(AccessPoint != nullptr);
+
     if (AccessPoint == nullptr) {
-        throw std::runtime_error("AccessPointControllerTest::SetIeeeProtocol called with null AccessPoint");
+        return AccessPointOperationStatus::InvalidAccessPoint("null AccessPoint");
     }
 
     for (const auto &frequencyBandToSet : frequencyBands) {
@@ -100,10 +106,12 @@ AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand>
 }
 
 AccessPointOperationStatus
-AccessPointControllerTest::SetSssid(std::string_view ssid)
+AccessPointControllerTest::SetSssid(std::string_view ssid) noexcept
 {
+    assert(AccessPoint != nullptr);
+
     if (AccessPoint == nullptr) {
-        throw std::runtime_error("AccessPointControllerTest::SetSssid called with null AccessPoint");
+        return AccessPointOperationStatus::InvalidAccessPoint("null AccessPoint");
     }
 
     AccessPoint->Ssid = ssid;
@@ -117,6 +125,8 @@ AccessPointControllerFactoryTest::AccessPointControllerFactoryTest(AccessPointTe
 std::unique_ptr<IAccessPointController>
 AccessPointControllerFactoryTest::Create(std::string_view interfaceName)
 {
+    assert(AccessPoint != nullptr);
+
     if (AccessPoint != nullptr && interfaceName != AccessPoint->InterfaceName) {
         throw std::runtime_error("AccessPointControllerFactoryTest::Create called with unexpected interface name");
     }

--- a/tests/unit/wifi/helpers/AccessPointTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointTest.cxx
@@ -21,7 +21,7 @@ AccessPointTest::AccessPointTest(std::string_view interfaceName, Ieee80211Access
 {}
 
 std::string_view
-AccessPointTest::GetInterfaceName() const
+AccessPointTest::GetInterfaceName() const noexcept
 {
     return InterfaceName;
 }

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -56,7 +56,7 @@ struct AccessPointControllerTest final :
      * @return std::string_view
      */
     std::string_view
-    GetInterfaceName() const override;
+    GetInterfaceName() const noexcept override;
 
     /**
      * @brief Get the access point operational state.
@@ -65,7 +65,7 @@ struct AccessPointControllerTest final :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    GetOperationalState(AccessPointOperationalState &operationalState) override;
+    GetOperationalState(AccessPointOperationalState &operationalState) noexcept override;
 
     /**
      * @brief Get the capabilities of the access point.
@@ -74,7 +74,7 @@ struct AccessPointControllerTest final :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    GetCapabilities(Ieee80211AccessPointCapabilities &ieee80211AccessPointCapabilities) override;
+    GetCapabilities(Ieee80211AccessPointCapabilities &ieee80211AccessPointCapabilities) noexcept override;
 
     /**
      * @brief Set the operational state of the access point.
@@ -83,7 +83,7 @@ struct AccessPointControllerTest final :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    SetOperationalState(AccessPointOperationalState operationalState) override;
+    SetOperationalState(AccessPointOperationalState operationalState) noexcept override;
 
     /**
      * @brief Set the Ieee80211 protocol of the access point.
@@ -92,7 +92,7 @@ struct AccessPointControllerTest final :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol) override;
+    SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol) noexcept override;
 
     /**
      * @brief Set the frquency bands the access point should enable.
@@ -101,7 +101,7 @@ struct AccessPointControllerTest final :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    SetFrequencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) override;
+    SetFrequencyBands(std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> frequencyBands) noexcept override;
 
     /**
      * @brief Set the SSID of the access point.
@@ -110,7 +110,7 @@ struct AccessPointControllerTest final :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    SetSssid(std::string_view ssid) override;
+    SetSssid(std::string_view ssid) noexcept override;
 };
 
 /**

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -52,9 +52,12 @@ struct AccessPointTest final :
      * Prevent copying and moving of this object.
      */
     AccessPointTest(const AccessPointTest&) = delete;
+
+    AccessPointTest(AccessPointTest&&) = delete;
+
     AccessPointTest&
     operator=(const AccessPointTest&) = delete;
-    AccessPointTest(AccessPointTest&&) = delete;
+
     AccessPointTest&
     operator=(AccessPointTest&&) = delete;
 
@@ -64,7 +67,7 @@ struct AccessPointTest final :
      * @return std::string_view
      */
     std::string_view
-    GetInterfaceName() const override;
+    GetInterfaceName() const noexcept override;
 
     /**
      * @brief Create a new instance that can control the access point.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure no unnecessary code exists in the API implementation.
* Simplify API implementation.

### Technical Details

* Update `WifiAccessPointSetPhyType` API implementation to avoid a `try/catch` block when calling `SetProtocol` on the AP controller. This is no longer needed since the `SetProtocol` function now returns an `AccessPointOperationStatus` instead of possibly returning an exception.
* Annotate `IAccessPointController` interface functions with `noexcept`.
* Replace throwing `std::runtime_error` in test code with `assert`.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
