### PR TITLE
Update IHostapd interface to replace bool returns with exceptions and direct return values

### DIFF
--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -108,7 +108,7 @@ AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState oper
             status.Code = AccessPointOperationStatusCode::Succeeded;
         } catch (const Wpa::HostapdException& ex) {
             status.Code = AccessPointOperationStatusCode::InternalError;
-            status.Details = "failed to set operational state to 'enabled'";
+            status.Details = std::format("failed to set operational state to 'enabled' ({})", ex.what());
         }
         break;
     }
@@ -118,7 +118,7 @@ AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState oper
             status.Code = AccessPointOperationStatusCode::Succeeded;
         } catch (const Wpa::HostapdException& ex) {
             status.Code = AccessPointOperationStatusCode::InternalError;
-            status.Details = "failed to set operational state to 'disabled'";
+            status.Details = std::format("failed to set operational state to 'disabled' ({})", ex.what());
         }
         break;
     }

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -175,10 +175,7 @@ AccessPointControllerLinux::SetProtocol(Ieee80211Protocol ieeeProtocol) noexcept
     try {
         for (auto& propertyToSet : propertiesToSet) {
             std::tie(propertyKeyToSet, propertyValueToSet) = std::move(propertyToSet);
-            hostapdOperationSucceeded = m_hostapd.SetProperty(propertyKeyToSet, propertyValueToSet, EnforceConfigurationChange::Defer);
-            if (!hostapdOperationSucceeded) {
-                break;
-            }
+            m_hostapd.SetProperty(propertyKeyToSet, propertyValueToSet, EnforceConfigurationChange::Defer);
         }
     } catch (const Wpa::HostapdException& ex) {
         hostapdOperationSucceeded = false;
@@ -235,7 +232,7 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
 
     // Set the hostapd "setband" property.
     try {
-        hostapdOperationSucceeded = m_hostapd.SetProperty(propertyKeyToSet, propertyValueToSet, EnforceConfigurationChange::Now);
+        m_hostapd.SetProperty(propertyKeyToSet, propertyValueToSet, EnforceConfigurationChange::Now);
     } catch (const Wpa::HostapdException& ex) {
         hostapdOperationSucceeded = false;
         errorDetails = ex.what();
@@ -270,7 +267,7 @@ AccessPointControllerLinux::SetSsid(std::string_view ssid) noexcept
 
     // Attempt to set the SSID.
     try {
-        hostapdOperationSucceeded = m_hostapd.SetProperty(Wpa::ProtocolHostapd::PropertyNameSsid, ssid, EnforceConfigurationChange::Now);
+        m_hostapd.SetProperty(Wpa::ProtocolHostapd::PropertyNameSsid, ssid, EnforceConfigurationChange::Now);
     } catch (Wpa::HostapdException& ex) {
         hostapdOperationSucceeded = false;
         errorDetails = ex.what();

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -192,10 +192,11 @@ AccessPointControllerLinux::SetProtocol(Ieee80211Protocol ieeeProtocol) noexcept
     }
 
     // Reload the hostapd configuration to pick up the changes.
-    hostapdOperationSucceeded = m_hostapd.Reload();
-    if (!hostapdOperationSucceeded) {
+    try {
+        m_hostapd.Reload();
+    } catch (const Wpa::HostapdException& ex) {
         status.Code = AccessPointOperationStatusCode::InternalError;
-        status.Details = "failed to reload hostapd configuration";
+        status.Details = std::format("failed to reload hostapd configuration - {}", ex.what());
         return status;
     }
 

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -168,7 +168,7 @@ Hostapd::Disable()
     }
 }
 
-bool
+void
 Hostapd::Terminate()
 {
     static constexpr WpaCommand TerminateCommand(ProtocolHostapd::CommandPayloadTerminate);
@@ -178,7 +178,10 @@ Hostapd::Terminate()
         throw HostapdException("Failed to send hostapd 'terminate' command");
     }
 
-    return response->IsOk();
+    if (!response->IsOk()) {
+        LOGV << std::format("Invalid response received when terminating hostapd\nResponse payload={}", response->Payload());
+        throw HostapdException("Failed to terminate hostapd process (invalid response)");
+    }
 }
 
 bool

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -33,7 +33,7 @@ Hostapd::GetInterface()
     return m_interface;
 }
 
