### PR TITLE
Move client and streamwriter creation into thread function

### DIFF
--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -57,14 +57,12 @@ TEST_CASE("DataStreamUpload API", "[basic][rpc][client][remote][stream]")
     {
         static constexpr auto numberOfClients = 5;
 
-        std::vector<std::unique_ptr<NetRemoteDataStreaming::Stub>> dataStreamingClients;
         std::vector<std::jthread> clientThreads;
-
         for (std::size_t i = 0; i < numberOfClients; i++) {
-            dataStreamingClients.push_back(NetRemoteDataStreaming::NewStub(channel));
-            auto dataStreamWriter = std::make_unique<DataStreamWriter>(dataStreamingClients.back().get(), numberOfDataBlocksToWrite);
+            clientThreads.emplace_back([&]() {
+                auto dataStreamingClient = NetRemoteDataStreaming::NewStub(channel);
+                auto dataStreamWriter = std::make_unique<DataStreamWriter>(dataStreamingClient.get(), numberOfDataBlocksToWrite);
 
-            clientThreads.emplace_back([dataStreamWriter = std::move(dataStreamWriter)]() {
                 DataStreamUploadResult result{};
                 const grpc::Status status = dataStreamWriter->Await(&result);
                 REQUIRE(status.ok());


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

Improve resource usage in upload API unit test.

### Technical Details

* Moved client stub and `DataStreamWriter` creation into the thread function.

### Test Results

All tests pass.

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
