### PR TITLE
Add DataStreamBidirectional API

### DIFF
--- a/protocol/protos/NetRemoteDataStreamingService.proto
+++ b/protocol/protos/NetRemoteDataStreamingService.proto
@@ -10,4 +10,5 @@ service NetRemoteDataStreaming
 {
     rpc DataStreamUpload (stream Microsoft.Net.Remote.DataStream.DataStreamUploadData) returns (Microsoft.Net.Remote.DataStream.DataStreamUploadResult);
     rpc DataStreamDownload (Microsoft.Net.Remote.DataStream.DataStreamDownloadRequest) returns (stream Microsoft.Net.Remote.DataStream.DataStreamDownloadData);
+    rpc DataStreamBidirectional (stream Microsoft.Net.Remote.DataStream.DataStreamUploadData) returns (stream Microsoft.Net.Remote.DataStream.DataStreamDownloadData);
 }

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -235,3 +235,45 @@ DataStreamWriter::HandleFailure(const std::string& errorMessage)
     // DataStreamOperationStatusCodeFailed status code set here to know to complete the RPC.
     StartWrite(&m_data);
 }
+
+DataStreamReaderWriter::DataStreamReaderWriter()
+{
+    const FunctionTracer traceMe{};
+}
+
+void
+DataStreamReaderWriter::OnReadDone(bool isOk)
+{
+    const FunctionTracer traceMe{};
+}
+
+void
+DataStreamReaderWriter::OnWriteDone(bool isOk)
+{
+    const FunctionTracer traceMe{};
+}
+
+void
+DataStreamReaderWriter::OnCancel()
+{
+    const FunctionTracer traceMe{};
+}
+
+void
+DataStreamReaderWriter::OnDone()
+{
+    const FunctionTracer traceMe{};
+    delete this;
+}
+
+void
+DataStreamReaderWriter::NextWrite()
+{
+    const FunctionTracer traceMe{};
+}
+
+void
+DataStreamReaderWriter::HandleFailure(const std::string& errorMessage)
+{
+    const FunctionTracer traceMe{};
+}

--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -239,24 +239,68 @@ DataStreamWriter::HandleFailure(const std::string& errorMessage)
 DataStreamReaderWriter::DataStreamReaderWriter()
 {
     const FunctionTracer traceMe{};
+
+    m_status.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeUnknown);
+    m_status.set_message("No data sent yet");
+    StartRead(&m_readData);
+    NextWrite();
 }
 
 void
 DataStreamReaderWriter::OnReadDone(bool isOk)
 {
     const FunctionTracer traceMe{};
+
+    if (isOk) {
+        m_numberOfDataBlocksReceived++;
+        m_status.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeSucceeded);
+        m_status.set_message("Data read successful");
+        StartRead(&m_readData);
+    } else {
+        // A false "isOk" value could either mean a failed RPC or that no more data is available.
+        // Unfortunately, there is no clear way to tell which situation occurred.
+        Finish(grpc::Status::OK);
+    }
 }
 
 void
 DataStreamReaderWriter::OnWriteDone(bool isOk)
 {
     const FunctionTracer traceMe{};
+
+    // Client may have canceled the RPC, so check for cancelation to prevent writing more data
+    // when we shouldn't.
+    if (m_isCanceled.load(std::memory_order_relaxed)) {
+        LOGD << "RPC canceled, returning early";
+        return;
+    }
+
+    // Check for a failed status code from HandleWriteFailure since that invoked a final write, thus causing this callback to be invoked.
+    if (m_status.code() == DataStreamOperationStatusCode::DataStreamOperationStatusCodeFailed) {
+        Finish(::grpc::Status::OK);
+        return;
+    }
+
+    // Continue writing if previous write was successful, otherwise handle the failure.
+    if (isOk) {
+        m_status.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeSucceeded);
+        m_status.set_message("Data write successful");
+        NextWrite();
+    } else {
+        //HandleFailure("Data write failed");
+    }
 }
 
 void
 DataStreamReaderWriter::OnCancel()
 {
     const FunctionTracer traceMe{};
+
+    // The RPC is canceled by the client, so call Finish to complete it from the server perspective.
+    bool isCanceledExpected{ false };
+    if (m_isCanceled.compare_exchange_strong(isCanceledExpected, true, std::memory_order_relaxed, std::memory_order_relaxed)) {
+        Finish(grpc::Status::CANCELLED);
+    }
 }
 
 void
