### PR TITLE
Move NL80211 <-> Ieee80211 adaption code into own source file

### DIFF
--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -1,6 +1,5 @@
 
 #include <algorithm>
-#include <cstdint>
 #include <format>
 #include <iterator>
 #include <memory>
@@ -15,7 +14,6 @@
 
 #include <Wpa/IHostapd.hxx>
 #include <Wpa/ProtocolHostapd.hxx>
-#include <linux/nl80211.h>
 #include <magic_enum.hpp>
 #include <microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx>
 #include <microsoft/net/wifi/AccessPointController.hxx>
@@ -137,7 +135,7 @@ AccessPointOperationStatus
 AccessPointControllerLinux::SetProtocol(Ieee80211Protocol ieeeProtocol) noexcept
 {
     const auto ieeeProtocolName = std::format("802.11 {}", magic_enum::enum_name(ieeeProtocol));
-    AccessPointOperationStatus status{ GetInterfaceName(), std::format("SetProtocol {}", ieeeProtocolName).c_str() };
+    AccessPointOperationStatus status{ GetInterfaceName(), std::format("SetProtocol {}", ieeeProtocolName) };
     const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
 
     // Populate a list of required properties to set.

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -27,6 +27,8 @@
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
 #include <plog/Severity.h>
 
+#include "Ieee80211Nl80211Adapters.hxx"
+
 using namespace Microsoft::Net::Wifi;
 
 using Microsoft::Net::Netlink::Nl80211::Nl80211Wiphy;
@@ -36,121 +38,6 @@ AccessPointControllerLinux::AccessPointControllerLinux(std::string_view interfac
     m_hostapd(interfaceName)
 {
 }
-
-namespace detail
-{
-Ieee80211CipherSuite
-Nl80211CipherSuiteToIeee80211CipherSuite(uint32_t nl80211CipherSuite) noexcept
-{
-    return static_cast<Ieee80211CipherSuite>(nl80211CipherSuite);
-}
-
-Ieee80211AkmSuite
-Nl80211AkmSuiteToIeee80211AkmSuite(uint32_t nl80211AkmSuite) noexcept
-{
-    return static_cast<Ieee80211AkmSuite>(nl80211AkmSuite);
-}
-
-Ieee80211FrequencyBand
-Nl80211BandToIeee80211FrequencyBand(nl80211_band nl80211Band) noexcept
-{
-    switch (nl80211Band) {
-    case NL80211_BAND_2GHZ:
-        return Ieee80211FrequencyBand::TwoPointFourGHz;
-    case NL80211_BAND_5GHZ:
-        return Ieee80211FrequencyBand::FiveGHz;
-    case NL80211_BAND_60GHZ:
-        return Ieee80211FrequencyBand::SixGHz;
-    default:
-        return Ieee80211FrequencyBand::Unknown;
-    }
-}
-
-std::vector<Ieee80211Protocol>
-Nl80211WiphyToIeee80211Protocols(const Nl80211Wiphy& nl80211Wiphy)
-{
-    // Ieee80211 B & G are always supported.
-    std::vector<Ieee80211Protocol> protocols{
-        Ieee80211Protocol::B,
-        Ieee80211Protocol::G,
-    };
-
-    for (const auto& band : std::views::values(nl80211Wiphy.Bands)) {
-        if (band.HtCapabilities != 0) {
-            protocols.push_back(Ieee80211Protocol::N);
-        }
-        if (band.VhtCapabilities != 0) {
-            protocols.push_back(Ieee80211Protocol::AC);
-        }
-        // TODO: once Nl80211WiphyBand is updated to support HE (AX) and EHT (BE), add them here.
-    }
-
-    // Remove duplicates.
-    std::ranges::sort(protocols);
-    protocols.erase(std::ranges::begin(std::ranges::unique(protocols)), std::ranges::end(protocols));
-
-    return protocols;
-}
-
-Wpa::HostapdHwMode
-IeeeProtocolToHostapdHwMode(Ieee80211Protocol ieeeProtocol)
-{
-    switch (ieeeProtocol) {
-    case Ieee80211Protocol::B:
-        return Wpa::HostapdHwMode::Ieee80211b;
-    case Ieee80211Protocol::G:
-        return Wpa::HostapdHwMode::Ieee80211g;
-    case Ieee80211Protocol::N:
-        return Wpa::HostapdHwMode::Ieee80211a; // TODO: Could be a or g depending on band
-    case Ieee80211Protocol::A:
-        return Wpa::HostapdHwMode::Ieee80211a;
-    case Ieee80211Protocol::AC:
-        return Wpa::HostapdHwMode::Ieee80211a;
-    case Ieee80211Protocol::AD:
-        return Wpa::HostapdHwMode::Ieee80211ad;
-    case Ieee80211Protocol::AX:
-        return Wpa::HostapdHwMode::Ieee80211a;
-    case Ieee80211Protocol::BE:
-        return Wpa::HostapdHwMode::Ieee80211a; // TODO: Assuming a, although hostapd docs don't mention it
-    default:
-        return Wpa::HostapdHwMode::Unknown;
-    }
-}
-
-std::string
-HostapdHwModeToPropertyValue(Wpa::HostapdHwMode hwMode)
-{
-    switch (hwMode) {
-    case Wpa::HostapdHwMode::Ieee80211b:
-        return Wpa::ProtocolHostapd::PropertyHwModeValueB;
-    case Wpa::HostapdHwMode::Ieee80211g:
-        return Wpa::ProtocolHostapd::PropertyHwModeValueG;
-    case Wpa::HostapdHwMode::Ieee80211a:
-        return Wpa::ProtocolHostapd::PropertyHwModeValueA;
-    case Wpa::HostapdHwMode::Ieee80211ad:
-        return Wpa::ProtocolHostapd::PropertyHwModeValueAD;
-    case Wpa::HostapdHwMode::Ieee80211any:
-        return Wpa::ProtocolHostapd::PropertyHwModeValueAny;
-    default: // case Wpa::HostapdHwMode::Unknown
-        throw AccessPointControllerException(std::format("Invalid hostapd hw_mode value {}", magic_enum::enum_name(hwMode)));
-    }
-}
-
-std::string_view
-IeeeFrequencyBandToHostapdBand(Ieee80211FrequencyBand ieeeFrequencyBand)
-{
-    switch (ieeeFrequencyBand) {
-    case Ieee80211FrequencyBand::TwoPointFourGHz:
-        return Wpa::ProtocolHostapd::PropertySetBandValue2G;
-    case Ieee80211FrequencyBand::FiveGHz:
-        return Wpa::ProtocolHostapd::PropertySetBandValue5G;
-    case Ieee80211FrequencyBand::SixGHz:
-        return Wpa::ProtocolHostapd::PropertySetBandValue6G;
-    default:
-        throw AccessPointControllerException(std::format("Invalid ieee80211 frequency band value {}", magic_enum::enum_name(ieeeFrequencyBand)));
-    }
-}
-} // namespace detail
 
 AccessPointOperationStatus
 AccessPointControllerLinux::GetCapabilities(Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) noexcept
@@ -168,19 +55,19 @@ AccessPointControllerLinux::GetCapabilities(Ieee80211AccessPointCapabilities& ie
     Ieee80211AccessPointCapabilities capabilities{};
 
     // Convert protocols.
-    capabilities.Protocols = detail::Nl80211WiphyToIeee80211Protocols(wiphy.value());
+    capabilities.Protocols = Nl80211WiphyToIeee80211Protocols(wiphy.value());
 
     // Convert frequency bands.
     capabilities.FrequencyBands = std::vector<Ieee80211FrequencyBand>(std::size(wiphy->Bands));
-    std::ranges::transform(std::views::keys(wiphy->Bands), std::begin(capabilities.FrequencyBands), detail::Nl80211BandToIeee80211FrequencyBand);
+    std::ranges::transform(std::views::keys(wiphy->Bands), std::begin(capabilities.FrequencyBands), Nl80211BandToIeee80211FrequencyBand);
 
     // Convert AKM suites.
     capabilities.AkmSuites = std::vector<Ieee80211AkmSuite>(std::size(wiphy->AkmSuites));
-    std::ranges::transform(wiphy->AkmSuites, std::begin(capabilities.AkmSuites), detail::Nl80211AkmSuiteToIeee80211AkmSuite);
+    std::ranges::transform(wiphy->AkmSuites, std::begin(capabilities.AkmSuites), Nl80211AkmSuiteToIeee80211AkmSuite);
 
     // Convert cipher suites.
     capabilities.CipherSuites = std::vector<Ieee80211CipherSuite>(std::size(wiphy->CipherSuites));
-    std::ranges::transform(wiphy->CipherSuites, std::begin(capabilities.CipherSuites), detail::Nl80211CipherSuiteToIeee80211CipherSuite);
+    std::ranges::transform(wiphy->CipherSuites, std::begin(capabilities.CipherSuites), Nl80211CipherSuiteToIeee80211CipherSuite);
 
     ieee80211AccessPointCapabilities = std::move(capabilities);
 
@@ -257,8 +144,8 @@ AccessPointControllerLinux::SetProtocol(Ieee80211Protocol ieeeProtocol) noexcept
     std::vector<std::pair<std::string_view, std::string_view>> propertiesToSet{};
 
     // Add the hw_mode property.
-    const auto hwMode = detail::IeeeProtocolToHostapdHwMode(ieeeProtocol);
-    const auto hwModeValue = detail::HostapdHwModeToPropertyValue(hwMode);
+    const auto hwMode = IeeeProtocolToHostapdHwMode(ieeeProtocol);
+    const auto hwModeValue = HostapdHwModeToPropertyValue(hwMode);
     propertiesToSet.emplace_back(Wpa::ProtocolHostapd::PropertyNameHwMode, hwModeValue);
 
     // Additively set other hostapd properties based on the protocol.
@@ -335,7 +222,7 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
     // Generate the argument for the hostapd "setband" command, which accepts a comma separated list of bands.
     std::ostringstream setBandArgumentBuilder;
     for (const auto& band : frequencyBands) {
-        setBandArgumentBuilder << detail::IeeeFrequencyBandToHostapdBand(band) << ',';
+        setBandArgumentBuilder << IeeeFrequencyBandToHostapdBand(band) << ',';
     }
 
     const std::string setBandArgumentAll = setBandArgumentBuilder.str();

--- a/src/linux/wifi/core/CMakeLists.txt
+++ b/src/linux/wifi/core/CMakeLists.txt
@@ -9,6 +9,8 @@ target_sources(wifi-core-linux
     PRIVATE
         AccessPointControllerLinux.cxx
         AccessPointLinux.cxx
+        Ieee80211Nl80211Adapters.cxx
+        Ieee80211Nl80211Adapters.hxx
     PUBLIC
     FILE_SET HEADERS
     BASE_DIRS ${WIFI_CORE_LINUX_PUBLIC_INCLUDE}

--- a/src/linux/wifi/core/Ieee80211Nl80211Adapters.cxx
+++ b/src/linux/wifi/core/Ieee80211Nl80211Adapters.cxx
@@ -1,0 +1,132 @@
+
+#include <algorithm>
+#include <cstdint>
+#include <format>
+#include <ranges>
+#include <vector>
+
+#include <Wpa/ProtocolHostapd.hxx>
+#include <linux/nl80211.h>
+#include <magic_enum.hpp>
+#include <microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx>
+#include <microsoft/net/wifi/IAccessPointController.hxx>
+#include <microsoft/net/wifi/Ieee80211.hxx>
+
+#include "Ieee80211Nl80211Adapters.hxx"
+
+using Microsoft::Net::Netlink::Nl80211::Nl80211Wiphy;
+
+namespace Microsoft::Net::Wifi
+{
+Ieee80211CipherSuite
+Nl80211CipherSuiteToIeee80211CipherSuite(uint32_t nl80211CipherSuite) noexcept
+{
+    return static_cast<Ieee80211CipherSuite>(nl80211CipherSuite);
+}
+
+Ieee80211AkmSuite
+Nl80211AkmSuiteToIeee80211AkmSuite(uint32_t nl80211AkmSuite) noexcept
+{
+    return static_cast<Ieee80211AkmSuite>(nl80211AkmSuite);
+}
+
+Ieee80211FrequencyBand
+Nl80211BandToIeee80211FrequencyBand(nl80211_band nl80211Band) noexcept
+{
+    switch (nl80211Band) {
+    case NL80211_BAND_2GHZ:
+        return Ieee80211FrequencyBand::TwoPointFourGHz;
+    case NL80211_BAND_5GHZ:
+        return Ieee80211FrequencyBand::FiveGHz;
+    case NL80211_BAND_60GHZ:
+        return Ieee80211FrequencyBand::SixGHz;
+    default:
+        return Ieee80211FrequencyBand::Unknown;
+    }
+}
+
+std::vector<Ieee80211Protocol>
+Nl80211WiphyToIeee80211Protocols(const Nl80211Wiphy& nl80211Wiphy)
+{
+    // Ieee80211 B & G are always supported.
+    std::vector<Ieee80211Protocol> protocols{
+        Ieee80211Protocol::B,
+        Ieee80211Protocol::G,
+    };
+
+    for (const auto& band : std::views::values(nl80211Wiphy.Bands)) {
+        if (band.HtCapabilities != 0) {
+            protocols.push_back(Ieee80211Protocol::N);
+        }
+        if (band.VhtCapabilities != 0) {
+            protocols.push_back(Ieee80211Protocol::AC);
+        }
+        // TODO: once Nl80211WiphyBand is updated to support HE (AX) and EHT (BE), add them here.
+    }
+
+    // Remove duplicates.
+    std::ranges::sort(protocols);
+    protocols.erase(std::ranges::begin(std::ranges::unique(protocols)), std::ranges::end(protocols));
+
+    return protocols;
+}
+
+Wpa::HostapdHwMode
+IeeeProtocolToHostapdHwMode(Ieee80211Protocol ieeeProtocol)
+{
+    switch (ieeeProtocol) {
+    case Ieee80211Protocol::B:
+        return Wpa::HostapdHwMode::Ieee80211b;
+    case Ieee80211Protocol::G:
+        return Wpa::HostapdHwMode::Ieee80211g;
+    case Ieee80211Protocol::N:
+        return Wpa::HostapdHwMode::Ieee80211a; // TODO: Could be a or g depending on band
+    case Ieee80211Protocol::A:
+        return Wpa::HostapdHwMode::Ieee80211a;
+    case Ieee80211Protocol::AC:
+        return Wpa::HostapdHwMode::Ieee80211a;
+    case Ieee80211Protocol::AD:
+        return Wpa::HostapdHwMode::Ieee80211ad;
+    case Ieee80211Protocol::AX:
+        return Wpa::HostapdHwMode::Ieee80211a;
+    case Ieee80211Protocol::BE:
+        return Wpa::HostapdHwMode::Ieee80211a; // TODO: Assuming a, although hostapd docs don't mention it
+    default:
+        return Wpa::HostapdHwMode::Unknown;
+    }
+}
+
+std::string
+HostapdHwModeToPropertyValue(Wpa::HostapdHwMode hwMode)
+{
+    switch (hwMode) {
+    case Wpa::HostapdHwMode::Ieee80211b:
+        return Wpa::ProtocolHostapd::PropertyHwModeValueB;
+    case Wpa::HostapdHwMode::Ieee80211g:
+        return Wpa::ProtocolHostapd::PropertyHwModeValueG;
+    case Wpa::HostapdHwMode::Ieee80211a:
+        return Wpa::ProtocolHostapd::PropertyHwModeValueA;
+    case Wpa::HostapdHwMode::Ieee80211ad:
+        return Wpa::ProtocolHostapd::PropertyHwModeValueAD;
+    case Wpa::HostapdHwMode::Ieee80211any:
+        return Wpa::ProtocolHostapd::PropertyHwModeValueAny;
+    default: // case Wpa::HostapdHwMode::Unknown
+        throw AccessPointControllerException(std::format("Invalid hostapd hw_mode value {}", magic_enum::enum_name(hwMode)));
+    }
+}
+
+std::string_view
+IeeeFrequencyBandToHostapdBand(Ieee80211FrequencyBand ieeeFrequencyBand)
+{
+    switch (ieeeFrequencyBand) {
+    case Ieee80211FrequencyBand::TwoPointFourGHz:
+        return Wpa::ProtocolHostapd::PropertySetBandValue2G;
+    case Ieee80211FrequencyBand::FiveGHz:
+        return Wpa::ProtocolHostapd::PropertySetBandValue5G;
+    case Ieee80211FrequencyBand::SixGHz:
+        return Wpa::ProtocolHostapd::PropertySetBandValue6G;
+    default:
+        throw AccessPointControllerException(std::format("Invalid ieee80211 frequency band value {}", magic_enum::enum_name(ieeeFrequencyBand)));
+    }
+}
+} // namespace Microsoft::Net::Wifi

--- a/src/linux/wifi/core/Ieee80211Nl80211Adapters.cxx
+++ b/src/linux/wifi/core/Ieee80211Nl80211Adapters.cxx
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <format>
 #include <ranges>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include <Wpa/ProtocolHostapd.hxx>

--- a/src/linux/wifi/core/Ieee80211Nl80211Adapters.hxx
+++ b/src/linux/wifi/core/Ieee80211Nl80211Adapters.hxx
@@ -3,6 +3,8 @@
 #define IEEE_80211_NL80211_ADAPTERS_HXX
 
 #include <cstdint>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include <Wpa/ProtocolHostapd.hxx>

--- a/src/linux/wifi/core/Ieee80211Nl80211Adapters.hxx
+++ b/src/linux/wifi/core/Ieee80211Nl80211Adapters.hxx
@@ -1,0 +1,38 @@
+
+#ifndef IEEE_80211_NL80211_ADAPTERS_HXX
+#define IEEE_80211_NL80211_ADAPTERS_HXX
+
+#include <cstdint>
+#include <vector>
+
+#include <Wpa/ProtocolHostapd.hxx>
+#include <linux/nl80211.h>
+#include <microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx>
+#include <microsoft/net/wifi/Ieee80211.hxx>
+
+namespace Microsoft::Net::Wifi
+{
+Ieee80211CipherSuite
+Nl80211CipherSuiteToIeee80211CipherSuite(uint32_t nl80211CipherSuite) noexcept;
+
+Ieee80211AkmSuite
+Nl80211AkmSuiteToIeee80211AkmSuite(uint32_t nl80211AkmSuite) noexcept;
+
+Ieee80211FrequencyBand
+Nl80211BandToIeee80211FrequencyBand(nl80211_band nl80211Band) noexcept;
+
+std::vector<Ieee80211Protocol>
+Nl80211WiphyToIeee80211Protocols(const Microsoft::Net::Netlink::Nl80211::Nl80211Wiphy& nl80211Wiphy);
+
+Wpa::HostapdHwMode
+IeeeProtocolToHostapdHwMode(Ieee80211Protocol ieeeProtocol);
+
+std::string
+HostapdHwModeToPropertyValue(Wpa::HostapdHwMode hwMode);
+
+std::string_view
+IeeeFrequencyBandToHostapdBand(Ieee80211FrequencyBand ieeeFrequencyBand);
+
+} // namespace Microsoft::Net::Wifi
+
+#endif // IEEE_80211_NL80211_ADAPTERS_HXX

--- a/src/linux/wifi/core/Ieee80211Nl80211Adapters.hxx
+++ b/src/linux/wifi/core/Ieee80211Nl80211Adapters.hxx
@@ -14,24 +14,66 @@
 
 namespace Microsoft::Net::Wifi
 {
+/**
+ * @brief Convert the specified nl80211 cipher suite value to the equivalent Ieee80211CipherSuite.
+ *
+ * @param nl80211CipherSuite The nl80211 cipher suite value to convert.
+ * @return Ieee80211CipherSuite
+ */
 Ieee80211CipherSuite
 Nl80211CipherSuiteToIeee80211CipherSuite(uint32_t nl80211CipherSuite) noexcept;
 
+/**
+ * @brief Convert the specified nl80211 akm suite value to the equivalent Ieee80211AkmSuite.
+ *
+ * @param nl80211AkmSuite The nl80211 akm suite value to convert.
+ * @return Ieee80211AkmSuite
+ */
 Ieee80211AkmSuite
 Nl80211AkmSuiteToIeee80211AkmSuite(uint32_t nl80211AkmSuite) noexcept;
 
+/**
+ * @brief Convert the specified nl80211_band value to the equivalent Ieee80211FrequencyBand.
+ *
+ * @param nl80211Band The nl80211_band value to convert.
+ * @return Ieee80211FrequencyBand
+ */
 Ieee80211FrequencyBand
 Nl80211BandToIeee80211FrequencyBand(nl80211_band nl80211Band) noexcept;
 
+/**
+ * @brief Obtain a list of Ieee80211Protocols from a Nl80211Wiphy.
+ *
+ * @param nl80211Wiphy The Nl80211Wiphy to obtain the protocols from.
+ * @return std::vector<Ieee80211Protocol>
+ */
 std::vector<Ieee80211Protocol>
 Nl80211WiphyToIeee80211Protocols(const Microsoft::Net::Netlink::Nl80211::Nl80211Wiphy& nl80211Wiphy);
 
+/**
+ * @brief Convert a WPA "hwmode" value from a Ieee80211Protocol value.
+ *
+ * @param ieeeProtocol The Ieee80211Protocol value to convert.
+ * @return Wpa::HostapdHwMode
+ */
 Wpa::HostapdHwMode
 IeeeProtocolToHostapdHwMode(Ieee80211Protocol ieeeProtocol);
 
+/**
+ * @brief Get a string representation of a HostapdHwMode.
+ *
+ * @param hwMode The HostapdHwMode value to convert.
+ * @return std::string
+ */
 std::string
 HostapdHwModeToPropertyValue(Wpa::HostapdHwMode hwMode);
 
+/**
+ * @brief Get a string representation of a Ieee80211FrequencyBand.
+ *
+ * @param ieeeFrequencyBand The Ieee80211FrequencyBand value to convert.
+ * @return std::string_view
+ */
 std::string_view
 IeeeFrequencyBandToHostapdBand(Ieee80211FrequencyBand ieeeFrequencyBand);
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Make NL80211 helper code available more broadly.

### Technical Details

* Move helpers that convert NL80211 <-> Ieee80211 types to its own (private) source file.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
