### PR TITLE
Expand FunctionTracer to allow configurable log severity for entrance log

### DIFF
--- a/src/common/service/NetRemoteApiTrace.cxx
+++ b/src/common/service/NetRemoteApiTrace.cxx
@@ -8,6 +8,6 @@
 
 using namespace Microsoft::Net::Remote::Service::Tracing;
 
-NetRemoteApiTrace::NetRemoteApiTrace(bool deferEnter, plog::Severity logSeverityEnter, std::source_location location) :
-    logging::FunctionTracer(logSeverityEnter, LogTracePrefix, {}, deferEnter, location)
+NetRemoteApiTrace::NetRemoteApiTrace(bool deferEnter, plog::Severity logSeverityEnter, plog::Severity logSeverityExit, std::source_location location) :
+    logging::FunctionTracer(logSeverityEnter, logSeverityExit, LogTracePrefix, {}, deferEnter, location)
 {}

--- a/src/common/service/NetRemoteApiTrace.cxx
+++ b/src/common/service/NetRemoteApiTrace.cxx
@@ -1,11 +1,13 @@
 
 #include <source_location>
 
-#include "NetRemoteApiTrace.hxx"
 #include <logging/FunctionTracer.hxx>
+#include <plog/Severity.h>
+
+#include "NetRemoteApiTrace.hxx"
 
 using namespace Microsoft::Net::Remote::Service::Tracing;
 
-NetRemoteApiTrace::NetRemoteApiTrace(bool deferEnter, std::source_location location) :
-    logging::FunctionTracer(LogTracePrefix, {}, deferEnter, location)
+NetRemoteApiTrace::NetRemoteApiTrace(bool deferEnter, plog::Severity logSeverityEnter, std::source_location location) :
+    logging::FunctionTracer(logSeverityEnter, LogTracePrefix, {}, deferEnter, location)
 {}

--- a/src/common/service/NetRemoteApiTrace.hxx
+++ b/src/common/service/NetRemoteApiTrace.hxx
@@ -20,9 +20,13 @@ struct NetRemoteApiTrace :
      *
      * @param deferEnter Whether to defer the entry log message upon construction.
      * @param logSeverityEnter The log severity to use when tracing function entrance.
+     * @param logSeverityExit The log severity to use when tracing function exit.
      * @param location The source code location of the function call.
      */
-    NetRemoteApiTrace(bool deferEnter = false, plog::Severity logSeverityEnter = LogSeverityEnterDefault, std::source_location location = std::source_location::current());
+    NetRemoteApiTrace(bool deferEnter = false, plog::Severity logSeverityEnter = LogSeverityDefaultApi, plog::Severity logSeverityExit = LogSeverityDefaultApi, std::source_location location = std::source_location::current());
+
+protected:
+    static constexpr auto LogSeverityDefaultApi{ plog::Severity::info };
 
 private:
     static constexpr auto LogTracePrefix = "[API]";

--- a/src/common/service/NetRemoteApiTrace.hxx
+++ b/src/common/service/NetRemoteApiTrace.hxx
@@ -5,6 +5,7 @@
 #include <source_location>
 
 #include <logging/FunctionTracer.hxx>
