### PR TITLE
Rename 'Bands' fields in API types to 'FrequencyBands' for consistency. 

### DIFF
--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -142,12 +142,12 @@ message Dot11AccessPointConfiguration
     Dot11PhyType PhyType = 3;
     Dot11AuthenticationAlgorithm AuthenticationAlgorithm = 4;
     Dot11CipherSuite CipherSuite = 5;
-    repeated Dot11FrequencyBand Bands = 6;
+    repeated Dot11FrequencyBand FrequencyBands = 6;
 }
 
 message Dot11AccessPointCapabilities
 {
-    repeated Microsoft.Net.Wifi.Dot11FrequencyBand Bands = 1;
+    repeated Microsoft.Net.Wifi.Dot11FrequencyBand FrequencyBands = 1;
     repeated Microsoft.Net.Wifi.Dot11PhyType PhyTypes = 2;
     repeated Microsoft.Net.Wifi.Dot11AkmSuite AkmSuites = 3;
     repeated Microsoft.Net.Wifi.Dot11CipherSuite CipherSuites = 4;

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -469,7 +469,7 @@ NetRemoteService::WifiAccessPointEnableImpl(std::string_view accessPointId, cons
             }
         }
 
-        if (!std::empty(dot11AccessPointConfiguration->bands())) {
+        if (!std::empty(dot11AccessPointConfiguration->frequencybands())) {
             auto dot11FrequencyBands = ToDot11FrequencyBands(*dot11AccessPointConfiguration);
             wifiOperationStatus = WifiAccessPointSetFrequencyBandsImpl(accessPointId, dot11FrequencyBands, accessPointController);
             if (wifiOperationStatus.code() != WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded) {

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -61,7 +61,7 @@ NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::Dot11Access
     ss << '\n'
        << indent0
        << "Bands:";
-    for (const auto& band : accessPointCapabilities.bands()) {
+    for (const auto& band : accessPointCapabilities.frequencybands()) {
         std::string_view bandName(magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11FrequencyBand>(band)));
         bandName.remove_prefix(BandPrefixLength);
         ss << '\n'

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -176,8 +176,8 @@ ToDot11FrequencyBands(const WifiAccessPointSetFrequencyBandsRequest& request) no
 std::vector<Dot11FrequencyBand>
 ToDot11FrequencyBands(const Dot11AccessPointConfiguration& dot11AccessPointConfiguration) noexcept
 {
-    std::vector<Dot11FrequencyBand> dot11FrequencyBands(static_cast<std::size_t>(std::size(dot11AccessPointConfiguration.bands())));
-    std::ranges::transform(dot11AccessPointConfiguration.bands(), std::begin(dot11FrequencyBands), detail::toDot11FrequencyBand);
+    std::vector<Dot11FrequencyBand> dot11FrequencyBands(static_cast<std::size_t>(std::size(dot11AccessPointConfiguration.frequencybands())));
+    std::ranges::transform(dot11AccessPointConfiguration.frequencybands(), std::begin(dot11FrequencyBands), detail::toDot11FrequencyBand);
 
     return dot11FrequencyBands;
 }
@@ -444,7 +444,7 @@ ToDot11AccessPointCapabilities(const Ieee80211AccessPointCapabilities& ieee80211
     std::vector<Dot11FrequencyBand> bands(std::size(ieee80211AccessPointCapabilities.FrequencyBands));
     std::ranges::transform(ieee80211AccessPointCapabilities.FrequencyBands, std::begin(bands), ToDot11FrequencyBand);
 
-    *dot11Capabilities.mutable_bands() = {
+    *dot11Capabilities.mutable_frequencybands() = {
         std::make_move_iterator(std::begin(bands)),
         std::make_move_iterator(std::end(bands))
     };

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -125,8 +125,8 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
         apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
         apConfiguration.set_authenticationalgorithm(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);
         apConfiguration.set_ciphersuite(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
-        apConfiguration.mutable_bands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
-        apConfiguration.mutable_bands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
+        apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
+        apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
 
         WifiAccessPointEnableRequest request{};
         request.set_accesspointid(InterfaceName1);
@@ -169,7 +169,7 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
         apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
         apConfiguration.set_authenticationalgorithm(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);
         apConfiguration.set_ciphersuite(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
-        apConfiguration.mutable_bands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
+        apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
 
         WifiAccessPointEnableRequest request{};
         request.set_accesspointid(InterfaceName1);


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [X] Breaking change
- [ ] Non-functional change

### Goals

* Name wifi types consistently throughout the stack.

### Technical Details

* Rename `Dot11AccessPointConfiguration::Bands` -> `Dot11AccessPointConfiguration::FrequencyBands`
* Rename `Dot11AccessPointCapabilities::Bands` -> `Dot11AccessPointCapabilities::FrequencyBands`

### Test Results

* Compile tested only.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
