### PR TITLE
Add continuous download stream unit test

### DIFF
--- a/protocol/protos/NetRemoteDataStream.proto
+++ b/protocol/protos/NetRemoteDataStream.proto
@@ -8,7 +8,7 @@ enum DataStreamOperationStatusCode
     DataStreamOperationStatusCodeUnknown = 0;
     DataStreamOperationStatusCodeSucceeded = 1;
     DataStreamOperationStatusCodeFailed = 2;
-    DataStreamOperationStatusCodeCancelled = 3;
+    DataStreamOperationStatusCodeCanceled = 3;
     DataStreamOperationStatusCodeTimedOut = 4;
 }
 

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -3,6 +3,7 @@
 
 #include "NetRemoteDataStreamingReactors.hxx"
 #include <magic_enum.hpp>
+#include <plog/Log.h>
 
 using namespace Microsoft::Net::Remote::DataStream;
 using namespace Microsoft::Net::Remote::Service::Reactors;
@@ -48,6 +49,7 @@ DataStreamReader::OnDone()
 
 DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request)
 {
+    LOGD << "Enter constructor";
     m_dataStreamProperties = request->properties();
 
     switch (m_dataStreamProperties.type()) {
@@ -85,6 +87,7 @@ DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request)
 void
 DataStreamWriter::OnWriteDone(bool isOk)
 {
+    LOGD << "Enter OnWriteDone";
     // Check for a failed status code from HandleWriteFailure since that invoked a final write, thus causing this callback to be invoked.
     if (m_writeStatus.code() == DataStreamOperationStatusCode::DataStreamOperationStatusCodeFailed) {
         Finish(::grpc::Status::OK);
@@ -107,6 +110,7 @@ DataStreamWriter::OnWriteDone(bool isOk)
 void
 DataStreamWriter::OnCancel()
 {
+    LOGD << "Enter OnCancel";
     // The RPC is cancelled by the client, so call Finish to complete it from the server perspective.
     Finish(grpc::Status::CANCELLED);
 }
@@ -114,12 +118,14 @@ DataStreamWriter::OnCancel()
 void
 DataStreamWriter::OnDone()
 {
+    LOGD << "Enter OnDone";
     delete this;
 }
 
 void
 DataStreamWriter::NextWrite()
 {
+    LOGD << "Enter NextWrite";
     if (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeContinuous ||
         (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeFixed && m_numberOfDataBlocksToStream > 0)) {
         // Create data to write to the client.
@@ -139,6 +145,7 @@ DataStreamWriter::NextWrite()
 void
 DataStreamWriter::HandleFailure(const std::string& errorMessage)
 {
+    LOGD << "Enter HandleFailure";
     m_writeStatus.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeFailed);
     m_writeStatus.set_message(errorMessage);
     *m_data.mutable_status() = m_writeStatus;

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -40,8 +40,8 @@ DataStreamReader::OnCancel()
     LOGD << "Enter OnCancel";
 
     m_result->set_numberofdatablocksreceived(m_numberOfDataBlocksReceived);
-    m_readStatus.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeCancelled);
-    m_readStatus.set_message("RPC cancelled");
+    m_readStatus.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeCanceled);
+    m_readStatus.set_message("RPC canceled");
     *m_result->mutable_status() = std::move(m_readStatus);
     Finish(grpc::Status::CANCELLED);
 }
@@ -95,9 +95,10 @@ DataStreamWriter::OnWriteDone(bool isOk)
 {
     LOGD << "Enter OnWriteDone";
 
-    // Client may have cancelled the RPC, so check for cancellation to prevent writing more data
+    // Client may have canceled the RPC, so check for cancelation to prevent writing more data
     // when we shouldn't.
-    if (m_isCancelled.load(std::memory_order_relaxed)) {
+    if (m_isCanceled.load(std::memory_order_relaxed)) {
+        LOGD << "RPC canceled, returning early";
         return;
     }
 
@@ -125,9 +126,9 @@ DataStreamWriter::OnCancel()
 {
     LOGD << "Enter OnCancel";
 
-    // The RPC is cancelled by the client, so call Finish to complete it from the server perspective.
-    if (!m_isCancelled.load(std::memory_order_relaxed)) {
-        m_isCancelled.store(true, std::memory_order_relaxed);
+    // The RPC is canceled by the client, so call Finish to complete it from the server perspective.
+    if (!m_isCanceled.load(std::memory_order_relaxed)) {
+        m_isCanceled.store(true, std::memory_order_relaxed);
         Finish(grpc::Status::CANCELLED);
     }
 }
@@ -144,9 +145,10 @@ DataStreamWriter::NextWrite()
 {
     LOGD << "Enter NextWrite";
 
-    // Client may have cancelled the RPC, so check for cancellation to prevent writing more data
+    // Client may have canceled the RPC, so check for cancelation to prevent writing more data
     // when we shouldn't.
-    if (m_isCancelled.load(std::memory_order_relaxed)) {
+    if (m_isCanceled.load(std::memory_order_relaxed)) {
+        LOGD << "RPC canceled, aborting write";
         return;
     }
 

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -127,8 +127,8 @@ DataStreamWriter::OnCancel()
     LOGD << "Enter OnCancel";
 
     // The RPC is canceled by the client, so call Finish to complete it from the server perspective.
-    if (!m_isCanceled.load(std::memory_order_relaxed)) {
-        m_isCanceled.store(true, std::memory_order_relaxed);
+    bool isCanceledExpected{ false };
+    if (m_isCanceled.compare_exchange_strong(isCanceledExpected, true, std::memory_order_relaxed, std::memory_order_relaxed)) {
         Finish(grpc::Status::CANCELLED);
     }
 }

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -34,7 +34,7 @@ public:
     OnReadDone(bool isOk) override;
 
     /**
-     * @brief Callback that is executed when an RPC is cancelled before successfully sending a status to the client.
+     * @brief Callback that is executed when an RPC is canceled before successfully sending a status to the client.
      */
     void
     OnCancel() override;
@@ -75,7 +75,7 @@ public:
     OnWriteDone(bool isOk) override;
 
     /**
-     * @brief Callback that is executed when an RPC is cancelled before successfully sending a status to the client.
+     * @brief Callback that is executed when an RPC is canceled before successfully sending a status to the client.
      */
     void
     OnCancel() override;
@@ -107,7 +107,7 @@ private:
     uint32_t m_numberOfDataBlocksToStream{};
     uint32_t m_numberOfDataBlocksWritten{};
     Microsoft::Net::Remote::DataStream::DataStreamOperationStatus m_writeStatus{};
-    std::atomic<bool> m_isCancelled{};
+    std::atomic<bool> m_isCanceled{};
 };
 } // namespace Microsoft::Net::Remote::Service::Reactors
 

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -2,6 +2,7 @@
 #ifndef NET_REMOTE_DATA_STREAMING_REACTORS_HXX
 #define NET_REMOTE_DATA_STREAMING_REACTORS_HXX
 
+#include <atomic>
 #include <cstdint>
 #include <string>
 
@@ -106,6 +107,7 @@ private:
     uint32_t m_numberOfDataBlocksToStream{};
     uint32_t m_numberOfDataBlocksWritten{};
     Microsoft::Net::Remote::DataStream::DataStreamOperationStatus m_writeStatus{};
+    std::atomic<bool> m_isCancelled{};
 };
 } // namespace Microsoft::Net::Remote::Service::Reactors
 

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -125,3 +125,9 @@ DataStreamReader::Await(uint32_t* numberOfDataBlocksReceived, DataStreamOperatio
 
     return m_status;
 }
+
+void
+DataStreamReader::Cancel()
+{
+    m_clientContext.TryCancel();
+}

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -3,6 +3,7 @@
 #include <format>
 
 #include "TestNetRemoteDataStreamingReactors.hxx"
+#include <plog/Log.h>
 
 using namespace Microsoft::Net::Remote::DataStream;
 using namespace Microsoft::Net::Remote::Service;
@@ -129,5 +130,6 @@ DataStreamReader::Await(uint32_t* numberOfDataBlocksReceived, DataStreamOperatio
 void
 DataStreamReader::Cancel()
 {
+    LOGD << "Attempting to cancel RPC";
     m_clientContext.TryCancel();
 }

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -117,6 +117,12 @@ public:
     grpc::Status
     Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus);
 
+    /**
+     * @brief Cancel the ongoing RPC.
+     */
+    void
+    Cancel();
+
 private:
     static inline constexpr auto c_defaultTimeoutValue{ 10s };
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

This PR adds a unit test to test the continuous data streaming feature of the `DataStreamDownload` API. Some extra logging to help with debugging is added too.

### Technical Details

* Add new unit test.
* Add `Cancel` method to client test reactor, which invokes gRPC `TryCancel()`.
* Properly handle cancellation on the server side with `std::atomic<bool>` flag in `OnCancel`, `OnWriteDone`, and `NextWrite`.
* Add plog usage to `NetRemoteDataStreamingReactors`.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
