### PR TITLE
Check when mismatched sequencing occurs

### DIFF
--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -1,7 +1,9 @@
 
+#include <cstddef>
 #include <cstdint>
 #include <format>
 #include <mutex>
+#include <span>
 #include <utility>
 
 #include <grpcpp/impl/codegen/status.h>

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -111,7 +111,7 @@ DataStreamReader::OnDone(const grpc::Status& status)
 }
 
 grpc::Status
-DataStreamReader::Await(uint32_t* numberOfDataBlocksReceived, DataStreamOperationStatus* operationStatus, std::vector<uint32_t>* lostDataBlockSequenceNumbers)
+DataStreamReader::Await(uint32_t* numberOfDataBlocksReceived, DataStreamOperationStatus* operationStatus, std::span<uint32_t> lostDataBlockSequenceNumbers)
 {
     std::unique_lock lock(m_readStatusGate);
 
@@ -129,7 +129,10 @@ DataStreamReader::Await(uint32_t* numberOfDataBlocksReceived, DataStreamOperatio
 
     *numberOfDataBlocksReceived = m_numberOfDataBlocksReceived;
     *operationStatus = m_data.status();
-    *lostDataBlockSequenceNumbers = m_lostDataBlockSequenceNumbers;
+
+    for (std::size_t i = 0; i < std::size(m_lostDataBlockSequenceNumbers); i++) {
+        lostDataBlockSequenceNumbers[i] = m_lostDataBlockSequenceNumbers[i];
+    }
 
     return m_status;
 }
@@ -188,7 +191,7 @@ DataStreamReaderWriter::OnDone(const grpc::Status& status)
 }
 
 grpc::Status
-DataStreamReaderWriter::Await(uint32_t* numberOfDataBlocksReceived, DataStreamOperationStatus* operationStatus, std::vector<uint32_t>* lostDataBlockSequenceNumbers)
+DataStreamReaderWriter::Await(uint32_t* numberOfDataBlocksReceived, DataStreamOperationStatus* operationStatus, std::span<uint32_t> lostDataBlockSequenceNumbers)
 {
     std::unique_lock lock(m_operationStatusGate);
 
@@ -206,7 +209,10 @@ DataStreamReaderWriter::Await(uint32_t* numberOfDataBlocksReceived, DataStreamOp
 
     *numberOfDataBlocksReceived = m_numberOfDataBlocksReceived;
     *operationStatus = m_readData.status();
-    *lostDataBlockSequenceNumbers = m_lostDataBlockSequenceNumbers;
+
+    for (std::size_t i = 0; i < std::size(m_lostDataBlockSequenceNumbers); i++) {
+        lostDataBlockSequenceNumbers[i] = m_lostDataBlockSequenceNumbers[i];
+    }
 
     return m_operationStatus;
 }

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -131,10 +131,7 @@ DataStreamReader::Await(uint32_t* numberOfDataBlocksReceived, DataStreamOperatio
 
     *numberOfDataBlocksReceived = m_numberOfDataBlocksReceived;
     *operationStatus = m_data.status();
-
-    for (std::size_t i = 0; i < std::size(m_lostDataBlockSequenceNumbers); i++) {
-        lostDataBlockSequenceNumbers[i] = m_lostDataBlockSequenceNumbers[i];
-    }
+    lostDataBlockSequenceNumbers = std::span<uint32_t>(std::data(m_lostDataBlockSequenceNumbers), std::size(m_lostDataBlockSequenceNumbers));
 
     return m_status;
 }
@@ -211,10 +208,7 @@ DataStreamReaderWriter::Await(uint32_t* numberOfDataBlocksReceived, DataStreamOp
 
     *numberOfDataBlocksReceived = m_numberOfDataBlocksReceived;
     *operationStatus = m_readData.status();
-
-    for (std::size_t i = 0; i < std::size(m_lostDataBlockSequenceNumbers); i++) {
-        lostDataBlockSequenceNumbers[i] = m_lostDataBlockSequenceNumbers[i];
-    }
+    lostDataBlockSequenceNumbers = std::span<uint32_t>(std::data(m_lostDataBlockSequenceNumbers), std::size(m_lostDataBlockSequenceNumbers));
 
     return m_operationStatus;
 }

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -6,6 +6,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <mutex>
+#include <vector>
 
 #include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
 #include <microsoft/net/remote/protocol/NetRemoteDataStreamingService.grpc.pb.h>
@@ -112,10 +113,11 @@ public:
      *
      * @param numberOfDataBlocksReceived The number of data blocks received by the client.
      * @param operationStatus The status of the data stream read operation.
+     * @param lostDataBlockSequenceNumbers The list of sequence numbers associated with data blocks sent by the server that were not received by the client.
      * @return grpc::Status
      */
     grpc::Status
-    Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus);
+    Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus, std::vector<uint32_t>* lostDataBlockSequenceNumbers);
 
     /**
      * @brief Cancel the ongoing RPC.
@@ -134,6 +136,7 @@ private:
     std::condition_variable m_readsDone{};
     bool m_done{ false };
     std::chrono::duration<uint32_t> m_readsDoneTimeoutValue{ DefaultTimeoutValue };
+    std::vector<uint32_t> m_lostDataBlockSequenceNumbers{};
 };
 
 /**

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -6,6 +6,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <mutex>
+#include <span>
 #include <vector>
 
 #include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
@@ -117,7 +118,7 @@ public:
      * @return grpc::Status
      */
     grpc::Status
