### PR TITLE
Add built proto headers for data streaming to CMakeLists

### DIFF
--- a/protocol/CMakeLists.txt
+++ b/protocol/CMakeLists.txt
@@ -26,6 +26,7 @@ set(PROTO_FILES
 #
 set(PROTO_HEADERS_GENERATED
     ${PROTO_DIR_BINARY}/NetRemote.pb.h
+    ${PROTO_DIR_BINARY}/NetRemoteDataStream.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteDataStreamingService.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteService.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteWifi.pb.h
@@ -34,6 +35,7 @@ set(PROTO_HEADERS_GENERATED
 
 set(PROTO_HEADERS_GENERATED_GRPC
     ${PROTO_DIR_BINARY}/NetRemote.grpc.pb.h
+    ${PROTO_DIR_BINARY}/NetRemoteDataStream.grpc.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteDataStreamingService.grpc.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteService.grpc.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteWifi.grpc.pb.h


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

In order to use the data streaming types from `NetRemoteDataStream.proto` in another repo, CMake needs to build the `.grpc.pb.h` and `.pb.h` header files.

### Technical Details

Update `protocol/CMakeLists.txt`.

### Test Results

None.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