@@ -270,10 +314,35 @@ void
 DataStreamReaderWriter::NextWrite()
 {
     const FunctionTracer traceMe{};
+
+    // Client may have canceled the RPC, so check for cancelation to prevent writing more data
+    // when we shouldn't.
+    if (m_isCanceled.load(std::memory_order_relaxed)) {
+        LOGD << "RPC canceled, aborting write";
+        return;
+    }
+
+    // Create data to write to the client.
+    const auto data = m_dataGenerator.GenerateRandomData();
+    m_numberOfDataBlocksWritten++;
+
+    // Write data to the client.
+    m_writeData.set_data(data);
+    m_writeData.set_sequencenumber(m_numberOfDataBlocksWritten);
+    *m_writeData.mutable_status() = m_status;
+    StartWrite(&m_writeData);
 }
 
 void
 DataStreamReaderWriter::HandleFailure(const std::string& errorMessage)
 {
     const FunctionTracer traceMe{};
+
+    m_status.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeFailed);
+    m_status.set_message(errorMessage);
+    *m_writeData.mutable_status() = m_status;
+
+    // Write a final message to the client. The OnWriteDone() callback will check for the
+    // DataStreamOperationStatusCodeFailed status code set here to know to complete the RPC.
+    StartWrite(&m_writeData);
 }

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -150,6 +150,72 @@ private:
     std::atomic<bool> m_isCanceled{};
     Microsoft::Net::Remote::Service::Reactors::Helpers::DataGenerator m_dataGenerator{};
 };
+
+/**
+ * @brief Implementation of the gRPC ServerBidiReactor for server-side data stream reading and writing.
+ */
+class DataStreamReaderWriter :
+    public grpc::ServerBidiReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData, Microsoft::Net::Remote::DataStream::DataStreamDownloadData>
+{
+public:
+    /**
+     * @brief Construct a new DataStreamReaderWriter object.
+     *
+     */
+    explicit DataStreamReaderWriter();
+
+    /**
+     * @brief Callback that is executed when a read operation is completed.
+     *
+     * @param isOk Indicates whether a message was read as expected.
+     */
+    void
+    OnReadDone(bool isOk) override;
+
+    /**
+     * @brief Callback that is executed when a write operation is completed.
+     *
+     * @param isOk Indicates whether a write was successfully sent.
+     */
+    void
+    OnWriteDone(bool isOk) override;
+
+    /**
+     * @brief Callback that is executed when an RPC is canceled before successfully sending a status to the client.
+     */
+    void
+    OnCancel() override;
+
+    /**
+     * @brief Callback that is executed when all RPC operations are completed for a given RPC.
+     */
+    void
+    OnDone() override;
+
+private:
+    /**
+     * @brief Facilitate the next write operation.
+     */
+    void
+    NextWrite();
+
+    /**
+     * @brief Handle a failed operation.
+     *
+     * @param errorMessage The error message associated with the failed operation.
+     */
+    void
+    HandleFailure(const std::string& errorMessage);
+
+private:
+    Microsoft::Net::Remote::DataStream::DataStreamUploadData m_readData{};
+    Microsoft::Net::Remote::DataStream::DataStreamDownloadData m_writeData{};
+    uint32_t m_numberOfDataBlocksReceived{};
+    uint32_t m_numberOfDataBlocksWritten{};
+    Microsoft::Net::Remote::DataStream::DataStreamOperationStatus m_status{};
+    std::atomic<bool> m_isCanceled{};
+    Microsoft::Net::Remote::Service::Reactors::Helpers::DataGenerator m_dataGenerator{};
+};
 } // namespace Microsoft::Net::Remote::Service::Reactors
 
 #endif // NET_REMOTE_DATA_STREAMING_REACTORS_HXX

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -214,6 +214,7 @@ private:
     uint32_t m_numberOfDataBlocksWritten{};
     Microsoft::Net::Remote::DataStream::DataStreamOperationStatus m_status{};
     std::atomic<bool> m_isCanceled{};
+    std::atomic<bool> m_readsDone{};
     Microsoft::Net::Remote::Service::Reactors::Helpers::DataGenerator m_dataGenerator{};
 };
 } // namespace Microsoft::Net::Remote::Service::Reactors

