### PR TITLE
Clang-tidy fixes for DataStreamDownload API

### DIFF
--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -16,6 +16,8 @@
 
 #include "NetRemoteDataStreamingReactors.hxx"
 
+using logging::FunctionTracer;
+
 namespace Microsoft::Net::Remote::Service::Reactors::Helpers
 {
 DataGenerator::DataGenerator()
@@ -50,14 +52,14 @@ using namespace Microsoft::Net::Remote::Service::Reactors;
 DataStreamReader::DataStreamReader(DataStreamUploadResult* result) :
     m_result(result)
 {
-    logging::FunctionTracer traceMe(plog::Severity::debug);
+    FunctionTracer traceMe{};
     StartRead(&m_data);
 }
 
 void
 DataStreamReader::OnReadDone(bool isOk)
 {
-    logging::FunctionTracer traceMe(plog::Severity::debug);
+    FunctionTracer traceMe{};
 
     if (isOk) {
         m_numberOfDataBlocksReceived++;
@@ -76,7 +78,7 @@ DataStreamReader::OnReadDone(bool isOk)
 void
 DataStreamReader::OnCancel()
 {
-    logging::FunctionTracer traceMe(plog::Severity::debug);
+    FunctionTracer traceMe{};
 
     m_result->set_numberofdatablocksreceived(m_numberOfDataBlocksReceived);
     m_readStatus.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeCanceled);
@@ -88,13 +90,13 @@ DataStreamReader::OnCancel()
 void
 DataStreamReader::OnDone()
 {
-    logging::FunctionTracer traceMe(plog::Severity::debug);
+    FunctionTracer traceMe{};
     delete this;
 }
 
 DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request)
 {
-    logging::FunctionTracer traceMe(plog::Severity::debug);
+    FunctionTracer traceMe{};
     m_dataStreamProperties = request->properties();
 
     switch (m_dataStreamProperties.type()) {
@@ -132,7 +134,7 @@ DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request)
 void
 DataStreamWriter::OnWriteDone(bool isOk)
 {
-    logging::FunctionTracer traceMe(plog::Severity::debug);
+    FunctionTracer traceMe{};
 
     // Client may have canceled the RPC, so check for cancelation to prevent writing more data
     // when we shouldn't.
@@ -163,7 +165,7 @@ DataStreamWriter::OnWriteDone(bool isOk)
 void
 DataStreamWriter::OnCancel()
 {
-    logging::FunctionTracer traceMe(plog::Severity::debug);
+    FunctionTracer traceMe{};
 
     // The RPC is canceled by the client, so call Finish to complete it from the server perspective.
     bool isCanceledExpected{ false };
@@ -175,14 +177,14 @@ DataStreamWriter::OnCancel()
 void
 DataStreamWriter::OnDone()
 {
-    logging::FunctionTracer traceMe(plog::Severity::debug);
+    FunctionTracer traceMe{};
     delete this;
 }
 
 void
 DataStreamWriter::NextWrite()
 {
-    logging::FunctionTracer traceMe(plog::Severity::debug);
+    FunctionTracer traceMe{};
 
     // Client may have canceled the RPC, so check for cancelation to prevent writing more data
     // when we shouldn't.
@@ -223,7 +225,7 @@ DataStreamWriter::NextWrite()
 void
 DataStreamWriter::HandleFailure(const std::string& errorMessage)
 {
-    logging::FunctionTracer traceMe(plog::Severity::debug);
+    FunctionTracer traceMe{};
 
     m_writeStatus.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeFailed);
     m_writeStatus.set_message(errorMessage);

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -12,7 +12,6 @@
 #include <magic_enum.hpp>
 #include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
 #include <plog/Log.h>
-#include <plog/Severity.h>
 
 #include "NetRemoteDataStreamingReactors.hxx"
 
@@ -52,14 +51,14 @@ using namespace Microsoft::Net::Remote::Service::Reactors;
 DataStreamReader::DataStreamReader(DataStreamUploadResult* result) :
     m_result(result)
 {
-    FunctionTracer traceMe{};
+    const FunctionTracer traceMe{};
     StartRead(&m_data);
 }
 
 void
 DataStreamReader::OnReadDone(bool isOk)
 {
-    FunctionTracer traceMe{};
+    const FunctionTracer traceMe{};
 
     if (isOk) {
         m_numberOfDataBlocksReceived++;
@@ -78,7 +77,7 @@ DataStreamReader::OnReadDone(bool isOk)
 void
 DataStreamReader::OnCancel()
 {
-    FunctionTracer traceMe{};
+    const FunctionTracer traceMe{};
 
     m_result->set_numberofdatablocksreceived(m_numberOfDataBlocksReceived);
     m_readStatus.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeCanceled);
@@ -90,13 +89,13 @@ DataStreamReader::OnCancel()
 void
 DataStreamReader::OnDone()
 {
-    FunctionTracer traceMe{};
+    const FunctionTracer traceMe{};
     delete this;
 }
 
 DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request)
 {
-    FunctionTracer traceMe{};
+    const FunctionTracer traceMe{};
     m_dataStreamProperties = request->properties();
 
     switch (m_dataStreamProperties.type()) {
@@ -134,7 +133,7 @@ DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request)
 void
 DataStreamWriter::OnWriteDone(bool isOk)
 {
-    FunctionTracer traceMe{};
+    const FunctionTracer traceMe{};
 
     // Client may have canceled the RPC, so check for cancelation to prevent writing more data
     // when we shouldn't.
@@ -165,7 +164,7 @@ DataStreamWriter::OnWriteDone(bool isOk)
 void
 DataStreamWriter::OnCancel()
 {
-    FunctionTracer traceMe{};
+    const FunctionTracer traceMe{};
 
     // The RPC is canceled by the client, so call Finish to complete it from the server perspective.
     bool isCanceledExpected{ false };
@@ -177,14 +176,14 @@ DataStreamWriter::OnCancel()
 void
 DataStreamWriter::OnDone()
 {
-    FunctionTracer traceMe{};
+    const FunctionTracer traceMe{};
     delete this;
 }
 
 void
 DataStreamWriter::NextWrite()
 {
-    FunctionTracer traceMe{};
+    const FunctionTracer traceMe{};
 
     // Client may have canceled the RPC, so check for cancelation to prevent writing more data
     // when we shouldn't.
@@ -225,7 +224,7 @@ DataStreamWriter::NextWrite()
 void
 DataStreamWriter::HandleFailure(const std::string& errorMessage)
 {
-    FunctionTracer traceMe{};
+    const FunctionTracer traceMe{};
 
     m_writeStatus.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeFailed);
     m_writeStatus.set_message(errorMessage);

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -1,11 +1,20 @@
 
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
 #include <format>
+#include <limits>
+#include <random>
+#include <string>
 
-#include "NetRemoteDataStreamingReactors.hxx"
+#include <grpcpp/impl/codegen/status.h>
 #include <logging/FunctionTracer.hxx>
 #include <magic_enum.hpp>
+#include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
 #include <plog/Log.h>
 #include <plog/Severity.h>
+
+#include "NetRemoteDataStreamingReactors.hxx"
 
 namespace Microsoft::Net::Remote::Service::Reactors::Helpers
 {

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -6,6 +6,7 @@
 #include <limits>
 #include <random>
 #include <string>
+#include <utility>
 
 #include <grpcpp/impl/codegen/status.h>
 #include <logging/FunctionTracer.hxx>
@@ -93,10 +94,10 @@ DataStreamReader::OnDone()
     delete this;
 }
 
-DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request)
+DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request) :
+    m_dataStreamProperties(request->properties())
 {
     const FunctionTracer traceMe{};
-    m_dataStreamProperties = request->properties();
 
     switch (m_dataStreamProperties.type()) {
     case DataStreamType::DataStreamTypeFixed: {

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -18,7 +18,7 @@ namespace Microsoft::Net::Remote::Service::Reactors::Helpers
 class DataGenerator
 {
 public:
-    static constexpr std::size_t c_defaultDataLength{ 8 };
+    static constexpr std::size_t DefaultDataLength{ 8 };
 
     /**
      * @brief Construct a DataGenerator object.
@@ -33,7 +33,7 @@ public:
      * @return std::string
      */
     std::string
-    GenerateRandomData(const std::size_t length = c_defaultDataLength);
+    GenerateRandomData(const std::size_t length = DefaultDataLength);
 
 private:
     /**

--- a/src/common/service/NetRemoteDataStreamingService.cxx
+++ b/src/common/service/NetRemoteDataStreamingService.cxx
@@ -1,7 +1,13 @@
 
+#include <memory>
+
+#include <grpcpp/server_context.h>
+#include <grpcpp/support/server_callback.h>
+#include <microsoft/net/remote/NetRemoteDataStreamingService.hxx>
+#include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
+
 #include "NetRemoteApiTrace.hxx"
 #include "NetRemoteDataStreamingReactors.hxx"
-#include <microsoft/net/remote/NetRemoteDataStreamingService.hxx>
 
 using namespace Microsoft::Net::Remote::DataStream;
 using namespace Microsoft::Net::Remote::Service;
@@ -12,7 +18,7 @@ NetRemoteDataStreamingService::DataStreamUpload([[maybe_unused]] grpc::CallbackS
 {
     const NetRemoteApiTrace traceMe{};
 
-    return new Reactors::DataStreamReader(result);
+    return std::make_unique<Reactors::DataStreamReader>(result).release();
 }
 
 grpc::ServerWriteReactor<DataStreamDownloadData>*
@@ -20,5 +26,5 @@ NetRemoteDataStreamingService::DataStreamDownload([[maybe_unused]] grpc::Callbac
 {
     const NetRemoteApiTrace traceMe{};
 
-    return new Reactors::DataStreamWriter(request);
+    return std::make_unique<Reactors::DataStreamWriter>(request).release();
 }

--- a/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
@@ -2,6 +2,8 @@
 #ifndef NET_REMOTE_DATA_STREAMING_SERVICE_HXX
 #define NET_REMOTE_DATA_STREAMING_SERVICE_HXX
 
+#include <grpcpp/server_context.h>
+#include <grpcpp/support/server_callback.h>
 #include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
 #include <microsoft/net/remote/protocol/NetRemoteDataStreamingService.grpc.pb.h>
 

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -1,9 +1,15 @@
 
-#include <chrono>
+#include <cstdint>
 #include <format>
+#include <mutex>
+#include <utility>
+
+#include <grpcpp/impl/codegen/status.h>
+#include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
+#include <microsoft/net/remote/protocol/NetRemoteDataStreamingService.grpc.pb.h>
+#include <plog/Log.h>
 
 #include "TestNetRemoteDataStreamingReactors.hxx"
-#include <plog/Log.h>
 
 using namespace Microsoft::Net::Remote::DataStream;
 using namespace Microsoft::Net::Remote::Service;
@@ -30,7 +36,7 @@ DataStreamWriter::OnWriteDone(bool isOk)
 void
 DataStreamWriter::OnDone(const grpc::Status& status)
 {
-    std::unique_lock lock(m_writeStatusGate);
+    const std::unique_lock lock(m_writeStatusGate);
 
     m_status = status;
     m_done = true;
@@ -89,7 +95,7 @@ DataStreamReader::OnReadDone(bool isOk)
 void
 DataStreamReader::OnDone(const grpc::Status& status)
 {
-    std::unique_lock lock(m_readStatusGate);
+    const std::unique_lock lock(m_readStatusGate);
 
     m_status = status;
     m_done = true;

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -62,7 +62,7 @@ private:
     NextWrite();
 
 private:
-    static inline constexpr auto c_defaultTimeoutValue{ 10s };
+    static inline constexpr auto DefaultTimeoutValue{ 10s };
 
     grpc::ClientContext m_clientContext{};
     Microsoft::Net::Remote::DataStream::DataStreamUploadData m_data{};
@@ -73,7 +73,7 @@ private:
     std::mutex m_writeStatusGate{};
     std::condition_variable m_writesDone{};
     bool m_done{ false };
-    std::chrono::duration<uint32_t> m_writesDoneTimeoutValue{ c_defaultTimeoutValue };
+    std::chrono::duration<uint32_t> m_writesDoneTimeoutValue{ DefaultTimeoutValue };
 };
 
 /**
@@ -124,7 +124,7 @@ public:
     Cancel();
 
 private:
-    static inline constexpr auto c_defaultTimeoutValue{ 10s };
+    static inline constexpr auto DefaultTimeoutValue{ 10s };
 
     grpc::ClientContext m_clientContext{};
     Microsoft::Net::Remote::DataStream::DataStreamDownloadData m_data{};
@@ -133,7 +133,7 @@ private:
     std::mutex m_readStatusGate{};
     std::condition_variable m_readsDone{};
     bool m_done{ false };
-    std::chrono::duration<uint32_t> m_readsDoneTimeoutValue{ c_defaultTimeoutValue };
+    std::chrono::duration<uint32_t> m_readsDoneTimeoutValue{ DefaultTimeoutValue };
 };
 
 } // namespace Microsoft::Net::Remote::Test

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -1,15 +1,19 @@
 
-#include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <mutex>
 #include <thread>
 #include <utility>
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
 #include <grpcpp/create_channel.h>
+#include <grpcpp/impl/codegen/status.h>
+#include <grpcpp/impl/codegen/status_code_enum.h>
+#include <grpcpp/security/credentials.h>
 #include <microsoft/net/remote/NetRemoteServer.hxx>
+#include <microsoft/net/remote/NetRemoteServerConfiguration.hxx>
+#include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
 #include <microsoft/net/remote/protocol/NetRemoteDataStreamingService.grpc.pb.h>
 
 #include "TestNetRemoteCommon.hxx"
@@ -24,7 +28,7 @@ TEST_CASE("DataStreamUpload API", "[basic][rpc][client][remote][stream]")
     using Microsoft::Net::Remote::Test::DataStreamWriter;
     using Microsoft::Net::Remote::Test::RemoteServiceAddressHttp;
 
-    NetRemoteServerConfiguration Configuration{
+    const NetRemoteServerConfiguration Configuration{
         .ServerAddress = RemoteServiceAddressHttp,
     };
 
@@ -41,7 +45,7 @@ TEST_CASE("DataStreamUpload API", "[basic][rpc][client][remote][stream]")
         auto dataStreamWriter = std::make_unique<DataStreamWriter>(client.get(), numberOfDataBlocksToWrite);
 
         DataStreamUploadResult result{};
-        grpc::Status status = dataStreamWriter->Await(&result);
+        const grpc::Status status = dataStreamWriter->Await(&result);
         REQUIRE(status.ok());
         REQUIRE(result.numberofdatablocksreceived() == numberOfDataBlocksToWrite);
         REQUIRE(result.status().code() == DataStreamOperationStatusCodeSucceeded);
@@ -60,7 +64,7 @@ TEST_CASE("DataStreamUpload API", "[basic][rpc][client][remote][stream]")
 
             clientThreads.emplace_back([dataStreamWriter = std::move(dataStreamWriter)]() {
                 DataStreamUploadResult result{};
-                grpc::Status status = dataStreamWriter->Await(&result);
+                const grpc::Status status = dataStreamWriter->Await(&result);
                 REQUIRE(status.ok());
                 REQUIRE(result.numberofdatablocksreceived() == numberOfDataBlocksToWrite);
                 REQUIRE(result.status().code() == DataStreamOperationStatusCodeSucceeded);
@@ -82,7 +86,7 @@ TEST_CASE("DataStreamDownload API", "[basic][rpc][client][remote][stream]")
     using Microsoft::Net::Remote::Test::DataStreamReader;
     using Microsoft::Net::Remote::Test::RemoteServiceAddressHttp;
 
-    NetRemoteServerConfiguration Configuration{
+    const NetRemoteServerConfiguration Configuration{
         .ServerAddress = RemoteServiceAddressHttp,
     };
 
@@ -111,7 +115,7 @@ TEST_CASE("DataStreamDownload API", "[basic][rpc][client][remote][stream]")
 
         uint32_t numberOfDataBlocksReceived{};
         DataStreamOperationStatus operationStatus{};
-        grpc::Status status = dataStreamReader.Await(&numberOfDataBlocksReceived, &operationStatus);
+        const grpc::Status status = dataStreamReader.Await(&numberOfDataBlocksReceived, &operationStatus);
         REQUIRE(status.ok());
         REQUIRE(numberOfDataBlocksReceived == fixedNumberOfDataBlocksToStream);
         REQUIRE(operationStatus.code() == DataStreamOperationStatusCodeSucceeded);
@@ -119,6 +123,8 @@ TEST_CASE("DataStreamDownload API", "[basic][rpc][client][remote][stream]")
 
     SECTION("Can be called with DataStreamTypeContinuous and DataStreamPatternConstant")
     {
+        static constexpr auto StreamingDelayTime = 5s;
+
         DataStreamContinuousTypeProperties continuousTypeProperties{};
 
         DataStreamProperties properties{};
@@ -132,12 +138,12 @@ TEST_CASE("DataStreamDownload API", "[basic][rpc][client][remote][stream]")
         DataStreamReader dataStreamReader{ client.get(), &request };
 
         // Allow some time of continuous streaming by the server, then cancel the RPC.
-        std::this_thread::sleep_for(5s);
+        std::this_thread::sleep_for(StreamingDelayTime);
         dataStreamReader.Cancel();
 
         uint32_t numberOfDataBlocksReceived{};
         DataStreamOperationStatus operationStatus{};
-        grpc::Status status = dataStreamReader.Await(&numberOfDataBlocksReceived, &operationStatus);
+        const grpc::Status status = dataStreamReader.Await(&numberOfDataBlocksReceived, &operationStatus);
         REQUIRE(status.error_code() == grpc::StatusCode::CANCELLED);
         REQUIRE(operationStatus.code() == DataStreamOperationStatusCodeSucceeded);
     }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Ensure code merging to `develop` has clean clang-tidy delta.

### Technical Details

* Fix issues identified by clang-tidy, mostly include-cleaner type things.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