-    Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus, std::vector<uint32_t>* lostDataBlockSequenceNumbers);
+    Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus, std::span<uint32_t> lostDataBlockSequenceNumbers);
 
     /**
      * @brief Cancel the ongoing RPC.
@@ -187,7 +188,7 @@ public:
      * @return grpc::Status
      */
     grpc::Status
-    Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus, std::vector<uint32_t>* lostDataBlockSequenceNumbers);
+    Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus, std::span<uint32_t> lostDataBlockSequenceNumbers);
 
 private:
     /**

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -183,10 +183,11 @@ public:
      *
      * @param numberOfDataBlocksReceived The number of data blocks received by the client.
      * @param operationStatus The status of the read/write data operations.
+     * @param lostDataBlockSequenceNumbers The list of sequence numbers associated with data blocks sent by the server that were not received by the client.
      * @return grpc::Status
      */
     grpc::Status
-    Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus);
+    Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus, std::vector<uint32_t>* lostDataBlockSequenceNumbers);
 
 private:
     /**
@@ -208,6 +209,7 @@ private:
     std::mutex m_operationStatusGate{};
     std::condition_variable m_operationsDone{};
     bool m_done{ false };
+    std::vector<uint32_t> m_lostDataBlockSequenceNumbers{};
 };
 
 } // namespace Microsoft::Net::Remote::Test

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -117,7 +117,7 @@ TEST_CASE("DataStreamDownload API", "[basic][rpc][client][remote][stream]")
         uint32_t numberOfDataBlocksReceived{};
         DataStreamOperationStatus operationStatus{};
         std::vector<uint32_t> lostDataBlockSequenceNumbers{};
-        const grpc::Status status = dataStreamReader.Await(&numberOfDataBlocksReceived, &operationStatus, &lostDataBlockSequenceNumbers);
+        const grpc::Status status = dataStreamReader.Await(&numberOfDataBlocksReceived, &operationStatus, lostDataBlockSequenceNumbers);
         REQUIRE(status.ok());
         REQUIRE(numberOfDataBlocksReceived == fixedNumberOfDataBlocksToStream);
         REQUIRE(operationStatus.code() == DataStreamOperationStatusCodeSucceeded);
@@ -147,7 +147,7 @@ TEST_CASE("DataStreamDownload API", "[basic][rpc][client][remote][stream]")
         uint32_t numberOfDataBlocksReceived{};
         DataStreamOperationStatus operationStatus{};
         std::vector<uint32_t> lostDataBlockSequenceNumbers{};
-        const grpc::Status status = dataStreamReader.Await(&numberOfDataBlocksReceived, &operationStatus, &lostDataBlockSequenceNumbers);
+        const grpc::Status status = dataStreamReader.Await(&numberOfDataBlocksReceived, &operationStatus, lostDataBlockSequenceNumbers);
         REQUIRE(status.error_code() == grpc::StatusCode::CANCELLED);
         REQUIRE(operationStatus.code() == DataStreamOperationStatusCodeSucceeded);
         REQUIRE(lostDataBlockSequenceNumbers.empty());
@@ -182,7 +182,7 @@ TEST_CASE("DataStreamBidirectional API", "[basic][rpc][client][remote][stream]")
         uint32_t numberOfDataBlocksReceived{};
         DataStreamOperationStatus operationStatus{};
         std::vector<uint32_t> lostDataBlockSequenceNumbers{};
-        const grpc::Status status = dataStreamReaderWriter.Await(&numberOfDataBlocksReceived, &operationStatus, &lostDataBlockSequenceNumbers);
+        const grpc::Status status = dataStreamReaderWriter.Await(&numberOfDataBlocksReceived, &operationStatus, lostDataBlockSequenceNumbers);
         REQUIRE(status.ok());
         REQUIRE(numberOfDataBlocksReceived > 0);
         REQUIRE(operationStatus.code() == DataStreamOperationStatusCodeSucceeded);

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -181,9 +181,11 @@ TEST_CASE("DataStreamBidirectional API", "[basic][rpc][client][remote][stream]")
 
         uint32_t numberOfDataBlocksReceived{};
         DataStreamOperationStatus operationStatus{};
-        const grpc::Status status = dataStreamReaderWriter.Await(&numberOfDataBlocksReceived, &operationStatus);
+        std::vector<uint32_t> lostDataBlockSequenceNumbers{};
+        const grpc::Status status = dataStreamReaderWriter.Await(&numberOfDataBlocksReceived, &operationStatus, &lostDataBlockSequenceNumbers);
         REQUIRE(status.ok());
         REQUIRE(numberOfDataBlocksReceived > 0);
         REQUIRE(operationStatus.code() == DataStreamOperationStatusCodeSucceeded);
+        REQUIRE(lostDataBlockSequenceNumbers.empty());
     }
 }

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -116,10 +116,12 @@ TEST_CASE("DataStreamDownload API", "[basic][rpc][client][remote][stream]")
 
         uint32_t numberOfDataBlocksReceived{};
         DataStreamOperationStatus operationStatus{};
-        const grpc::Status status = dataStreamReader.Await(&numberOfDataBlocksReceived, &operationStatus);
+        std::vector<uint32_t> lostDataBlockSequenceNumbers{};
+        const grpc::Status status = dataStreamReader.Await(&numberOfDataBlocksReceived, &operationStatus, &lostDataBlockSequenceNumbers);
         REQUIRE(status.ok());
         REQUIRE(numberOfDataBlocksReceived == fixedNumberOfDataBlocksToStream);
         REQUIRE(operationStatus.code() == DataStreamOperationStatusCodeSucceeded);
+        REQUIRE(lostDataBlockSequenceNumbers.empty());
     }
 
     SECTION("Can be called with DataStreamTypeContinuous and DataStreamPatternConstant")
@@ -144,9 +146,11 @@ TEST_CASE("DataStreamDownload API", "[basic][rpc][client][remote][stream]")
 
         uint32_t numberOfDataBlocksReceived{};
         DataStreamOperationStatus operationStatus{};
-        const grpc::Status status = dataStreamReader.Await(&numberOfDataBlocksReceived, &operationStatus);
+        std::vector<uint32_t> lostDataBlockSequenceNumbers{};
+        const grpc::Status status = dataStreamReader.Await(&numberOfDataBlocksReceived, &operationStatus, &lostDataBlockSequenceNumbers);
         REQUIRE(status.error_code() == grpc::StatusCode::CANCELLED);
         REQUIRE(operationStatus.code() == DataStreamOperationStatusCodeSucceeded);
+        REQUIRE(lostDataBlockSequenceNumbers.empty());
     }
 }
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

Fixes #186 

### Technical Details

* Check for mismatched sequencing in `OnReadDone` callbacks and store a list of the unreceived sequence numbers.
* Return a `std::span` parameter of the sequence numbers in the client test `Await` functions.
* Don't set status to failed if sequence mismatch occurs, just let client handle it how it wants to.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
