### PR TITLE
Implement WifiAccessPointEnable

### DIFF
--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -628,7 +628,7 @@ NetRemoteService::WifiAccessPointSetFrequencyBandsImpl(std::string_view accessPo
 }
 
 WifiAccessPointOperationStatus
-NetRemoteService::WifiAccessPointSetSsidImpl(std::string_view accessPointId, const Dot11Ssid& dot11Ssid)
+NetRemoteService::WifiAccessPointSetSsidImpl(std::string_view accessPointId, const Dot11Ssid& dot11Ssid, std::shared_ptr<IAccessPointController> accessPointController)
 {
     WifiAccessPointOperationStatus wifiOperationStatus{};
 
@@ -638,13 +638,16 @@ NetRemoteService::WifiAccessPointSetSsidImpl(std::string_view accessPointId, con
         return wifiOperationStatus;
     }
 
-    // Create an AP controller for the requested AP.
-    std::shared_ptr<IAccessPointController> accessPointController{};
-    auto operationStatus = TryGetAccessPointController(accessPointId, accessPointController);
-    if (!operationStatus.Succeeded() || accessPointController == nullptr) {
-        wifiOperationStatus.set_code(ToDot11AccessPointOperationStatusCode(operationStatus.Code));
-        wifiOperationStatus.set_message(std::format("Failed to create access point controller for access point {} - {}", accessPointId, operationStatus.ToString()));
-        return wifiOperationStatus;
+    AccessPointOperationStatus operationStatus{ accessPointId };
+
+    // Create an AP controller for the requested AP if one wasn't specified.
+    if (accessPointController == nullptr) {
+        operationStatus = TryGetAccessPointController(accessPointId, accessPointController);
+        if (!operationStatus.Succeeded() || accessPointController == nullptr) {
+            wifiOperationStatus.set_code(ToDot11AccessPointOperationStatusCode(operationStatus.Code));
+            wifiOperationStatus.set_message(std::format("Failed to create access point controller for access point {} - {}", accessPointId, operationStatus.ToString()));
+            return wifiOperationStatus;
+        }
     }
 
     // Set the SSID.

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -4,6 +4,7 @@
 #include <format>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -500,6 +501,15 @@ NetRemoteService::TryGetAccessPointController(std::string_view accessPointId, st
     }
 
     return TryGetAccessPointController(accessPoint, accessPointController);
+}
+
+WifiAccessPointOperationStatus
+NetRemoteService::WifiAccessPointEnableImpl([[maybe_unused]] std::string_view accessPointId, [[maybe_unused]] const std::optional<Dot11AccessPointConfiguration>& dot11AccessPointConfiguration)
+{
+    WifiAccessPointOperationStatus wifiOperationStatus{};
+    // TODO
+    wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeOperationNotSupported);
+    return wifiOperationStatus;
 }
 
 WifiAccessPointOperationStatus

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -458,10 +458,8 @@ NetRemoteService::WifiAccessPointEnableImpl(std::string_view accessPointId, cons
         if (dot11AccessPointConfiguration != nullptr) {
             // Set all configuration items that are present.
             if (dot11AccessPointConfiguration->phytype() != Dot11PhyType::Dot11PhyTypeUnknown) {
-                operationStatus = accessPointController->SetProtocol(FromDot11PhyType(dot11AccessPointConfiguration->phytype()));
-                if (!operationStatus.Succeeded()) {
-                    wifiOperationStatus.set_code(ToDot11AccessPointOperationStatusCode(operationStatus.Code));
-                    wifiOperationStatus.set_message(std::format("Failed to set PHY type for access point {} - {}", accessPointId, operationStatus.ToString()));
+                wifiOperationStatus = WifiAccessPointSetPhyTypeImpl(accessPointId, dot11AccessPointConfiguration->phytype(), accessPointController);
+                if (wifiOperationStatus.code() != WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded) {
                     return wifiOperationStatus;
                 }
             }
@@ -476,7 +474,7 @@ NetRemoteService::WifiAccessPointEnableImpl(std::string_view accessPointId, cons
 
             if (dot11AccessPointConfiguration->has_ssid()) {
                 const auto& ssid = dot11AccessPointConfiguration->ssid();
-                wifiOperationStatus = WifiAccessPointSetSsidImpl(accessPointId, ssid);
+                wifiOperationStatus = WifiAccessPointSetSsidImpl(accessPointId, ssid, accessPointController);
                 if (wifiOperationStatus.code() != WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded) {
                     return wifiOperationStatus;
                 }
@@ -484,7 +482,7 @@ NetRemoteService::WifiAccessPointEnableImpl(std::string_view accessPointId, cons
 
             if (!std::empty(dot11AccessPointConfiguration->bands())) {
                 auto dot11FrequencyBands = ToDot11FrequencyBands(*dot11AccessPointConfiguration);
-                wifiOperationStatus = WifiAccessPointSetFrequencyBandsImpl(accessPointId, dot11FrequencyBands);
+                wifiOperationStatus = WifiAccessPointSetFrequencyBandsImpl(accessPointId, dot11FrequencyBands, accessPointController);
                 if (wifiOperationStatus.code() != WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded) {
                     return wifiOperationStatus;
                 }

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -508,7 +508,7 @@ NetRemoteService::WifiAccessPointEnableImpl(std::string_view accessPointId, cons
 }
 
 WifiAccessPointOperationStatus
-NetRemoteService::WifiAccessPointSetPhyTypeImpl(std::string_view accessPointId, Dot11PhyType dot11PhyType)
+NetRemoteService::WifiAccessPointSetPhyTypeImpl(std::string_view accessPointId, Dot11PhyType dot11PhyType, std::shared_ptr<IAccessPointController> accessPointController)
 {
     WifiAccessPointOperationStatus wifiOperationStatus{};
 
@@ -519,13 +519,16 @@ NetRemoteService::WifiAccessPointSetPhyTypeImpl(std::string_view accessPointId, 
         return wifiOperationStatus;
     }
 
-    // Create an AP controller for the requested AP.
-    std::shared_ptr<IAccessPointController> accessPointController{};
-    auto operationStatus = TryGetAccessPointController(accessPointId, accessPointController);
-    if (!operationStatus.Succeeded() || accessPointController == nullptr) {
-        wifiOperationStatus.set_code(ToDot11AccessPointOperationStatusCode(operationStatus.Code));
-        wifiOperationStatus.set_message(std::format("Failed to create access point controller for access point {} - {}", accessPointId, operationStatus.ToString()));
-        return wifiOperationStatus;
+    AccessPointOperationStatus operationStatus{ accessPointId };
+
+    // Create an AP controller for the requested AP if one wasn't specified.
+    if (accessPointController == nullptr) {
+        operationStatus = TryGetAccessPointController(accessPointId, accessPointController);
+        if (!operationStatus.Succeeded() || accessPointController == nullptr) {
+            wifiOperationStatus.set_code(ToDot11AccessPointOperationStatusCode(operationStatus.Code));
+            wifiOperationStatus.set_message(std::format("Failed to create access point controller for access point {} - {}", accessPointId, operationStatus.ToString()));
+            return wifiOperationStatus;
+        }
     }
 
     // Convert PHY type to Ieee80211 protocol.

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -145,10 +145,11 @@ protected:
      *
      * @param accessPointId The access point identifier.
      * @param dot11PhyType The new PHY type to set.
+     * @param accessPointController The access point controller for the specified access point (optional).
      * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
-    WifiAccessPointSetPhyTypeImpl(std::string_view accessPointId, Microsoft::Net::Wifi::Dot11PhyType dot11PhyType);
+    WifiAccessPointSetPhyTypeImpl(std::string_view accessPointId, Microsoft::Net::Wifi::Dot11PhyType dot11PhyType, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
     /**
      * @brief Set the active frequency bands of the access point. The access point must be enabled. This will cause the

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -3,12 +3,14 @@
 #define NET_REMOTE_SERVICE_HXX
 
 #include <memory>
+#include <optional>
 #include <string_view>
 
 #include <grpcpp/server_context.h>
 #include <grpcpp/support/status.h>
 #include <microsoft/net/remote/protocol/NetRemoteService.grpc.pb.h>
 #include <microsoft/net/remote/protocol/NetRemoteWifi.pb.h>
+#include <microsoft/net/remote/protocol/WifiCore.pb.h>
 #include <microsoft/net/wifi/AccessPointManager.hxx>
 #include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
 #include <microsoft/net/wifi/IAccessPoint.hxx>
@@ -121,11 +123,21 @@ protected:
      * @brief Attempt to obtain an IAccessPointController instance for the specified access point.
      *
      * @param accessPoint The access point to obtain a controller for.
-     * @param accessPointController
+     * @param accessPointController Optional configuration to apply to the access point prior to enablement.
      * @return Microsoft::Net::Wifi::AccessPointOperationStatus
      */
     static Microsoft::Net::Wifi::AccessPointOperationStatus
     TryGetAccessPointController(const std::shared_ptr<Microsoft::Net::Wifi::IAccessPoint>& accessPoint, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController>& accessPointController);
+
+    /**
+     * @brief Enable an access point. This brings the access point online, making it available for use by clients.
+     *
+     * @param accessPointId The access point identifier.
+     * @param dot11AccessPointConfiguration
+     * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+     */
+    Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+    WifiAccessPointEnableImpl(std::string_view accessPointId, const std::optional<Microsoft::Net::Wifi::Dot11AccessPointConfiguration>& dot11AccessPointConfiguration);
 
     /**
      * @brief Set the active PHY type or protocol of the access point. The access point must be enabled. This will cause

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -3,7 +3,6 @@
 #define NET_REMOTE_SERVICE_HXX
 
 #include <memory>
-#include <optional>
 #include <string_view>
 
 #include <grpcpp/server_context.h>
@@ -133,11 +132,11 @@ protected:
      * @brief Enable an access point. This brings the access point online, making it available for use by clients.
      *
      * @param accessPointId The access point identifier.
-     * @param dot11AccessPointConfiguration
+     * @param dot11AccessPointConfiguration (optional) The access point configuration to enforce prior to enablement. 
      * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
-    WifiAccessPointEnableImpl(std::string_view accessPointId, const std::optional<Microsoft::Net::Wifi::Dot11AccessPointConfiguration>& dot11AccessPointConfiguration);
+    WifiAccessPointEnableImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11AccessPointConfiguration* dot11AccessPointConfiguration);
 
     /**
      * @brief Set the active PHY type or protocol of the access point. The access point must be enabled. This will cause

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -168,10 +168,11 @@ protected:
      * 
      * @param accessPointId The access point identifier.
      * @param dot11Ssid The new SSID to set.
+     * @param accessPointController The access point controller for the specified access point (optional).
      * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus 
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
-    WifiAccessPointSetSsidImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11Ssid& dot11Ssid);
+    WifiAccessPointSetSsidImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11Ssid& dot11Ssid, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
 private:
     std::shared_ptr<Microsoft::Net::Wifi::AccessPointManager> m_accessPointManager;

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -157,10 +157,11 @@ protected:
      *
      * @param accessPointId The access point identifier.
      * @param dot11FrequencyBands The new frequency bands to set.
+     * @param accessPointController The access point controller for the specified access point (optional).
      * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
-    WifiAccessPointSetFrequencyBandsImpl(std::string_view accessPointId, std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>& dot11FrequencyBands);
+    WifiAccessPointSetFrequencyBandsImpl(std::string_view accessPointId, std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>& dot11FrequencyBands, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
     /**
      * @brief Set the SSID of the access point.

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -160,6 +160,16 @@ protected:
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
     WifiAccessPointSetFrequencyBandsImpl(std::string_view accessPointId, std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>& dot11FrequencyBands);
 
+    /**
+     * @brief Set the SSID of the access point.
+     * 
+     * @param accessPointId The access point identifier.
+     * @param dot11Ssid The new SSID to set.
+     * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus 
+     */
+    Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+    WifiAccessPointSetSsidImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11Ssid& dot11Ssid);
+
 private:
     std::shared_ptr<Microsoft::Net::Wifi::AccessPointManager> m_accessPointManager;
 };

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -161,18 +161,6 @@ protected:
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
     WifiAccessPointSetFrequencyBandsImpl(std::string_view accessPointId, std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>& dot11FrequencyBands);
 
-protected:
-    /**
-     * @brief Validate the basic input parameters for the WifiAccessPointEnable request.
-     *
-     * @param request The request to validate.
-     * @param status The status to populate with failure information.
-     * @return true
-     * @return false
-     */
-    static bool
-    ValidateWifiAccessPointEnableRequest(const Microsoft::Net::Remote::Wifi::WifiAccessPointEnableRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus& status);
-
 private:
     std::shared_ptr<Microsoft::Net::Wifi::AccessPointManager> m_accessPointManager;
 };

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -133,10 +133,11 @@ protected:
      *
      * @param accessPointId The access point identifier.
      * @param dot11AccessPointConfiguration (optional) The access point configuration to enforce prior to enablement. 
+     * @param accessPointController The access point controller for the specified access point (optional).
      * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
-    WifiAccessPointEnableImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11AccessPointConfiguration* dot11AccessPointConfiguration);
+    WifiAccessPointEnableImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11AccessPointConfiguration* dot11AccessPointConfiguration, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
     /**
      * @brief Set the active PHY type or protocol of the access point. The access point must be enabled. This will cause

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -99,7 +99,7 @@ struct IAccessPointController
      * @return AccessPointOperationStatus
      */
     virtual AccessPointOperationStatus
-    SetSssid(std::string_view ssid) noexcept = 0;
+    SetSsid(std::string_view ssid) noexcept = 0;
 };
 
 /**

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -153,34 +153,40 @@ FromDot11FrequencyBand(const Dot11FrequencyBand dot11FrequencyBand) noexcept
 
 using Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest;
 
+namespace detail
+{
+// protobuf encodes enums in repeated fields as 'int' instead of the enum type itself. So, the below is a simple
+// function to convert the repeated field of int to the enum type.
+constexpr auto toDot11FrequencyBand = [](const auto& frequencyBand) {
+    return static_cast<Dot11FrequencyBand>(frequencyBand);
+};
+} // details
+
 std::vector<Dot11FrequencyBand>
 ToDot11FrequencyBands(const WifiAccessPointSetFrequencyBandsRequest& request) noexcept
 {
-    // protobuf encodes enums in repeated fields as 'int' instead of the enum type itself. So, the below is a simple
-    // function to convert the repeated field of int to the enum type.
-    constexpr auto toDot11FrequencyBand = [](const auto& frequencyBand) {
-        return static_cast<Dot11FrequencyBand>(frequencyBand);
-    };
-
     std::vector<Dot11FrequencyBand> dot11FrequencyBands(static_cast<std::size_t>(std::size(request.frequencybands())));
-    std::ranges::transform(request.frequencybands(), std::begin(dot11FrequencyBands), toDot11FrequencyBand);
+    std::ranges::transform(request.frequencybands(), std::begin(dot11FrequencyBands), detail::toDot11FrequencyBand);
 
     return dot11FrequencyBands;
     // TODO: for some reason, std::ranges::to is not being found for clang. Once resolved, update to the following:
     // return request.frequencybands() | std::views::transform(toDot11FrequencyBand) | std::ranges::to<std::vector>();
 }
 
+std::vector<Dot11FrequencyBand>
+ToDot11FrequencyBands(const Dot11AccessPointConfiguration& dot11AccessPointConfiguration) noexcept
+{
+    std::vector<Dot11FrequencyBand> dot11FrequencyBands(static_cast<std::size_t>(std::size(dot11AccessPointConfiguration.bands())));
+    std::ranges::transform(dot11AccessPointConfiguration.bands(), std::begin(dot11FrequencyBands), detail::toDot11FrequencyBand);
+
+    return dot11FrequencyBands;
+}
+
 std::vector<Ieee80211FrequencyBand>
 FromDot11SetFrequencyBandsRequest(const WifiAccessPointSetFrequencyBandsRequest& request)
 {
-    // protobuf encodes enums in repeated fields as 'int' instead of the enum type itself. So, the below is a simple
-    // function to convert the repeated field of int to the enum type.
-    constexpr auto toDot11FrequencyBand = [](const auto& frequencyBand) {
-        return static_cast<Dot11FrequencyBand>(frequencyBand);
-    };
-
     std::vector<Ieee80211FrequencyBand> ieee80211FrequencyBands(static_cast<std::size_t>(std::size(request.frequencybands())));
-    std::ranges::transform(request.frequencybands() | std::views::transform(toDot11FrequencyBand), std::begin(ieee80211FrequencyBands), FromDot11FrequencyBand);
+    std::ranges::transform(request.frequencybands() | std::views::transform(detail::toDot11FrequencyBand), std::begin(ieee80211FrequencyBands), FromDot11FrequencyBand);
 
     return ieee80211FrequencyBands;
 }

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -67,6 +67,15 @@ std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>
 ToDot11FrequencyBands(const Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest& request) noexcept;
 
 /**
+ * @brief Obtain a vector of Dot11FrequencyBands from the specified Dot11AccessPointConfiguration.
+ * 
+ * @param dot11AccessPointConfiguration The Dot11AccessPointConfiguration to extract the Dot11FrequencyBands from.
+ * @return std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand> 
+ */
+std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>
+ToDot11FrequencyBands(const Microsoft::Net::Wifi::Dot11AccessPointConfiguration& dot11AccessPointConfiguration) noexcept;
+
+/**
  * @brief Convert the specified Dot11FrequencyBand to the equivalent IEEE 802.11 frequency band.
  *
  * @param dot11FrequencyBand The Dot11FrequencyBand to convert.

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -265,7 +265,7 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
 }
 
 AccessPointOperationStatus
-AccessPointControllerLinux::SetSssid(std::string_view ssid) noexcept
+AccessPointControllerLinux::SetSsid(std::string_view ssid) noexcept
 {
     AccessPointOperationStatus status{ GetInterfaceName() };
     const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -97,7 +97,7 @@ struct AccessPointControllerLinux :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    SetSssid(std::string_view ssid) noexcept override;
+    SetSsid(std::string_view ssid) noexcept override;
 
 private:
     Wpa::Hostapd m_hostapd;

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -98,7 +98,8 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
 
     auto apManagerTest = std::make_shared<AccessPointManagerTest>();
     const Ieee80211AccessPointCapabilities apCapabilities{
-        .Protocols{ std::cbegin(AllProtocols), std::cend(AllProtocols) }
+        .Protocols{ std::cbegin(AllProtocols), std::cend(AllProtocols) },
+        .FrequencyBands{ std::cbegin(AllBands), std::cend(AllBands) }
     };
 
     auto apTest1 = std::make_shared<AccessPointTest>(InterfaceName1, apCapabilities);

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -109,7 +109,7 @@ AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand>
 }
 
 AccessPointOperationStatus
-AccessPointControllerTest::SetSssid(std::string_view ssid) noexcept
+AccessPointControllerTest::SetSsid(std::string_view ssid) noexcept
 {
     assert(AccessPoint != nullptr);
 

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -110,7 +110,7 @@ struct AccessPointControllerTest final :
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    SetSssid(std::string_view ssid) noexcept override;
+    SetSsid(std::string_view ssid) noexcept override;
 };
 
 /**


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

*Allow access points to be enabled.

### Technical Details

* Add impl functions for each API to allow usage in smaller blocks.
* Add helper to extract strongly typed frequency bands from `Dot11AccessPointConfiguration`.
* Add helpers for obtaining an `IAccessPoint` and `IAccessPointController` in a consistent way.
* Fix `SetSssid` -> `SetSsid`.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Enforce AKM and cipher suite settings on enable. `IAccessPointController` needs to be expose functions for configuring security.
* Convert `WifiAccessPointDisable` to use an impl function of the new pattern.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