--- a/src/common/service/NetRemoteDataStreamingService.cxx
+++ b/src/common/service/NetRemoteDataStreamingService.cxx
@@ -34,5 +34,5 @@ NetRemoteDataStreamingService::DataStreamBidirectional([[maybe_unused]] grpc::Ca
 {
     const NetRemoteApiTrace traceMe{};
 
-    return nullptr;
+    return std::make_unique<Reactors::DataStreamReaderWriter>().release();
 }

--- a/src/common/service/NetRemoteDataStreamingService.cxx
+++ b/src/common/service/NetRemoteDataStreamingService.cxx
@@ -28,3 +28,11 @@ NetRemoteDataStreamingService::DataStreamDownload([[maybe_unused]] grpc::Callbac
 
     return std::make_unique<Reactors::DataStreamWriter>(request).release();
 }
+
+grpc::ServerBidiReactor<DataStreamUploadData, DataStreamDownloadData>*
+NetRemoteDataStreamingService::DataStreamBidirectional([[maybe_unused]] grpc::CallbackServerContext* context)
+{
+    const NetRemoteApiTrace traceMe{};
+
+    return nullptr;
+}

--- a/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
@@ -41,6 +41,15 @@ private:
      */
     grpc::ServerWriteReactor<Microsoft::Net::Remote::DataStream::DataStreamDownloadData>*
     DataStreamDownload(grpc::CallbackServerContext* context, const Microsoft::Net::Remote::DataStream::DataStreamDownloadRequest* request) override;
+
+    /**
+     * @brief Stream data from the client to the server and from the server to the client.
+     * 
+     * @param context
+     * @return grpc::ServerBidiReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData, Microsoft::Net::Remote::DataStream::DataStreamDownloadData>*
+     */
+    grpc::ServerBidiReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData, Microsoft::Net::Remote::DataStream::DataStreamDownloadData>*
+    DataStreamBidirectional(grpc::CallbackServerContext* context) override;
 };
 } // namespace Microsoft::Net::Remote::Service
 

--- a/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
@@ -44,7 +44,7 @@ private:
 
     /**
      * @brief Stream data from the client to the server and from the server to the client.
-     * 
+     *
      * @param context
      * @return grpc::ServerBidiReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData, Microsoft::Net::Remote::DataStream::DataStreamDownloadData>*
      */

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -179,7 +179,7 @@ DataStreamReaderWriter::OnDone(const grpc::Status& status)
 }
 
 grpc::Status