+#include <plog/Severity.h>
 
 namespace Microsoft::Net::Remote::Service::Tracing
 {
@@ -18,9 +19,10 @@ struct NetRemoteApiTrace :
      * @brief Construct a new NetRemoteApiTrace object.
      *
      * @param deferEnter Whether to defer the entry log message upon construction.
+     * @param logSeverityEnter The log severity to use when tracing function entrance.
      * @param location The source code location of the function call.
      */
-    NetRemoteApiTrace(bool deferEnter = false, std::source_location location = std::source_location::current());
+    NetRemoteApiTrace(bool deferEnter = false, plog::Severity logSeverityEnter = LogSeverityEnterDefault, std::source_location location = std::source_location::current());
 
 private:
     static constexpr auto LogTracePrefix = "[API]";

--- a/src/common/service/NetRemoteWifiApiTrace.cxx
+++ b/src/common/service/NetRemoteWifiApiTrace.cxx
@@ -14,8 +14,8 @@ using namespace Microsoft::Net::Remote::Service::Tracing;
 using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus;
 using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode;
 
-NetRemoteWifiApiTrace::NetRemoteWifiApiTrace(std::optional<std::string> accessPointId, const WifiAccessPointOperationStatus* operationStatus, plog::Severity logSeverityEnter, std::source_location location) :
-    NetRemoteApiTrace(/* deferEnter= */ true, logSeverityEnter, location),
+NetRemoteWifiApiTrace::NetRemoteWifiApiTrace(std::optional<std::string> accessPointId, const WifiAccessPointOperationStatus* operationStatus, plog::Severity logSeverityEnter, plog::Severity logSeverityExit, std::source_location location) :
+    NetRemoteApiTrace(/* deferEnter= */ true, logSeverityEnter, logSeverityExit, location),
     m_accessPointId(std::move(accessPointId)),
     m_operationStatus(operationStatus)
 {

--- a/src/common/service/NetRemoteWifiApiTrace.cxx
+++ b/src/common/service/NetRemoteWifiApiTrace.cxx
@@ -14,8 +14,8 @@ using namespace Microsoft::Net::Remote::Service::Tracing;
 using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus;
 using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode;
 
-NetRemoteWifiApiTrace::NetRemoteWifiApiTrace(std::optional<std::string> accessPointId, const WifiAccessPointOperationStatus* operationStatus, std::source_location location) :
-    NetRemoteApiTrace(/* deferEnter= */ true, location),
+NetRemoteWifiApiTrace::NetRemoteWifiApiTrace(std::optional<std::string> accessPointId, const WifiAccessPointOperationStatus* operationStatus, plog::Severity logSeverityEnter, std::source_location location) :
+    NetRemoteApiTrace(/* deferEnter= */ true, logSeverityEnter, location),
     m_accessPointId(std::move(accessPointId)),
     m_operationStatus(operationStatus)
 {

--- a/src/common/service/NetRemoteWifiApiTrace.cxx
+++ b/src/common/service/NetRemoteWifiApiTrace.cxx
@@ -1,13 +1,15 @@
 
 #include <optional>
-#include <string>
 #include <source_location>
+#include <string>
 #include <utility>
+
+#include <magic_enum.hpp>
+#include <microsoft/net/remote/protocol/NetRemoteWifi.pb.h>
+#include <plog/Severity.h>
 
 #include "NetRemoteApiTrace.hxx"
 #include "NetRemoteWifiApiTrace.hxx"
-#include <magic_enum.hpp>
-#include <microsoft/net/remote/protocol/NetRemoteWifi.pb.h>
 
 using namespace Microsoft::Net::Remote::Service::Tracing;
 

--- a/src/common/service/NetRemoteWifiApiTrace.hxx
+++ b/src/common/service/NetRemoteWifiApiTrace.hxx
@@ -6,8 +6,11 @@
 #include <source_location>
 #include <string>
 
-#include "NetRemoteApiTrace.hxx"
+#include <logging/FunctionTracer.hxx>
 #include <microsoft/net/remote/protocol/NetRemoteService.grpc.pb.h>
+#include <plog/Severity.h>
+
+#include "NetRemoteApiTrace.hxx"
 
 namespace Microsoft::Net::Remote::Service::Tracing
 {
@@ -25,7 +28,7 @@ struct NetRemoteWifiApiTrace :
      * @param operationStatus The result status of the operation, if present.
      * @param location The source code location of the function call.
      */
-    NetRemoteWifiApiTrace(std::optional<std::string> accessPointId = std::nullopt, const Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus* operationStatus = nullptr, std::source_location location = std::source_location::current());
+    NetRemoteWifiApiTrace(std::optional<std::string> accessPointId = std::nullopt, const Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus* operationStatus = nullptr, plog::Severity logSeverityEnter = LogSeverityEnterDefault, std::source_location location = std::source_location::current());
 
     /**
      * @brief Destroy the NetRemoteWifiApiTrace object.

--- a/src/common/service/NetRemoteWifiApiTrace.hxx
+++ b/src/common/service/NetRemoteWifiApiTrace.hxx
@@ -28,7 +28,7 @@ struct NetRemoteWifiApiTrace :
      * @param operationStatus The result status of the operation, if present.
      * @param location The source code location of the function call.
      */
-    NetRemoteWifiApiTrace(std::optional<std::string> accessPointId = std::nullopt, const Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus* operationStatus = nullptr, plog::Severity logSeverityEnter = LogSeverityEnterDefault, std::source_location location = std::source_location::current());
+    NetRemoteWifiApiTrace(std::optional<std::string> accessPointId = std::nullopt, const Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus* operationStatus = nullptr, plog::Severity logSeverityEnter = LogSeverityDefaultApi, plog::Severity logSeverityExit = LogSeverityDefaultApi, std::source_location location = std::source_location::current());
 
     /**
      * @brief Destroy the NetRemoteWifiApiTrace object.

--- a/src/common/shared/logging/FunctionTracer.cxx
+++ b/src/common/shared/logging/FunctionTracer.cxx
@@ -74,8 +74,8 @@ FunctionTracer::Enter()
     }
 
     m_entered = true;
-    auto arguments = detail::BuildValueList(m_arguments, " with arguments ");
-    LOGI << std::format("{} +{}{}", m_logPrefix, m_functionName, arguments);
+    const auto arguments = detail::BuildValueList(m_arguments, " with arguments ");
+    PLOG(m_logSeverityEnter) << std::format("{} +{}{}", m_logPrefix, m_functionName, arguments);
 }
 
 void

--- a/src/common/shared/logging/FunctionTracer.cxx
+++ b/src/common/shared/logging/FunctionTracer.cxx
@@ -39,7 +39,8 @@ BuildValueList(const std::vector<std::pair<std::string, std::string>>& values, s
 }
 } // namespace detail
 
-FunctionTracer::FunctionTracer(std::string logPrefix, std::vector<std::pair<std::string, std::string>> arguments, bool deferEnter, std::source_location location) :
+FunctionTracer::FunctionTracer(plog::Severity logSeverityEnter, std::string logPrefix, std::vector<std::pair<std::string, std::string>> arguments, bool deferEnter, std::source_location location) :
+    m_logSeverityEnter(logSeverityEnter),
     m_logPrefix(std::move(logPrefix)),
     m_location(location),
     m_functionName(m_location.function_name()),
@@ -117,7 +118,21 @@ FunctionTracer::SetFailed() noexcept
 }
 
 void
-FunctionTracer::SetExitLogSeverity(plog::Severity severity) noexcept
+FunctionTracer::SetEnterLogSeverity(plog::Severity logSeverityEnter) noexcept
 {
-    m_LogSeverityExit = severity;
+    if (m_entered) {
+        LOGW << "warning: calling SetEnterLogSeverity after entered log has already been printed; this will have no effect.";
+    }
+
+    m_logSeverityEnter = logSeverityEnter;
+}
+
+void
+FunctionTracer::SetExitLogSeverity(plog::Severity logSeverityExit) noexcept
+{
+    if (m_exited) {
+        LOGW << "warning: calling SetExitLogSeverity after exited log has already been printed; this will have no effect.";
+    }
+
+    m_LogSeverityExit = logSeverityExit;
 }

--- a/src/common/shared/logging/FunctionTracer.cxx
+++ b/src/common/shared/logging/FunctionTracer.cxx
@@ -39,8 +39,9 @@ BuildValueList(const std::vector<std::pair<std::string, std::string>>& values, s
 }
 } // namespace detail
 
-FunctionTracer::FunctionTracer(plog::Severity logSeverityEnter, std::string logPrefix, std::vector<std::pair<std::string, std::string>> arguments, bool deferEnter, std::source_location location) :
+FunctionTracer::FunctionTracer(plog::Severity logSeverityEnter, plog::Severity logSeverityExit, std::string logPrefix, std::vector<std::pair<std::string, std::string>> arguments, bool deferEnter, std::source_location location) :
     m_logSeverityEnter(logSeverityEnter),
+    m_logSeverityExit(logSeverityExit),
     m_logPrefix(std::move(logPrefix)),
     m_location(location),
     m_functionName(m_location.function_name()),
@@ -89,7 +90,7 @@ FunctionTracer::Exit()
     }
 
     auto returnValues = detail::BuildValueList(m_returnValues, " returning ");
-    PLOG(m_LogSeverityExit) << std::format("{} -{}{}", m_logPrefix, m_functionName, returnValues);
+    PLOG(m_logSeverityExit) << std::format("{} -{}{}", m_logPrefix, m_functionName, returnValues);
     m_exited = true;
 }
 
@@ -108,13 +109,13 @@ FunctionTracer::AddReturnValue(std::string name, std::string value)
 void
 FunctionTracer::SetSucceeded() noexcept
 {
-    m_LogSeverityExit = plog::Severity::info;
+    m_logSeverityExit = plog::Severity::info;
 }
 
 void
 FunctionTracer::SetFailed() noexcept
 {
-    m_LogSeverityExit = plog::Severity::error;
+    m_logSeverityExit = plog::Severity::error;
 }
 
 void
@@ -134,5 +135,5 @@ FunctionTracer::SetExitLogSeverity(plog::Severity logSeverityExit) noexcept
         LOGW << "warning: calling SetExitLogSeverity after exited log has already been printed; this will have no effect.";
     }
 
-    m_LogSeverityExit = logSeverityExit;
+    m_logSeverityExit = logSeverityExit;
 }

--- a/src/common/shared/logging/FunctionTracer.cxx
+++ b/src/common/shared/logging/FunctionTracer.cxx
@@ -86,7 +86,7 @@ FunctionTracer::Exit()
     }
 
     auto returnValues = detail::BuildValueList(m_returnValues, " returning ");
-    PLOG(m_exitLogSeverity) << std::format("{} -{}{}", m_logPrefix, m_functionName, returnValues);
+    PLOG(m_LogSeverityExit) << std::format("{} -{}{}", m_logPrefix, m_functionName, returnValues);
     m_exited = true;
 }
 

--- a/src/common/shared/logging/FunctionTracer.cxx
+++ b/src/common/shared/logging/FunctionTracer.cxx
@@ -69,6 +69,7 @@ FunctionTracer::~FunctionTracer()
 void
 FunctionTracer::Enter()
 {
+    // Note: this is not thread-safe.
     if (m_entered) {
         return;
     }
@@ -81,6 +82,7 @@ FunctionTracer::Enter()
 void
 FunctionTracer::Exit()
 {
+    // Note: this is not thread-safe.
     if (m_exited) {
         return;
     }
@@ -105,17 +107,17 @@ FunctionTracer::AddReturnValue(std::string name, std::string value)
 void
 FunctionTracer::SetSucceeded() noexcept
 {
-    m_exitLogSeverity = plog::Severity::info;
+    m_LogSeverityExit = plog::Severity::info;
 }
 
 void
 FunctionTracer::SetFailed() noexcept
 {
-    m_exitLogSeverity = plog::Severity::error;
+    m_LogSeverityExit = plog::Severity::error;
 }
 
 void
 FunctionTracer::SetExitLogSeverity(plog::Severity severity) noexcept
 {
-    m_exitLogSeverity = severity;
+    m_LogSeverityExit = severity;
 }

--- a/src/common/shared/logging/include/logging/FunctionTracer.hxx
+++ b/src/common/shared/logging/include/logging/FunctionTracer.hxx
@@ -23,7 +23,7 @@ struct FunctionTracer
 {
     /**
      * @brief Construct a new FunctionTracer object.
-     * 
+     *
      * @param logSeverityEnter The severity to log entrance with.
      * @param logSeverityExit The severity to log exit with.
      * @param logPrefix The prefix to use for both log messages.
@@ -31,7 +31,7 @@ struct FunctionTracer
      * @param deferEnter Whether to defer the call to Enter().
      * @param location The source location information of the caller.
      */
-    FunctionTracer(plog::Severity logSeverityEnter = LogSeverityEnterDefault, plog::Severity logSeverityExit = LogSeverityExitDefault, std::string logPrefix = {},  std::vector<std::pair<std::string, std::string>> arguments = {}, bool deferEnter = false, std::source_location location = std::source_location::current());
+    FunctionTracer(plog::Severity logSeverityEnter = LogSeverityEnterDefault, plog::Severity logSeverityExit = LogSeverityExitDefault, std::string logPrefix = {}, std::vector<std::pair<std::string, std::string>> arguments = {}, bool deferEnter = false, std::source_location location = std::source_location::current());
 
     /**
      * @brief Destroy the FunctionTracer object.
@@ -83,7 +83,7 @@ struct FunctionTracer
     /**
      * @brief Manually set the log severity for the enter log message. This only has an effect if the object was created
      * with deferEnter = true.
-     * 
+     *
      * @param logSeverityEnter The log severity to use when printing the entrance log message.
      */
     void
@@ -92,10 +92,10 @@ struct FunctionTracer
     /**
      * @brief Manually set the log severity for the exit log message. This overrides the SetSucceeded and SetFailed methods.
      *
-     * @param severity The log severity to use when printing the exit log message.
+     * @param logSeverityExit The log severity to use when printing the exit log message.
      */
     void
-    SetExitLogSeverity(plog::Severity severity) noexcept;
+    SetExitLogSeverity(plog::Severity logSeverityExit) noexcept;
 
 protected:
     static constexpr auto LogSeverityEnterDefault{ plog::Severity::debug };

--- a/src/common/shared/logging/include/logging/FunctionTracer.hxx
+++ b/src/common/shared/logging/include/logging/FunctionTracer.hxx
@@ -79,6 +79,7 @@ private:
     std::vector<std::pair<std::string, std::string>> m_returnValues;
     bool m_entered{ false };
     bool m_exited{ false };
+    plog::Severity m_logSeverityEnter{ plog:: Severity::info };
     plog::Severity m_exitLogSeverity{ plog::Severity::info };
 };
 } // namespace logging

--- a/src/common/shared/logging/include/logging/FunctionTracer.hxx
+++ b/src/common/shared/logging/include/logging/FunctionTracer.hxx
@@ -68,6 +68,15 @@ struct FunctionTracer
     SetFailed() noexcept;
 
     /**
+     * @brief Manually set the log severity for the enter log message. This only has an effect if the object was created
+     * with deferEnter = true.
+     * 
+     * @param logSeverityEnter The log severity to use when printing the entrance log message.
+     */
+    void
+    SetEnterLogSeverity(plog::Severity logSeverityEnter) noexcept;
+
+    /**
      * @brief Manually set the log severity for the exit log message. This overrides the SetSucceeded and SetFailed methods.
      *
      * @param severity The log severity to use when printing the exit log message.

--- a/src/common/shared/logging/include/logging/FunctionTracer.hxx
+++ b/src/common/shared/logging/include/logging/FunctionTracer.hxx
@@ -80,7 +80,7 @@ private:
     bool m_entered{ false };
     bool m_exited{ false };
     plog::Severity m_logSeverityEnter{ plog:: Severity::info };
-    plog::Severity m_exitLogSeverity{ plog::Severity::info };
+    plog::Severity m_LogSeverityExit{ plog::Severity::info };
 };
 } // namespace logging
 

--- a/src/common/shared/logging/include/logging/FunctionTracer.hxx
+++ b/src/common/shared/logging/include/logging/FunctionTracer.hxx
@@ -17,12 +17,24 @@ namespace logging
  *
  * Note that this does not behave in a thread-safe manner. It is unexpected that Enter() and Exit() calls would occur
  * concurrently since it's expected that this is used as stack-allocated objects which will follow typical stack-based
- * lifetime control, which is inherently single-threaded.  /
+ * lifetime control, which is inherently single-threaded.
  */
 struct FunctionTracer
 {
-    FunctionTracer(std::string logPrefix = {}, std::vector<std::pair<std::string, std::string>> arguments = {}, bool deferEnter = false, std::source_location location = std::source_location::current());
+    /**
+     * @brief Construct a new FunctionTracer object.
+     * 
+     * @param logSeverityEnter The severity to log entrance with.
+     * @param logPrefix The prefix to use for both log messages.
+     * @param arguments The arguments the function was called with.
+     * @param deferEnter Whether to defer the call to Enter().
+     * @param location The source location information of the caller.
+     */
+    FunctionTracer(plog::Severity logSeverityEnter = LogSeverityEnterDefault, std::string logPrefix = {}, std::vector<std::pair<std::string, std::string>> arguments = {}, bool deferEnter = false, std::source_location location = std::source_location::current());
 
+    /**
+     * @brief Destroy the FunctionTracer object.
+     */
     virtual ~FunctionTracer();
 
     /**
@@ -84,7 +96,13 @@ struct FunctionTracer
     void
     SetExitLogSeverity(plog::Severity severity) noexcept;
 
+protected:
+    static constexpr auto LogSeverityEnterDefault{ plog::Severity::debug };
+    static constexpr auto LogSeverityExitDefault{ plog::Severity::debug };
+
 private:
+    plog::Severity m_logSeverityEnter{ LogSeverityEnterDefault };
+    plog::Severity m_LogSeverityExit{ LogSeverityExitDefault };
     std::string m_logPrefix;
     std::source_location m_location;
     std::string_view m_functionName;
@@ -92,8 +110,6 @@ private:
     std::vector<std::pair<std::string, std::string>> m_returnValues;
     bool m_entered{ false };
     bool m_exited{ false };
-    plog::Severity m_logSeverityEnter{ plog::Severity::info };
-    plog::Severity m_LogSeverityExit{ plog::Severity::info };
 };
 } // namespace logging
 

--- a/src/common/shared/logging/include/logging/FunctionTracer.hxx
+++ b/src/common/shared/logging/include/logging/FunctionTracer.hxx
@@ -14,6 +14,10 @@ namespace logging
 {
 /**
  * @brief Traces a function's entry and exit, logging the arguments and return values.
+ *
+ * Note that this does not behave in a thread-safe manner. It is unexpected that Enter() and Exit() calls would occur
+ * concurrently since it's expected that this is used as stack-allocated objects which will follow typical stack-based
+ * lifetime control, which is inherently single-threaded.  /
  */
 struct FunctionTracer
 {
@@ -79,7 +83,7 @@ private:
     std::vector<std::pair<std::string, std::string>> m_returnValues;
     bool m_entered{ false };
     bool m_exited{ false };
-    plog::Severity m_logSeverityEnter{ plog:: Severity::info };
+    plog::Severity m_logSeverityEnter{ plog::Severity::info };
     plog::Severity m_LogSeverityExit{ plog::Severity::info };
 };
 } // namespace logging

--- a/src/common/shared/logging/include/logging/FunctionTracer.hxx
+++ b/src/common/shared/logging/include/logging/FunctionTracer.hxx
@@ -25,12 +25,13 @@ struct FunctionTracer
      * @brief Construct a new FunctionTracer object.
      * 
      * @param logSeverityEnter The severity to log entrance with.
+     * @param logSeverityExit The severity to log exit with.
      * @param logPrefix The prefix to use for both log messages.
      * @param arguments The arguments the function was called with.
      * @param deferEnter Whether to defer the call to Enter().
      * @param location The source location information of the caller.
      */
-    FunctionTracer(plog::Severity logSeverityEnter = LogSeverityEnterDefault, std::string logPrefix = {}, std::vector<std::pair<std::string, std::string>> arguments = {}, bool deferEnter = false, std::source_location location = std::source_location::current());
+    FunctionTracer(plog::Severity logSeverityEnter = LogSeverityEnterDefault, plog::Severity logSeverityExit = LogSeverityExitDefault, std::string logPrefix = {},  std::vector<std::pair<std::string, std::string>> arguments = {}, bool deferEnter = false, std::source_location location = std::source_location::current());
 
     /**
      * @brief Destroy the FunctionTracer object.
@@ -102,7 +103,7 @@ protected:
 
 private:
     plog::Severity m_logSeverityEnter{ LogSeverityEnterDefault };
-    plog::Severity m_LogSeverityExit{ LogSeverityExitDefault };
+    plog::Severity m_logSeverityExit{ LogSeverityExitDefault };
     std::string m_logPrefix;
     std::source_location m_location;
     std::string_view m_functionName;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow the severity of the entrance log to be configurable instead of hard-coded.

### Technical Details

* Add arguments to `FunctionTracer` constructor (and existing derived class constructors) that indicates the plog severity to use when logging the entrance and exit messages.
* Add function to manually set the entrance log severity (valid only when `deferEnter` used on construction).
* Set default severity to `plog::Severity::debug` for base class.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