-bool
+void
 Hostapd::Ping()
 {
     static constexpr WpaCommand PingCommand(ProtocolHostapd::CommandPayloadPing);
@@ -43,7 +43,10 @@ Hostapd::Ping()
         throw HostapdException("Failed to ping hostapd");
     }
 
-    return response->Payload().starts_with(ProtocolHostapd::ResponsePayloadPing);
+    if (!response->Payload().starts_with(ProtocolHostapd::ResponsePayloadPing)) {
+        LOGV << std::format("Invalid response received when sending hostapd ping\nResponse payload={}", response->Payload());
+        throw HostapdException("Invalid response received when pinging hostapd");
+    }
 }
 
 bool

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -226,7 +226,7 @@ Hostapd::SetWpaProtocols(std::vector<WpaProtocol> protocols, EnforceConfiguratio
     }
 }
 
-bool
+void
 Hostapd::SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceConfigurationChange enforceConfigurationChange)
 {
     if (std::empty(keyManagements)) {
@@ -252,6 +252,4 @@ Hostapd::SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceC
     if (!keyManagementWasSet) {
         throw HostapdException(std::format("Failed to set hostapd 'wpa_key_mgmt' property to '{}'", keyManagementPropertyValue));
     }
-
-    return true;
 }

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -192,11 +192,13 @@ Hostapd::Terminate()
     }
 }
 
-bool
+void
 Hostapd::SetSsid(std::string_view ssid, EnforceConfigurationChange enforceConfigurationChange)
 {
     const bool ssidWasSet = SetProperty(ProtocolHostapd::PropertyNameSsid, ssid, enforceConfigurationChange);
-    return ssidWasSet;
+    if (!ssidWasSet) {
+        throw HostapdException(std::format("Failed to set hostapd 'ssid' property to '{}'", ssid));
+    }
 }
 
 bool

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -201,7 +201,7 @@ Hostapd::SetSsid(std::string_view ssid, EnforceConfigurationChange enforceConfig
     }
 }
 