-DataStreamReaderWriter::Await(Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus)
+DataStreamReaderWriter::Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus)
 {
     std::unique_lock lock(m_operationStatusGate);
 
@@ -194,6 +194,7 @@ DataStreamReaderWriter::Await(Microsoft::Net::Remote::DataStream::DataStreamOper
         status.set_message("Timeout occurred while waiting for all operations to be completed");
         *m_readData.mutable_status() = std::move(status);
     }
+    *numberOfDataBlocksReceived = m_numberOfDataBlocksReceived;
     *operationStatus = m_readData.status();
 
     return m_operationStatus;

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -171,7 +171,7 @@ DataStreamReaderWriter::OnWriteDone(bool isOk)
 void
 DataStreamReaderWriter::OnDone(const grpc::Status& status)
 {
-    std::unique_lock lock(m_operationStatusGate);
+    const std::unique_lock lock(m_operationStatusGate);
 
     m_operationStatus = status;
     m_done = true;

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -139,3 +139,74 @@ DataStreamReader::Cancel()
     LOGD << "Attempting to cancel RPC";
     m_clientContext.TryCancel();
 }
+
+DataStreamReaderWriter::DataStreamReaderWriter(NetRemoteDataStreaming::Stub* client, uint32_t numberOfDataBlocksToWrite) :
+    m_numberOfDataBlocksToWrite(numberOfDataBlocksToWrite)
+{
+    client->async()->DataStreamBidirectional(&m_clientContext, this);
+    StartCall();
+    StartRead(&m_readData);
+    NextWrite();
+}
+
+void
+DataStreamReaderWriter::OnReadDone(bool isOk)
+{
+    if (isOk) {
+        m_numberOfDataBlocksReceived++;
+        StartRead(&m_readData);
+    }
+}
+
+void
+DataStreamReaderWriter::OnWriteDone(bool isOk)
+{
+    if (isOk) {
+        NextWrite();
+    } else {
+        StartWritesDone();
+    }
+}
+
+void
+DataStreamReaderWriter::OnDone(const grpc::Status& status)
+{
+    std::unique_lock lock(m_operationStatusGate);
+
+    m_operationStatus = status;
+    m_done = true;
+    m_operationsDone.notify_one();
+}
+
+grpc::Status
+DataStreamReaderWriter::Await(Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus)
+{
+    std::unique_lock lock(m_operationStatusGate);
+
+    const auto isDone = m_operationsDone.wait_for(lock, DefaultTimeoutValue, [this] {
+        return m_done;
+    });
+
+    // Handle timeout from waiting for reads to be completed.
+    if (!isDone) {
+        DataStreamOperationStatus status{};
+        status.set_code(DataStreamOperationStatusCode::DataStreamOperationStatusCodeTimedOut);
+        status.set_message("Timeout occurred while waiting for all operations to be completed");
+        *m_readData.mutable_status() = std::move(status);
+    }
+    *operationStatus = m_readData.status();
+
+    return m_operationStatus;
+}
+
+void
+DataStreamReaderWriter::NextWrite()
+{
+    if (m_numberOfDataBlocksToWrite > 0) {
+        m_writeData.set_data(std::format("Data #{}", ++m_numberOfDataBlocksWritten));
+        StartWrite(&m_writeData);
+        m_numberOfDataBlocksToWrite--;
+    } else {
+        StartWritesDone();
+    }
+}

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -139,7 +139,8 @@ private:
 /**
  * @brief Implementation of the gRPC ClientBidiReactor for client-side data stream reading and writing.
  */
-class DataStreamReaderWriter : public grpc::ClientBidiReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData, Microsoft::Net::Remote::DataStream::DataStreamDownloadData>
+class DataStreamReaderWriter :
+    public grpc::ClientBidiReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData, Microsoft::Net::Remote::DataStream::DataStreamDownloadData>
 {
 public:
     /**

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -177,11 +177,12 @@ public:
     /**
      * @brief Wait for all operations to complete and transfer the status to the status output parameter.
      *
+     * @param numberOfDataBlocksReceived The number of data blocks received by the client.
      * @param operationStatus The status of the read/write data operations.
      * @return grpc::Status
      */
     grpc::Status
-    Await(Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus);
+    Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus);
 
 private:
     /**

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -1,4 +1,5 @@
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -1,5 +1,5 @@
 
-#include <bits/chrono.h>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -1,5 +1,5 @@
 
-#include <chrono>
+#include <bits/chrono.h>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -174,9 +174,11 @@ TEST_CASE("DataStreamBidirectional API", "[basic][rpc][client][remote][stream]")
     {
         DataStreamReaderWriter dataStreamReaderWriter{ client.get(), numberOfDataBlocksToStream };
 
+        uint32_t numberOfDataBlocksReceived{};
         DataStreamOperationStatus operationStatus{};
-        const grpc::Status status = dataStreamReaderWriter.Await(&operationStatus);
+        const grpc::Status status = dataStreamReaderWriter.Await(&numberOfDataBlocksReceived, &operationStatus);
         REQUIRE(status.ok());
+        REQUIRE(numberOfDataBlocksReceived > 0);
         REQUIRE(operationStatus.code() == DataStreamOperationStatusCodeSucceeded);
     }
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

This PR adds the `DataStreamBidirectional` API along with a unit test.

### Technical Details

* Added `DataStreamBidirectional` API to `NetRemoteDataStreamingService.proto`.
* Added `DataStreamReaderWriter` implementation of the gRPC `ServerBidiReactor` to `NetRemoteDataStreamingReactors`.
* Added `DataStreamReaderWriter` implementation of the gRPC `ClientBidiReactor` to `TestNetRemoteDataStreamingReactors`.
* Added unit test to `TestNetRemoteDataStreamingServiceClient`.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

* Apply the work for #186 to this API as well.
* Check if access/writes to `m_status` need to be gated.
* Consider if the client will ever need to cancel this RPC and if so, add `Cancel()` function and another unit test.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
