### PR TITLE
Generate random data and check for DataStreamPattern

### DIFF
--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -9,12 +9,11 @@ namespace Microsoft::Net::Remote::Service::Reactors::Helpers
 {
 DataGenerator::DataGenerator()
 {
-    std::random_device randomDevice;
-    m_generator.seed(randomDevice());
+    m_generator.seed(std::random_device{}());
 }
 
 std::string
-DataGenerator::GenerateRandomData(std::size_t length)
+DataGenerator::GenerateRandomData(const std::size_t length)
 {
     std::string result;
     result.reserve(length);
@@ -29,7 +28,7 @@ DataGenerator::GenerateRandomData(std::size_t length)
 uint8_t
 DataGenerator::GetRandomByte()
 {
-    std::uniform_int_distribution<uint8_t> distribution(0, 255);
+    std::uniform_int_distribution<uint8_t> distribution(0, std::numeric_limits<uint8_t>::max());
     return distribution(m_generator);
 }
 } // namespace Microsoft::Net::Remote::Service::Reactors::Helpers

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -5,6 +5,35 @@
 #include <magic_enum.hpp>
 #include <plog/Log.h>
 
+namespace Microsoft::Net::Remote::Service::Reactors::Helpers
+{
+DataGenerator::DataGenerator()
+{
+    std::random_device randomDevice;
+    m_generator.seed(randomDevice());
+}
+
+std::string
+DataGenerator::GenerateRandomData(std::size_t length)
+{
+    std::string result;
+    result.reserve(length);
+
+    for (std::size_t i = 0; i < length; i++) {
+        result.push_back(static_cast<char>(GetRandomByte()));
+    }
+
+    return result;
+}
+
+uint8_t
+DataGenerator::GetRandomByte()
+{
+    std::uniform_int_distribution<uint8_t> distribution(0, 255);
+    return distribution(m_generator);
+}
+} // namespace Microsoft::Net::Remote::Service::Reactors::Helpers
+
 using namespace Microsoft::Net::Remote::DataStream;
 using namespace Microsoft::Net::Remote::Service::Reactors;
 
@@ -155,7 +184,8 @@ DataStreamWriter::NextWrite()
     if (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeContinuous ||
         (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeFixed && m_numberOfDataBlocksToStream > 0)) {
         // Create data to write to the client.
-        const auto data = std::format("Data #{}", ++m_numberOfDataBlocksWritten);
+        const auto data = m_dataGenerator.GenerateRandomData();
+        m_numberOfDataBlocksWritten++;
 
         // Write data to the client.
         m_data.set_data(data);

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -33,7 +33,7 @@ public:
      * @return std::string
      */
     std::string
-    GenerateRandomData(std::size_t length = c_defaultDataLength);
+    GenerateRandomData(const std::size_t length = c_defaultDataLength);
 
 private:
     /**
@@ -45,7 +45,7 @@ private:
     GetRandomByte();
 
 private:
-    std::mt19937_64 m_generator{};
+    std::mt19937 m_generator{};
 };
 } // namespace Microsoft::Net::Remote::Service::Reactors::Helpers
 

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -4,10 +4,50 @@
 
 #include <atomic>
 #include <cstdint>
+#include <random>
 #include <string>
 
 #include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
 #include <microsoft/net/remote/protocol/NetRemoteDataStreamingService.grpc.pb.h>
+
+namespace Microsoft::Net::Remote::Service::Reactors::Helpers
+{
+/**
+ * @brief A simple random data generator.
+ */
+class DataGenerator
+{
+public:
+    static constexpr std::size_t c_defaultDataLength{ 8 };
+
+    /**
+     * @brief Construct a DataGenerator object.
+     *
+     */
+    explicit DataGenerator();
+
+    /**
+     * @brief Generate a random data string of the specified length.
+     *
+     * @param length The length of the random data string.
+     * @return std::string
+     */
+    std::string
+    GenerateRandomData(std::size_t length = c_defaultDataLength);
+
+private:
+    /**
+     * @brief Generate a random byte of data.
+     *
+     * @return uint8_t
+     */
+    uint8_t
+    GetRandomByte();
+
+private:
+    std::mt19937_64 m_generator{};
+};
+} // namespace Microsoft::Net::Remote::Service::Reactors::Helpers
 
 namespace Microsoft::Net::Remote::Service::Reactors
 {
@@ -108,6 +148,7 @@ private:
     uint32_t m_numberOfDataBlocksWritten{};
     Microsoft::Net::Remote::DataStream::DataStreamOperationStatus m_writeStatus{};
     std::atomic<bool> m_isCanceled{};
+    Microsoft::Net::Remote::Service::Reactors::Helpers::DataGenerator m_dataGenerator{};
 };
 } // namespace Microsoft::Net::Remote::Service::Reactors
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

This PR adds the ability to generate random data of a specific length, as well as check for the `DataStreamPattern` requested by the client for the `DataStreamDownload` API.

### Technical Details

* Added `DataGenerator` helper class with basic functionality.
* Added check for `DataStreamPattern` and handling for `DataStreamPatternConstant`.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
