### PR TITLE
Fix Windows build break

### DIFF
--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -30,8 +30,8 @@ DataGenerator::GenerateRandomData(const std::size_t length)
 uint8_t
 DataGenerator::GetRandomByte()
 {
-    std::uniform_int_distribution<uint8_t> distribution(0, std::numeric_limits<uint8_t>::max());
-    return distribution(m_generator);
+    std::uniform_int_distribution<uint32_t> distribution(0, std::numeric_limits<uint8_t>::max());
+    return static_cast<uint8_t>(distribution(m_generator));
 }
 } // namespace Microsoft::Net::Remote::Service::Reactors::Helpers
 


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

Fixes the Windows build break caused by using `std::uniform_int_distribution<uint8_t>`.

### Technical Details

Changed to `std::uniform_int_distribution<uint32_t>` then cast result to `uint8_t`.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