-bool
+void
 Hostapd::SetWpaProtocols(std::vector<WpaProtocol> protocols, EnforceConfigurationChange enforceConfigurationChange)
 {
     if (std::empty(protocols)) {
@@ -224,8 +224,6 @@ Hostapd::SetWpaProtocols(std::vector<WpaProtocol> protocols, EnforceConfiguratio
     if (!protocolsWereSet) {
         throw HostapdException(std::format("Failed to set hostapd 'wpa' property to '{}'", protocolsValue));
     }
-
-    return true;
 }
 
 bool

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -27,11 +27,8 @@ struct Hostapd :
 
     /**
      * @brief Enables the interface for use.
-     *
-     * @return true
-     * @return false
      */
-    bool
+    void
     Enable() override;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -97,10 +97,8 @@ struct Hostapd :
      *
      * @param ssid The ssid to set.
      * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
-     * @return true If the ssid was set successfully.
-     * @return false If the ssid was not set successfully.
      */
-    bool
+    void
     SetSsid(std::string_view ssid, EnforceConfigurationChange enforceConfigurationChange = EnforceConfigurationChange::Now) override;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -39,11 +39,8 @@ struct Hostapd :
 
     /**
      * @brief Terminates the process hosting the daemon.
-     *
-     * @return true
-     * @return false
      */
-    bool
+    void
     Terminate() override;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -115,10 +115,8 @@ struct Hostapd :
      *
      * @param keyManagements The key management value(s) to set.
      * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
-     * @return true The key management value(s) were set successfully.
-     * @return false The key management value(s) were not set successfully.
      */
-    bool
+    void
     SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceConfigurationChange enforceConfigurationChange = EnforceConfigurationChange::Now) override;
 
 private:

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -33,11 +33,8 @@ struct Hostapd :
 
     /**
      * @brief Disables the interface for use.
-     *
-     * @return true
-     * @return false
      */
-    bool
+    void
     Disable() override;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -106,10 +106,8 @@ struct Hostapd :
      *
      * @param protocols The protocols to set.
      * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
-     * @return true If the protocols were set successfully.
-     * @return false If the protocols were not set successfully.
      */
-    bool
+    void
     SetWpaProtocols(std::vector<WpaProtocol> protocols, EnforceConfigurationChange enforceConfigurationChange = EnforceConfigurationChange::Now) override;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -75,12 +75,10 @@ struct Hostapd :
      * @brief Get a property value for the interface.
      *
      * @param propertyName The name of the property to retrieve.
-     * @param propertyValue The string to store the property value in.
-     * @return true If the property value was obtained and its value is in 'propertyValue'.
-     * @return false If t he property value could not be obtained due to an error.
+     * @return std::string The property string value.
      */
-    bool
-    GetProperty(std::string_view propertyName, std::string& propertyValue) override;
+    std::string
+    GetProperty(std::string_view propertyName) override;
 
     /**
      * @brief Set a property on the interface.

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -86,10 +86,8 @@ struct Hostapd :
      * @param propertyName The name of the property to set.
      * @param propertyValue The value of the property to set.
      * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
-     * @return true The property was set successfully.
-     * @return false The property was not set successfully.
      */
-    bool
+    void
     SetProperty(std::string_view propertyName, std::string_view propertyValue, EnforceConfigurationChange enforceConfigurationChange = EnforceConfigurationChange::Now) override;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -46,7 +46,7 @@ struct Hostapd :
     /**
      * @brief Checks connectivity to the hostapd daemon.
      */
-    bool
+    void
     Ping() override;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -51,11 +51,8 @@ struct Hostapd :
 
     /**
      * @brief Reloads the interface. This will cause any settings that have been changed to take effect.
-     *
-     * @return true If the configuration was reloaded successfully.
-     * @return false If the configuration was not reloaded successfully.
      */
-    bool
+    void
     Reload() override;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -63,11 +63,8 @@ struct IHostapd
 
     /**
      * @brief Terminates the process hosting the daemon.
-     *
-     * @return true
-     * @return false
      */
-    virtual bool
+    virtual void
     Terminate() = 0;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -51,11 +51,8 @@ struct IHostapd
 
     /**
      * @brief Enables the interface for use.
-     *
-     * @return true
-     * @return false
      */
-    virtual bool
+    virtual void
     Enable() = 0;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -110,10 +110,8 @@ struct IHostapd
      * @param propertyName The name of the property to set.
      * @param propertyValue The value of the property to set.
      * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
-     * @return true The property was set successfully.
-     * @return false The property was not set successfully.
      */
-    virtual bool
+    virtual void
     SetProperty(std::string_view propertyName, std::string_view propertyValue, EnforceConfigurationChange enforceConfigurationChange) = 0;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -99,12 +99,10 @@ struct IHostapd
      * @brief Get a property value for the interface.
      *
      * @param propertyName The name of the property to retrieve.
-     * @param propertyValue The string to store the property value in.
-     * @return true If the property value was obtained and its value is in 'propertyValue'.
-     * @return false If t he property value could not be obtained due to an error.
+     * @return std::string The property string value.
      */
-    virtual bool
-    GetProperty(std::string_view propertyName, std::string& propertyValue) = 0;
+    virtual std::string
+    GetProperty(std::string_view propertyName) = 0;
 
     /**
      * @brief Set a property on the interface.

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -139,10 +139,8 @@ struct IHostapd
      *
      * @param keyManagements The key management value(s) to set.
      * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
-     * @return true The key management value(s) were set successfully.
-     * @return false The key management value(s) were not set successfully.
      */
-    virtual bool
+    virtual void
     SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceConfigurationChange enforceConfigurationChange) = 0;
 };
 

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -70,7 +70,7 @@ struct IHostapd
     /**
      * @brief Checks connectivity to the hostapd daemon.
      */
-    virtual bool
+    virtual void
     Ping() = 0;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -130,10 +130,8 @@ struct IHostapd
      *
      * @param protocols The protocols to set.
      * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
