### PR TITLE
Continuous client-side streaming using DataStreamBidirectional API

### DIFF
--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -303,11 +303,10 @@ DataStreamReaderWriter::OnCancel()
 {
     const FunctionTracer traceMe{};
 
-    // The RPC is canceled by the client, so call Finish to complete it from the server perspective.
+    // Because the RPC is canceled by the client, there will be no more data to read. Thus, OnReadDone will fail and will
+    // call Finish(), so don't call Finish() here.
     bool isCanceledExpected{ false };
-    if (m_isCanceled.compare_exchange_strong(isCanceledExpected, true, std::memory_order_relaxed, std::memory_order_relaxed)) {
-        Finish(grpc::Status::CANCELLED);
-    }
+    m_isCanceled.compare_exchange_strong(isCanceledExpected, true, std::memory_order_relaxed, std::memory_order_relaxed);
 }
 
 void

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -1,5 +1,5 @@
 
-#include <cstddef>
+#include <atomic>
 #include <cstdint>
 #include <format>
 #include <mutex>
@@ -145,7 +145,7 @@ DataStreamReader::Cancel()
 }
 
 DataStreamReaderWriter::DataStreamReaderWriter(NetRemoteDataStreaming::Stub* client, DataStreamProperties dataStreamProperties) :
-    m_dataStreamProperties(dataStreamProperties)
+    m_dataStreamProperties(std::move(dataStreamProperties))
 {
     switch (m_dataStreamProperties.type()) {
     case DataStreamType::DataStreamTypeFixed: {

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -214,6 +214,13 @@ DataStreamReaderWriter::Await(uint32_t* numberOfDataBlocksReceived, DataStreamOp
 }
 
 void
+DataStreamReaderWriter::Cancel()
+{
+    LOGD << "Attempting to cancel RPC";
+    m_clientContext.TryCancel();
+}
+
+void
 DataStreamReaderWriter::NextWrite()
 {
     if (m_numberOfDataBlocksToWrite > 0) {

--- a/tests/unit/TestNetRemoteDataStreamingReactors.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.cxx
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include <grpcpp/impl/codegen/status.h>
+#include <magic_enum.hpp>
 #include <microsoft/net/remote/protocol/NetRemoteDataStream.pb.h>
 #include <microsoft/net/remote/protocol/NetRemoteDataStreamingService.grpc.pb.h>
 #include <plog/Log.h>
@@ -143,9 +144,36 @@ DataStreamReader::Cancel()
     m_clientContext.TryCancel();
 }
 
-DataStreamReaderWriter::DataStreamReaderWriter(NetRemoteDataStreaming::Stub* client, uint32_t numberOfDataBlocksToWrite) :
-    m_numberOfDataBlocksToWrite(numberOfDataBlocksToWrite)
+DataStreamReaderWriter::DataStreamReaderWriter(NetRemoteDataStreaming::Stub* client, DataStreamProperties dataStreamProperties) :
+    m_dataStreamProperties(dataStreamProperties)
 {
+    switch (m_dataStreamProperties.type()) {
+    case DataStreamType::DataStreamTypeFixed: {
+        if (m_dataStreamProperties.Properties_case() == DataStreamProperties::kFixed) {
+            m_numberOfDataBlocksToWrite = m_dataStreamProperties.fixed().numberofdatablockstostream();
+        } else {
+            LOGE << "Invalid properties for this streaming type. Expected Fixed for DataStreamTypeFixed";
+            return;
+        }
+
+        break;
+    }
+    case DataStreamType::DataStreamTypeContinuous: {
+        if (m_dataStreamProperties.Properties_case() == DataStreamProperties::kContinuous) {
+            m_numberOfDataBlocksToWrite = 0;
+        } else {
+            LOGE << "Invalid properties for this streaming type. Expected Continuous for DataStreamTypeContinuous";
+            return;
+        }
+
+        break;
+    }
+    default: {
+        LOGE << std::format("Invalid streaming type: {}", magic_enum::enum_name(m_dataStreamProperties.type()));
+        return;
+    }
+    };
+
     client->async()->DataStreamBidirectional(&m_clientContext, this);
     StartCall();
     StartRead(&m_readData);
@@ -173,6 +201,9 @@ void
 DataStreamReaderWriter::OnWriteDone(bool isOk)
 {
     if (isOk) {
+        if (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeFixed) {
+            m_numberOfDataBlocksToWrite--;
+        }
         NextWrite();
     } else {
         StartWritesDone();
@@ -223,9 +254,9 @@ DataStreamReaderWriter::Cancel()
 void
 DataStreamReaderWriter::NextWrite()
 {
-    if (m_numberOfDataBlocksToWrite > 0) {
+    if (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeContinuous ||
+        (m_dataStreamProperties.type() == DataStreamType::DataStreamTypeFixed && m_numberOfDataBlocksToWrite > 0)) {
         m_writeData.set_data(std::format("Data #{}", ++m_numberOfDataBlocksWritten));
-        m_numberOfDataBlocksToWrite--;
         StartWrite(&m_writeData);
     } else {
         StartWritesDone();

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -151,9 +151,9 @@ public:
      * @brief Construct a new DataStreamReaderWriter object with the client stub and specified number of data blocks to write.
      *
      * @param client The data streaming client stub.
-     * @param numberOfDataBlocksToWrite The number of data blocks to write to the server.
+     * @param dataStreamProperties The properties associated with the type of data streaming.
      */
-    explicit DataStreamReaderWriter(Microsoft::Net::Remote::Service::NetRemoteDataStreaming::Stub* client, uint32_t numberOfDataBlocksToWrite);
+    explicit DataStreamReaderWriter(Microsoft::Net::Remote::Service::NetRemoteDataStreaming::Stub* client, Microsoft::Net::Remote::DataStream::DataStreamProperties dataStreamProperties);
 
     /**
      * @brief Callback that is executed when a read operation is completed.
@@ -209,6 +209,7 @@ private:
     grpc::ClientContext m_clientContext{};
     Microsoft::Net::Remote::DataStream::DataStreamDownloadData m_readData{};
     Microsoft::Net::Remote::DataStream::DataStreamUploadData m_writeData{};
+    Microsoft::Net::Remote::DataStream::DataStreamProperties m_dataStreamProperties{};
     uint32_t m_numberOfDataBlocksToWrite{};
     uint32_t m_numberOfDataBlocksWritten{};
     uint32_t m_numberOfDataBlocksReceived{};

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -190,6 +190,12 @@ public:
     grpc::Status
     Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus, std::span<uint32_t> lostDataBlockSequenceNumbers);
 
+    /**
+     * @brief Cancel the ongoing RPC.
+     */
+    void
+    Cancel();
+
 private:
     /**
      * @brief Facilitate the next write operation.

--- a/tests/unit/TestNetRemoteDataStreamingReactors.hxx
+++ b/tests/unit/TestNetRemoteDataStreamingReactors.hxx
@@ -191,10 +191,10 @@ public:
     Await(uint32_t* numberOfDataBlocksReceived, Microsoft::Net::Remote::DataStream::DataStreamOperationStatus* operationStatus, std::span<uint32_t> lostDataBlockSequenceNumbers);
 
     /**
-     * @brief Cancel the ongoing RPC.
+     * @brief Stops writing data to the client. Should only be called with DataStreamTypeContinuous.
      */
     void
-    Cancel();
+    StopWrites();
 
 private:
     /**
@@ -218,6 +218,7 @@ private:
     std::condition_variable m_operationsDone{};
     bool m_done{ false };
     std::vector<uint32_t> m_lostDataBlockSequenceNumbers{};
+    std::atomic<bool> m_writesStopped{};
 };
 
 } // namespace Microsoft::Net::Remote::Test

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -173,11 +173,18 @@ TEST_CASE("DataStreamBidirectional API", "[basic][rpc][client][remote][stream]")
     auto channel = grpc::CreateChannel(RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());
     auto client = NetRemoteDataStreaming::NewStub(channel);
 
-    static constexpr auto numberOfDataBlocksToStream = 10;
+    static constexpr auto fixedNumberOfDataBlocksToStream = 10;
 
     SECTION("Can be called")
     {
-        DataStreamReaderWriter dataStreamReaderWriter{ client.get(), numberOfDataBlocksToStream };
+        DataStreamFixedTypeProperties fixedTypeProperties{};
+        fixedTypeProperties.set_numberofdatablockstostream(fixedNumberOfDataBlocksToStream);
+
+        DataStreamProperties properties{};
+        properties.set_type(DataStreamType::DataStreamTypeFixed);
+        *properties.mutable_fixed() = std::move(fixedTypeProperties);
+
+        DataStreamReaderWriter dataStreamReaderWriter{ client.get(), std::move(properties) };
 
         uint32_t numberOfDataBlocksReceived{};
         DataStreamOperationStatus operationStatus{};


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

Allow the client to continuously stream data via `DataStreamBidirectional` then stop when desired.

### Technical Details

* Fix the `OnCancel` callback in `NetRemoteDataStreamingReactors::DataStreamReaderWriter` to not call `Finish()` since it gets called in `OnReadDone`.
* Update the client-side `TestNetRemoteDataStreamingReactors::DataStreamReaderWriter` to accept a `DataStreamProperties` object to allow for either fixed or continuous streaming.
* Add `StopWrites()` function to client-side `TestNetRemoteDataStreamingReactors::DataStreamReaderWriter` to stop writing to the server in bidirectional streaming.
* Update existing unit test to use fixed-type streaming.
* Add new unit test to use continuous-type streaming.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
