### PR TITLE
Refine WifiAccessPointSetFrequencyBands into top-level and implementation functions

### DIFF
--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -124,8 +124,8 @@ protected:
      * @param accessPointController
      * @return Microsoft::Net::Wifi::AccessPointOperationStatus
      */
-    Microsoft::Net::Wifi::AccessPointOperationStatus
-    TryGetAccessPointController(std::shared_ptr<Microsoft::Net::Wifi::IAccessPoint> accessPoint, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController>& accessPointController);
+    static Microsoft::Net::Wifi::AccessPointOperationStatus
+    TryGetAccessPointController(const std::shared_ptr<Microsoft::Net::Wifi::IAccessPoint>& accessPoint, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController>& accessPointController);
 
     /**
      * @brief Set the active PHY type or protocol of the access point. The access point must be enabled. This will cause
@@ -138,6 +138,17 @@ protected:
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
     WifiAccessPointSetPhyTypeImpl(std::string_view accessPointId, Microsoft::Net::Wifi::Dot11PhyType dot11PhyType);
 
+    /**
+     * @brief Set the active frequency bands of the access point. The access point must be enabled. This will cause the
+     * access point to temporarily go offline while the change is being applied.
+     *
+     * @param accessPointId The access point identifier.
+     * @param dot11FrequencyBands The new frequency bands to set.
+     * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+     */
+    Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+    WifiAccessPointSetFrequencyBandsImpl(std::string_view accessPointId, std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>& dot11FrequencyBands);
+
 protected:
     /**
      * @brief Validate the basic input parameters for the WifiAccessPointEnable request.
@@ -149,17 +160,6 @@ protected:
      */
     static bool
     ValidateWifiAccessPointEnableRequest(const Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus& status);
-
-    /**
-     * @brief Validate the basic input parameters for the WifiAccessPointSetFrequencyBands reqest.
-     *
-     * @param request The request to validate.
-     * @param result The result to populate with failure information.
-     * @return true
-     * @return false
-     */
-    static bool
-    ValidateWifiSetFrequencyBandsRequest(const Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsResult* result);
 
 private:
     std::shared_ptr<Microsoft::Net::Wifi::AccessPointManager> m_accessPointManager;

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -153,6 +153,23 @@ FromDot11FrequencyBand(const Dot11FrequencyBand dot11FrequencyBand) noexcept
 
 using Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest;
 
+std::vector<Dot11FrequencyBand>
+ToDot11FrequencyBands(const WifiAccessPointSetFrequencyBandsRequest& request) noexcept
+{
+    // protobuf encodes enums in repeated fields as 'int' instead of the enum type itself. So, the below is a simple
+    // function to convert the repeated field of int to the enum type.
+    constexpr auto toDot11FrequencyBand = [](const auto& frequencyBand) {
+        return static_cast<Dot11FrequencyBand>(frequencyBand);
+    };
+
+    std::vector<Dot11FrequencyBand> dot11FrequencyBands(static_cast<std::size_t>(std::size(request.frequencybands())));
+    std::ranges::transform(request.frequencybands(), std::begin(dot11FrequencyBands), toDot11FrequencyBand);
+
+    return dot11FrequencyBands;
+    // TODO: for some reason, std::ranges::to is not being found for clang. Once resolved, update to the following:
+    // return request.frequencybands() | std::views::transform(toDot11FrequencyBand) | std::ranges::to<std::vector>();
+}
+
 std::vector<Ieee80211FrequencyBand>
 FromDot11SetFrequencyBandsRequest(const WifiAccessPointSetFrequencyBandsRequest& request)
 {

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -58,6 +58,15 @@ Microsoft::Net::Wifi::Dot11FrequencyBand
 ToDot11FrequencyBand(Microsoft::Net::Wifi::Ieee80211FrequencyBand ieee80211FrequencyBand) noexcept;
 
 /**
+ * @brief Obtain a vector of Dot11FrequencyBands from the specified WifiAccessPointSetFrequencyBandsRequest.
+ * 
+ * @param request The request to extract the Dot11FrequencyBands from.
+ * @return std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand> 
+ */
+std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>
+ToDot11FrequencyBands(const Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest& request) noexcept;
+
+/**
  * @brief Convert the specified Dot11FrequencyBand to the equivalent IEEE 802.11 frequency band.
  *
  * @param dot11FrequencyBand The Dot11FrequencyBand to convert.
@@ -73,6 +82,9 @@ FromDot11FrequencyBand(Microsoft::Net::Wifi::Dot11FrequencyBand dot11FrequencyBa
  * @param request
  * @return std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand>
  */
+std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand>
+FromDot11SetFrequencyBandsRequest(const Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest& request);
+
 std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand>
 FromDot11SetFrequencyBandsRequest(const Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest& request);
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow the frequency bands type of an access point to be set from any API, not just `WifiAccessPointSetFrequencyBands `. This is primarily to allow setting the frequency bands consistently, including from other APIs like `WifiAcccessPointEnable`.

### Technical Details

* Move most functionality from `WifiAccessPointSetFrequencyBands` to `WifiAccessPointSetFrequencyBandsImpl`.
* Add `ToDot11FrequencyBands` adapter for safely converting from loosely-typed `frequencybands()` member of `WifiAccessPointSetFrequencyBandsRequest` to strongly-typed version to workaround protobuf deficiency for repeated enum fields.
* Update const correctness of helper function.
* Add skeleton for `WifiAccessPointEnable`.
* Add extra tests for `WifiAccessPointEnable` matching the existing skeleton code.
* Remove extra validation function.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Make use of `WifiAccessPointSetFrequencyBands` in `WifiAccessPointEnable`.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