-     * @return true If the protocols were set successfully.
-     * @return false If the protocols were not set successfully.
      */
-    virtual bool
+    virtual void
     SetWpaProtocols(std::vector<WpaProtocol> protocols, EnforceConfigurationChange enforceConfigurationChange) = 0;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -57,11 +57,8 @@ struct IHostapd
 
     /**
      * @brief Disables the interface for use.
-     *
-     * @return true
-     * @return false
      */
-    virtual bool
+    virtual void
     Disable() = 0;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -120,10 +120,9 @@ struct IHostapd
      * @brief Set the ssid for the interface.
      *
      * @param ssid The ssid to set.
-     * @return true If the ssid was set successfully.
-     * @return false If the ssid was not set successfully.
+     * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
-    virtual bool
+    virtual void
     SetSsid(std::string_view ssid, EnforceConfigurationChange enforceConfigurationChange) = 0;
 
     /**

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -75,11 +75,8 @@ struct IHostapd
 
     /**
      * @brief Reloads the interface. This will cause any settings that have been changed to take effect.
-     *
-     * @return true If the configuration was reloaded successfully.
-     * @return false If the configuration was not reloaded successfully.
      */
-    virtual bool
+    virtual void
     Reload() = 0;
 
     /**

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -327,7 +327,7 @@ TEST_CASE("Send command: Terminate() ping failure (root)", "[wpa][hostapd][clien
 
     Hostapd hostapd(WpaDaemonManager::InterfaceNameDefault);
     REQUIRE(hostapd.Ping());
-    REQUIRE(hostapd.Terminate());
+    REQUIRE_NOTHROW(hostapd.Terminate());
 
     // The terminate command merely requests hostapd to shut down. The daemon's
     // polling loop must enter its next cycle before the termination process is

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -169,35 +169,27 @@ TEST_CASE("Send GetProperty() command (root)", "[wpa][hostapd][client][remote]")
 
     Hostapd hostapd(WpaDaemonManager::InterfaceNameDefault);
 
-    SECTION("GetProperty() doesn't throw")
+    SECTION("doesn't throw for valid property")
     {
-        std::string whateverValue;
-        REQUIRE_NOTHROW(hostapd.GetProperty("whatever", whateverValue));
+        REQUIRE_NOTHROW(hostapd.GetProperty(ProtocolHostapd::PropertyNameVersion));
     }
 
-    SECTION("GetProperty() returns false for invalid property")
-    {
-        std::string whateverValue;
-        REQUIRE_FALSE(hostapd.GetProperty("whatever", whateverValue));
-    }
-
-    SECTION("GetProperty() returns true for valid property")
+    SECTION("doesn't throw for valid property with non-empty value")
     {
         std::string versionValue;
-        REQUIRE(hostapd.GetProperty(ProtocolHostapd::PropertyNameVersion, versionValue));
-    }
-
-    SECTION("GetProperty() returns true for valid property with non-empty value")
-    {
-        std::string versionValue;
-        REQUIRE(hostapd.GetProperty(ProtocolHostapd::PropertyNameVersion, versionValue));
+        REQUIRE_NOTHROW(versionValue = hostapd.GetProperty(ProtocolHostapd::PropertyNameVersion));
         REQUIRE_FALSE(versionValue.empty());
     }
 
-    SECTION("GetProperty() returns correct value for valid property")
+    SECTION("throws for invalid property")
+    {
+        REQUIRE_THROWS_AS(hostapd.GetProperty("whatever"), HostapdException);
+    }
+
+    SECTION("returns correct value for valid property")
     {
         std::string versionValue;
-        CHECK(hostapd.GetProperty(ProtocolHostapd::PropertyNameVersion, versionValue));
+        CHECK_NOTHROW(versionValue = hostapd.GetProperty(ProtocolHostapd::PropertyNameVersion));
         REQUIRE(versionValue == ProtocolHostapd::PropertyVersionValue);
     }
 }

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -79,7 +79,7 @@ TEST_CASE("Send command: GetStatus() (root)", "[wpa][hostapd][client][remote]")
     using namespace Wpa;
 
     Hostapd hostapd(WpaDaemonManager::InterfaceNameDefault);
-    REQUIRE(hostapd.Enable());
+    REQUIRE_NOTHROW(hostapd.Enable());
 
     SECTION("GetStatus() doesn't throw")
     {
@@ -97,7 +97,7 @@ TEST_CASE("Send command: GetStatus() (root)", "[wpa][hostapd][client][remote]")
         REQUIRE(hostapd.Disable());
         const auto statusInitial = hostapd.GetStatus();
         REQUIRE(statusInitial.State == HostapdInterfaceState::Disabled);
-        REQUIRE(hostapd.Enable());
+        REQUIRE_NOTHROW(hostapd.Enable());
         const auto statusDisabled = hostapd.GetStatus();
         REQUIRE(statusDisabled.State == HostapdInterfaceState::Enabled);
     }
@@ -274,7 +274,7 @@ TEST_CASE("Send control commands: Enable(), Disable() (root)", "[wpa][hostapd][c
         CHECK(hostapd.Disable());
         auto hostapdStatus = hostapd.GetStatus();
         REQUIRE(hostapdStatus.State != HostapdInterfaceState::Enabled);
-        REQUIRE(hostapd.Enable());
+        REQUIRE_NOTHROW(hostapd.Enable());
         hostapdStatus = hostapd.GetStatus();
         REQUIRE(hostapdStatus.State == HostapdInterfaceState::Enabled);
     }
@@ -282,7 +282,7 @@ TEST_CASE("Send control commands: Enable(), Disable() (root)", "[wpa][hostapd][c
     SECTION("Enable() preserves further communication")
     {
         CHECK(hostapd.Disable());
-        CHECK(hostapd.Enable());
+        CHECK_NOTHROW(hostapd.Enable());
         REQUIRE(hostapd.Ping());
     }
 

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -338,14 +338,9 @@ TEST_CASE("Send SetSsid() command (root)", "[wpa][hostapd][client][remote]")
 
     Hostapd hostapd(WpaDaemonManager::InterfaceNameDefault);
 
-    SECTION("SetSsid() doesn't throw")
+    SECTION("doesn't throw for valid SSID")
     {
         REQUIRE_NOTHROW(hostapd.SetSsid(SsidValid));
-    }
-
-    SECTION("SetSsid() returns true for valid SSID")
-    {
-        REQUIRE(hostapd.SetSsid(SsidValid));
     }
 
     SECTION("SetSsid() throws for empty SSID")
@@ -361,7 +356,7 @@ TEST_CASE("Send SetSsid() command (root)", "[wpa][hostapd][client][remote]")
     SECTION("SetSsid() changes the SSID for valid input")
     {
         constexpr auto SsidToSet{ SsidValid };
-        REQUIRE(hostapd.SetSsid(SsidToSet));
+        REQUIRE_NOTHROW(hostapd.SetSsid(SsidToSet));
         const auto status = hostapd.GetStatus();
         REQUIRE(!std::empty(status.Bss));
         REQUIRE(status.Bss[0].Ssid == SsidToSet);

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -118,12 +118,12 @@ TEST_CASE("Send command: GetStatus() (root)", "[wpa][hostapd][client][remote]")
         const auto ieee80211nInitial = hostapd.GetStatus().Ieee80211n;
 
         auto ieee80211nValueExpected = static_cast<bool>(ieee80211nInitial);
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211N, GetPropertyEnablementValue(ieee80211nValueExpected)));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211N, GetPropertyEnablementValue(ieee80211nValueExpected)));
         auto ieee80211nValueUpdated = hostapd.GetStatus().Ieee80211n;
         REQUIRE(ieee80211nValueUpdated == ieee80211nValueExpected);
 
         ieee80211nValueExpected = static_cast<bool>(ieee80211nValueUpdated);
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211N, GetPropertyEnablementValue(ieee80211nValueExpected)));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211N, GetPropertyEnablementValue(ieee80211nValueExpected)));
         ieee80211nValueUpdated = hostapd.GetStatus().Ieee80211n;
         REQUIRE(ieee80211nValueUpdated == ieee80211nValueExpected);
     }
@@ -135,12 +135,12 @@ TEST_CASE("Send command: GetStatus() (root)", "[wpa][hostapd][client][remote]")
         const auto ieee80211acInitial = hostapd.GetStatus().Ieee80211ac;
 
         auto ieee80211acValueExpected = static_cast<bool>(ieee80211acInitial);
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AC, GetPropertyEnablementValue(ieee80211acValueExpected)));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AC, GetPropertyEnablementValue(ieee80211acValueExpected)));
         auto ieee80211acValueUpdated = hostapd.GetStatus().Ieee80211ac;
         REQUIRE(ieee80211acValueUpdated == ieee80211acValueExpected);
 
         ieee80211acValueExpected = static_cast<bool>(ieee80211acValueUpdated);
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AC, GetPropertyEnablementValue(ieee80211acValueExpected)));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AC, GetPropertyEnablementValue(ieee80211acValueExpected)));
         ieee80211acValueUpdated = hostapd.GetStatus().Ieee80211ac;
         REQUIRE(ieee80211acValueUpdated == ieee80211acValueExpected);
     }
@@ -152,12 +152,12 @@ TEST_CASE("Send command: GetStatus() (root)", "[wpa][hostapd][client][remote]")
         const auto ieee80211axInitial = hostapd.GetStatus().Ieee80211ax;
 
         auto ieee80211axValueExpected = static_cast<bool>(ieee80211axInitial);
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AX, GetPropertyEnablementValue(ieee80211axValueExpected)));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AX, GetPropertyEnablementValue(ieee80211axValueExpected)));
         auto ieee80211axValueUpdated = hostapd.GetStatus().Ieee80211ax;
         REQUIRE(ieee80211axValueUpdated == ieee80211axValueExpected);
 
         ieee80211axValueExpected = static_cast<bool>(ieee80211axValueUpdated);
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AX, GetPropertyEnablementValue(ieee80211axValueExpected)));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameIeee80211AX, GetPropertyEnablementValue(ieee80211axValueExpected)));
         ieee80211axValueUpdated = hostapd.GetStatus().Ieee80211ax;
         REQUIRE(ieee80211axValueUpdated == ieee80211axValueExpected);
     }
@@ -217,34 +217,34 @@ TEST_CASE("Send SetProperty() command (root)", "[wpa][hostapd][client][remote]")
 
     SECTION("SetProperty() returns true for valid property")
     {
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Now));
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Defer));
     }
 
     SECTION("SetProperty() allows setting a property to the same value")
     {
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Now));
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Now));
 
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Defer));
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Defer));
     }
 
     SECTION("SetProperty allows setting a property to a different value")
     {
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Now));
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValue2G, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValue2G, EnforceConfigurationChange::Now));
 
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValue5G, EnforceConfigurationChange::Defer));
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValue6G, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValue5G, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValue6G, EnforceConfigurationChange::Defer));
     }
 
     SECTION("SetProperty allows interleaving enforcement of configuration changes")
     {
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Now));
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValue2G, EnforceConfigurationChange::Defer));
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValue5G, EnforceConfigurationChange::Now));
-        REQUIRE(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValue6G, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValueAuto, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValue2G, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValue5G, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetProperty(ProtocolHostapd::PropertyNameSetBand, ProtocolHostapd::PropertySetBandValue6G, EnforceConfigurationChange::Defer));
     }
 
     // TODO: validate that the property was actually set. Need to find a property whose value is retrievable.

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -64,13 +64,13 @@ TEST_CASE("Send Ping() command (root)", "[wpa][hostapd][client][remote]")
 
     SECTION("Send Ping() command")
     {
-        REQUIRE(hostapd.Ping());
+        REQUIRE_NOTHROW(hostapd.Ping());
     }
 
     SECTION("Send Ping() command on second instance")
     {
         Hostapd hostapd2(WpaDaemonManager::InterfaceNameDefault);
-        REQUIRE(hostapd2.Ping());
+        REQUIRE_NOTHROW(hostapd2.Ping());
     }
 }
 
@@ -283,7 +283,7 @@ TEST_CASE("Send control commands: Enable(), Disable() (root)", "[wpa][hostapd][c
     {
         CHECK_NOTHROW(hostapd.Disable());
         CHECK_NOTHROW(hostapd.Enable());
-        REQUIRE(hostapd.Ping());
+        REQUIRE_NOTHROW(hostapd.Ping());
     }
 
     SECTION("Disable() doesn't throw")
@@ -301,7 +301,7 @@ TEST_CASE("Send control commands: Enable(), Disable() (root)", "[wpa][hostapd][c
     SECTION("Disable() doesn't prevent further communication")
     {
         CHECK_NOTHROW(hostapd.Disable());
-        REQUIRE(hostapd.Ping());
+        REQUIRE_NOTHROW(hostapd.Ping());
     }
 }
 
@@ -326,7 +326,7 @@ TEST_CASE("Send command: Terminate() ping failure (root)", "[wpa][hostapd][clien
     static constexpr auto TerminationWaitTime{ 2s }; // NOLINT
 
     Hostapd hostapd(WpaDaemonManager::InterfaceNameDefault);
-    REQUIRE(hostapd.Ping());
+    REQUIRE_NOTHROW(hostapd.Ping());
     REQUIRE_NOTHROW(hostapd.Terminate());
 
     // The terminate command merely requests hostapd to shut down. The daemon's

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -499,8 +499,8 @@ TEST_CASE("Send SetKeyManagement() command (root)", "[wpa][hostapd][client][remo
     SECTION("Succeeds with all valid, single inputs")
     {
         for (const auto keyManagementValidValue : KeyManagementValidValues) {
-            REQUIRE(hostapd.SetKeyManagement({ keyManagementValidValue }, EnforceConfigurationChange::Now));
-            REQUIRE(hostapd.SetKeyManagement({ keyManagementValidValue }, EnforceConfigurationChange::Defer));
+            REQUIRE_NOTHROW(hostapd.SetKeyManagement({ keyManagementValidValue }, EnforceConfigurationChange::Now));
+            REQUIRE_NOTHROW(hostapd.SetKeyManagement({ keyManagementValidValue }, EnforceConfigurationChange::Defer));
         }
     }
 
@@ -509,16 +509,16 @@ TEST_CASE("Send SetKeyManagement() command (root)", "[wpa][hostapd][client][remo
         std::vector<WpaKeyManagement> keyManagementValidValues{};
         for (const auto keyManagementValidValue : KeyManagementValidValues) {
             keyManagementValidValues.push_back(keyManagementValidValue);
-            REQUIRE(hostapd.SetKeyManagement(keyManagementValidValues, EnforceConfigurationChange::Now));
-            REQUIRE(hostapd.SetKeyManagement(keyManagementValidValues, EnforceConfigurationChange::Defer));
+            REQUIRE_NOTHROW(hostapd.SetKeyManagement(keyManagementValidValues, EnforceConfigurationChange::Now));
+            REQUIRE_NOTHROW(hostapd.SetKeyManagement(keyManagementValidValues, EnforceConfigurationChange::Defer));
         }
     }
 
     SECTION("Succeeds with valid, duplicate inputs")
     {
         for (const auto keyManagementValidValue : KeyManagementValidValues) {
-            REQUIRE(hostapd.SetKeyManagement({ keyManagementValidValue, keyManagementValidValue }, EnforceConfigurationChange::Now));
-            REQUIRE(hostapd.SetKeyManagement({ keyManagementValidValue, keyManagementValidValue }, EnforceConfigurationChange::Defer));
+            REQUIRE_NOTHROW(hostapd.SetKeyManagement({ keyManagementValidValue, keyManagementValidValue }, EnforceConfigurationChange::Now));
+            REQUIRE_NOTHROW(hostapd.SetKeyManagement({ keyManagementValidValue, keyManagementValidValue }, EnforceConfigurationChange::Defer));
         }
     }
 }

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -94,7 +94,7 @@ TEST_CASE("Send command: GetStatus() (root)", "[wpa][hostapd][client][remote]")
 
     SECTION("GetStatus() reflects changes in interface state (disabled -> not disabled)")
     {
-        REQUIRE(hostapd.Disable());
+        REQUIRE_NOTHROW(hostapd.Disable());
         const auto statusInitial = hostapd.GetStatus();
         REQUIRE(statusInitial.State == HostapdInterfaceState::Disabled);
         REQUIRE_NOTHROW(hostapd.Enable());
@@ -106,7 +106,7 @@ TEST_CASE("Send command: GetStatus() (root)", "[wpa][hostapd][client][remote]")
     {
         const auto statusInitial = hostapd.GetStatus();
         REQUIRE(IsHostapdStateOperational(statusInitial.State));
-        REQUIRE(hostapd.Disable());
+        REQUIRE_NOTHROW(hostapd.Disable());
         const auto statusDisabled = hostapd.GetStatus();
         REQUIRE(!IsHostapdStateOperational(statusDisabled.State));
     }
@@ -271,7 +271,7 @@ TEST_CASE("Send control commands: Enable(), Disable() (root)", "[wpa][hostapd][c
 
     SECTION("Enable() enables the interface")
     {
-        CHECK(hostapd.Disable());
+        CHECK_NOTHROW(hostapd.Disable());
         auto hostapdStatus = hostapd.GetStatus();
         REQUIRE(hostapdStatus.State != HostapdInterfaceState::Enabled);
         REQUIRE_NOTHROW(hostapd.Enable());
@@ -281,7 +281,7 @@ TEST_CASE("Send control commands: Enable(), Disable() (root)", "[wpa][hostapd][c
 
     SECTION("Enable() preserves further communication")
     {
-        CHECK(hostapd.Disable());
+        CHECK_NOTHROW(hostapd.Disable());
         CHECK_NOTHROW(hostapd.Enable());
         REQUIRE(hostapd.Ping());
     }
@@ -293,14 +293,14 @@ TEST_CASE("Send control commands: Enable(), Disable() (root)", "[wpa][hostapd][c
 
     SECTION("Disable() disables the interface")
     {
-        CHECK(hostapd.Disable());
+        CHECK_NOTHROW(hostapd.Disable());
         const auto hostapdStatus = hostapd.GetStatus();
         REQUIRE(hostapdStatus.State == HostapdInterfaceState::Disabled);
     }
 
     SECTION("Disable() doesn't prevent further communication")
     {
-        CHECK(hostapd.Disable());
+        CHECK_NOTHROW(hostapd.Disable());
         REQUIRE(hostapd.Ping());
     }
 }

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -413,23 +413,23 @@ TEST_CASE("Send SetWpaProtocols() command (root)", "[wpa][hostapd][client][remot
 
     SECTION("Succeeds with valid, single input")
     {
-        REQUIRE(hostapd.SetWpaProtocols({ WpaProtocol::Wpa }, EnforceConfigurationChange::Now));
-        REQUIRE(hostapd.SetWpaProtocols({ WpaProtocol::Wpa }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa }, EnforceConfigurationChange::Defer));
     }
 
     SECTION("Succeeds with valid, multiple inputs")
     {
-        REQUIRE(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Now));
-        REQUIRE(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Defer));
     }
 
     SECTION("Succeeds with valid, duplicate inputs")
     {
-        REQUIRE(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa }, EnforceConfigurationChange::Now));
-        REQUIRE(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa }, EnforceConfigurationChange::Defer));
 
-        REQUIRE(hostapd.SetWpaProtocols({ WpaProtocol::Wpa2, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Now));
-        REQUIRE(hostapd.SetWpaProtocols({ WpaProtocol::Wpa2, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa2, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa2, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Defer));
     }
 }
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Enable `IHostapd` consumers to apply consistent calling and error checking.

### Technical Details

* Change the following functions to throw exceptions instead of returning `bool`:
    - `Enable`, `Disable`, `Terminate`, `Ping`, `Reload`, `SetProperty`, `SetSsid`, `SetWpaProtocols`, `SetKeyManagement`.
* Change `GetProperty` return type from `bool` to `std::string`, which captures the property value.
    - Replace `bool` returns with `HostapdException`.
 
### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
