### PR TITLE
Enable cipher configuration via hostapd

### DIFF
--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -85,7 +85,7 @@ struct Hostapd :
      *
      * @param propertyName The name of the property to set.
      * @param propertyValue The value of the property to set.
-     * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     void
     SetProperty(std::string_view propertyName, std::string_view propertyValue, EnforceConfigurationChange enforceConfigurationChange = EnforceConfigurationChange::Now) override;
@@ -94,7 +94,7 @@ struct Hostapd :
      * @brief Set the ssid for the interface.
      *
      * @param ssid The ssid to set.
-     * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     void
     SetSsid(std::string_view ssid, EnforceConfigurationChange enforceConfigurationChange = EnforceConfigurationChange::Now) override;
@@ -103,16 +103,16 @@ struct Hostapd :
      * @brief Set the WPA protocol(s) for the interface.
      *
      * @param protocols The protocols to set.
-     * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     void
     SetWpaProtocols(std::vector<WpaProtocol> protocols, EnforceConfigurationChange enforceConfigurationChange = EnforceConfigurationChange::Now) override;
 
     /**
-     * @brief Set the Key Management object
+     * @brief Set the allowed key management algorithms for the interfacallowed key management algorithms for the interface.
      *
      * @param keyManagements The key management value(s) to set.
-     * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     void
     SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceConfigurationChange enforceConfigurationChange = EnforceConfigurationChange::Now) override;

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -117,6 +117,25 @@ struct Hostapd :
     void
     SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceConfigurationChange enforceConfigurationChange = EnforceConfigurationChange::Now) override;
 
+    /**
+     * @brief Set the allowed cipher suites for the interface.
+     *
+     * @param protocol The WPA protocol to set the cipher suites for.
+     * @param ciphers The ciphers to allow.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     */
+    void
+    SetCipherSuites(WpaProtocol protocol, std::vector<WpaCipher> ciphers, EnforceConfigurationChange enforceConfigurationChange) override;
+
+    /**
+     * @brief Set the allowed cipher suites for the interface.
+     *
+     * @param protocolCipherMap map specifying the ciphers to allow for each protocol.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     */
+    void
+    SetCipherSuites(std::unordered_map<WpaProtocol, std::vector<WpaCipher>> protocolCipherMap, EnforceConfigurationChange enforceConfigurationChange) override;
+
 private:
     const std::string m_interface;
     WpaController m_controller;

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -5,6 +5,7 @@
 #include <exception>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include <Wpa/ProtocolHostapd.hxx>
@@ -140,6 +141,25 @@ struct IHostapd
      */
     virtual void
     SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceConfigurationChange enforceConfigurationChange) = 0;
+
+    /**
+     * @brief Set the allowed cipher suites for the interface.
+     *
+     * @param protocol The WPA protocol to set the cipher suites for.
+     * @param ciphers The ciphers to allow.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     */
+    virtual void
+    SetCipherSuites(WpaProtocol protocol, std::vector<WpaCipher> ciphers, EnforceConfigurationChange enforceConfigurationChange) = 0;
+
+    /**
+     * @brief Set the allowed cipher suites for the interface.
+     *
+     * @param protocolCipherMap map specifying the ciphers to allow for each protocol.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     */
+    virtual void
+    SetCipherSuites(std::unordered_map<WpaProtocol, std::vector<WpaCipher>> protocolCipherMap, EnforceConfigurationChange enforceConfigurationChange) = 0;
 };
 
 /**

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -109,7 +109,7 @@ struct IHostapd
      *
      * @param propertyName The name of the property to set.
      * @param propertyValue The value of the property to set.
-     * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     virtual void
     SetProperty(std::string_view propertyName, std::string_view propertyValue, EnforceConfigurationChange enforceConfigurationChange) = 0;
@@ -118,7 +118,7 @@ struct IHostapd
      * @brief Set the ssid for the interface.
      *
      * @param ssid The ssid to set.
-     * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     virtual void
     SetSsid(std::string_view ssid, EnforceConfigurationChange enforceConfigurationChange) = 0;
@@ -127,16 +127,16 @@ struct IHostapd
      * @brief Set the WPA protocol(s) for the interface.
      *
      * @param protocols The protocols to set.
-     * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     virtual void
     SetWpaProtocols(std::vector<WpaProtocol> protocols, EnforceConfigurationChange enforceConfigurationChange) = 0;
 
     /**
-     * @brief Set the Key Management object
+     * @brief Set the allowed key management algorithms for the interfacallowed key management algorithms for the interface.
      *
      * @param keyManagements The key management value(s) to set.
-     * @param enforceConfigurationChange When the enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     virtual void
     SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceConfigurationChange enforceConfigurationChange) = 0;

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -447,6 +447,55 @@ WpaKeyManagementPropertyValue(WpaKeyManagement wpaKeyManagement) noexcept
         return WpaKeyManagementInvalidValue;
     }
 }
+
+/**
+ * @brief WpaCipher sentinel for an invalid value.
+ */
+constexpr std::string_view WpaCipherInvalidValue = "UNKNOWN";
+
+/**
+ * @brief Convert a WpaCipher value to the corresponding property value string expected by hostapd. The returned value
+ * may be used for hostapd properties 'wpa_pairwise' and 'rsn_pairwise'.
+ *
+ * @param wpaCipher The WpaCipher value to convert.
+ * @return constexpr std::string_view The corresponding hostapd property value string.
+ */
+constexpr std::string_view
+WpaCipherPropertyValue(WpaCipher wpaCipher) noexcept
+{
+    switch (wpaCipher) {
+    case WpaCipher::None:
+        return "NONE";
+    case WpaCipher::Wep40:
+        return "WEP40";
+    case WpaCipher::Wep104:
+        return "WEP104";
+    case WpaCipher::Tkip:
+        return "TKIP";
+    case WpaCipher::Ccmp:
+        return "CCMP";
+    case WpaCipher::Aes128Cmac:
+        return "AES-128-CMAC";
+    case WpaCipher::Gcmp:
+        return "GCMP";
+    case WpaCipher::Gcmp256:
+        return "GCMP-256";
+    case WpaCipher::Ccmp256:
+        return "CCMP-256";
+    case WpaCipher::BipGmac128:
+        return "BIP-GMAC-128";
+    case WpaCipher::BipGmac256:
+        return "BIP-GMAC-256";
+    case WpaCipher::BipCmac256:
+        return "BIP-CMAC-256";
+    case WpaCipher::GtkNotUsed:
+        return "GTK_NOT_USED";
+    case WpaCipher::Sms4:
+        [[fallthrough]];
+    default:
+        return WpaCipherInvalidValue;
+    }
+}
 } // namespace Wpa
 
 #endif // HOSTAPD_PROTOCOL_HXX

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -380,7 +380,8 @@ IsHostapdStateOperational(HostapdInterfaceState state) noexcept;
 constexpr std::string_view WpaKeyManagementInvalidValue = "UNKNOWN";
 
 /**
- * @brief Convert a WpaKeyManagement value to the corresponding property value string expected by hostapd.
+ * @brief Convert a WpaKeyManagement value to the corresponding property value string expected by hostapd. The return
+ * value may be used for the hostapd property 'wpa_key_mgmt'.
  *
  * @param wpaKeyManagement The WpaKeyManagement value to convert.
  * @return constexpr std::string_view The corresponding hostapd property value string.

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -305,6 +305,7 @@ struct ProtocolHostapd :
     // Property names for "SET" commands.
     static constexpr auto PropertyEnabled = "1";
     static constexpr auto PropertyDisabled = "0";
+    static constexpr auto PropertyNameInvalid = "invalid";
 
     static constexpr auto PropertyNameSetBand = "setband";
     static constexpr auto PropertySetBandValueAuto = "AUTO";
@@ -494,6 +495,28 @@ WpaCipherPropertyValue(WpaCipher wpaCipher) noexcept
         [[fallthrough]];
     default:
         return WpaCipherInvalidValue;
+    }
+}
+
+/**
+ * @brief Get the hostapd property name to use to set the cipher for the specified WPA protocol.
+ *
+ * Hostapd uses different configuration properties for WPA and WPA2/RSN protocols. This function maps the protocol to
+ * the associated property name.
+ *
+ * @param wpaProtocol The wpa protocol to get the cipher name property for.
+ * @return constexpr std::string_view
+ */
+constexpr std::string_view
+WpaCipherPropertyName(WpaProtocol wpaProtocol) noexcept
+{
+    switch (wpaProtocol) {
+    case WpaProtocol::Wpa:
+        return ProtocolHostapd::PropertyNameWpaPairwise;
+    case WpaProtocol::Rsn:
+        return ProtocolHostapd::PropertyNameRsnPairwise;
+    default:
+        return ProtocolHostapd::PropertyNameInvalid;
     }
 }
 } // namespace Wpa

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -2,6 +2,7 @@
 #ifndef HOSTAPD_PROTOCOL_HXX
 #define HOSTAPD_PROTOCOL_HXX
 
+#include <algorithm>
 #include <array>
 #include <optional>
 #include <string>
@@ -56,6 +57,27 @@ enum class WpaProtocol : uint32_t {
 };
 
 /**
+ * @brief Array of all unsupported WpaProtocol values.
+ */
+inline constexpr std::array<WpaProtocol, 2> WpaProtocolsUnsupported = {
+    WpaProtocol::Wapi,
+    WpaProtocol::Osen,
+};
+
+/**
+ * @brief Determine if the specified WpaProtocol is supported by hostapd.
+ *
+ * @param wpaProtocol The WpaProtocol to check.
+ * @return true The protocol is supported.
+ * @return false The protocol is not supported.
+ */
+constexpr bool
+IsWpaProtocolSupported(WpaProtocol wpaProtocol) noexcept
+{
+    return !std::ranges::contains(WpaProtocolsUnsupported, wpaProtocol);
+}
+
+/**
  * @brief Numerical bitmask of valid WpaProtocol values.
  */
 static constexpr std::underlying_type_t<WpaProtocol> WpaProtocolMask =
@@ -92,7 +114,7 @@ enum class WpaCipher : uint32_t {
  *
  * magic_enum::enum_values() cannot be used since the enum values exceed [MAGIC_ENUM_RANGE_MIN, MAGIC_ENUM_RANGE_MAX].
  */
-inline constexpr std::array<WpaCipher, 14> AllWpaCiphers = {
+inline constexpr std::array<WpaCipher, 14> WpaCiphersAll = {
     WpaCipher::None,
     WpaCipher::Wep40,
     WpaCipher::Wep104,
@@ -108,6 +130,29 @@ inline constexpr std::array<WpaCipher, 14> AllWpaCiphers = {
     WpaCipher::BipCmac256,
     WpaCipher::GtkNotUsed,
 };
+
+/**
+ * @brief Array of all unsupported WpaCipher values.
+ */
+inline constexpr std::array<WpaCipher, 4> WpaCiphersUnsupported = {
+    WpaCipher::None,
+    WpaCipher::Wep40,
+    WpaCipher::Wep104,
+    WpaCipher::Sms4,
+};
+
+/**
+ * @brief Detrmine if the specified WpaCipher is supported by hostapd.
+ *
+ * @param wpaCipher The WpaCipher to check.
+ * @return true The cipher is supported.
+ * @return false The cipher is not supported.
+ */
+constexpr bool
+IsWpaCipherSupported(WpaCipher wpaCipher) noexcept
+{
+    return !std::ranges::contains(WpaCiphersUnsupported, wpaCipher);
+}
 
 /**
  * @brief WPA encoding of IEEE 802.11 algorithm types.

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -2,9 +2,11 @@
 #ifndef HOSTAPD_PROTOCOL_HXX
 #define HOSTAPD_PROTOCOL_HXX
 
+#include <array>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -56,7 +58,7 @@ enum class WpaProtocol : uint32_t {
 /**
  * @brief Numerical bitmask of valid WpaProtocol values.
  */
-static constexpr auto WpaProtocolMask =
+static constexpr std::underlying_type_t<WpaProtocol> WpaProtocolMask =
     std::to_underlying(WpaProtocol::Wpa) |
     std::to_underlying(WpaProtocol::Wpa2) |
     std::to_underlying(WpaProtocol::Wapi) |
@@ -83,6 +85,28 @@ enum class WpaCipher : uint32_t {
     BipGmac256 = (1U << 12U),
     BipCmac256 = (1U << 13U),
     GtkNotUsed = (1U << 14U),
+};
+
+/**
+ * @brief Array of all WpaCipher values.
+ *
+ * magic_enum::enum_values() cannot be used since the enum values exceed [MAGIC_ENUM_RANGE_MIN, MAGIC_ENUM_RANGE_MAX].
+ */
+inline constexpr std::array<WpaCipher, 14> AllWpaCiphers = {
+    WpaCipher::None,
+    WpaCipher::Wep40,
+    WpaCipher::Wep104,
+    WpaCipher::Tkip,
+    WpaCipher::Ccmp,
+    WpaCipher::Aes128Cmac,
+    WpaCipher::Gcmp,
+    WpaCipher::Sms4,
+    WpaCipher::Gcmp256,
+    WpaCipher::Ccmp256,
+    WpaCipher::BipGmac128,
+    WpaCipher::BipGmac256,
+    WpaCipher::BipCmac256,
+    WpaCipher::GtkNotUsed,
 };
 
 /**
@@ -141,9 +165,43 @@ enum class WpaKeyManagement : uint32_t {
 };
 
 /**
+ * @brief Array of all WpaKeyManagement values.
+ *
+ * magic_enum::enum_values() cannot be used since the enum values exceed [MAGIC_ENUM_RANGE_MIN, MAGIC_ENUM_RANGE_MAX].
+ */
+inline constexpr std::array<WpaKeyManagement, 26> AllWpaKeyManagements = {
+    WpaKeyManagement::Ieee80211x,
+    WpaKeyManagement::Psk,
+    WpaKeyManagement::None,
+    WpaKeyManagement::Ieee80211xNoWpa,
+    WpaKeyManagement::WpaNone,
+    WpaKeyManagement::FtIeee8021x,
+    WpaKeyManagement::FtPsk,
+    WpaKeyManagement::Ieee8021xSha256,
+    WpaKeyManagement::PskSha256,
+    WpaKeyManagement::Wps,
+    WpaKeyManagement::Sae,
+    WpaKeyManagement::FtSae,
+    WpaKeyManagement::WapiPsk,
+    WpaKeyManagement::WapiCert,
+    WpaKeyManagement::Cckm,
+    WpaKeyManagement::Osen,
+    WpaKeyManagement::Ieee80211xSuiteB,
+    WpaKeyManagement::Ieee80211xSuiteB192,
+    WpaKeyManagement::FilsSha256,
+    WpaKeyManagement::FilsSha384,
+    WpaKeyManagement::FtFilsSha256,
+    WpaKeyManagement::FtFilsSha384,
+    WpaKeyManagement::Owe,
+    WpaKeyManagement::Dpp,
+    WpaKeyManagement::FtIeee8021xSha384,
+    WpaKeyManagement::Pasn,
+};
+
+/**
  * @brief All valid WpaKeyManagement values supporting fast-transition (FT).
  */
-static constexpr auto WpaKeyManagementFt =
+static constexpr std::underlying_type_t<WpaKeyManagement> WpaKeyManagementFt =
     std::to_underlying(WpaKeyManagement::Ieee80211x) |
     std::to_underlying(WpaKeyManagement::FtIeee8021x) |
     std::to_underlying(WpaKeyManagement::FtIeee8021xSha384) |

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -529,28 +529,6 @@ TEST_CASE("Send SetCipherSuites() command (root)", "[wpa][hostapd][client][remot
 {
     using namespace Wpa;
 
-    constexpr auto isValidCipher = [](WpaCipher wpaCipher) noexcept {
-        switch (wpaCipher) {
-        case WpaCipher::None:
-        case WpaCipher::Wep40:
-        case WpaCipher::Wep104:
-        case WpaCipher::Sms4:
-            return false;
-        default:
-            return true;
-        }
-    };
-
-    constexpr auto isValidProtocol = [](WpaProtocol wpaProtocol) noexcept {
-        switch (wpaProtocol) {
-        case WpaProtocol::Wpa:
-        case WpaProtocol::Wpa2:
-            return true;
-        default:
-            return false;
-        }
-    };
-
     Hostapd hostapd(WpaDaemonManager::InterfaceNameDefault);
 
     SECTION("Doesn't throw")
@@ -614,8 +592,8 @@ TEST_CASE("Send SetCipherSuites() command (root)", "[wpa][hostapd][client][remot
 
     SECTION("Succeeds with all valid, single inputs")
     {
-        for (const auto wpaProtocol : magic_enum::enum_values<WpaProtocol>() | std::views::filter(isValidProtocol)) {
-            for (const auto wpaCipher : AllWpaCiphers | std::views::filter(isValidCipher)) {
+        for (const auto wpaProtocol : magic_enum::enum_values<WpaProtocol>() | std::views::filter(IsWpaProtocolSupported)) {
+            for (const auto wpaCipher : WpaCiphersAll | std::views::filter(IsWpaCipherSupported)) {
                 REQUIRE_NOTHROW(hostapd.SetCipherSuites(wpaProtocol, { wpaCipher }, EnforceConfigurationChange::Now));
                 REQUIRE_NOTHROW(hostapd.SetCipherSuites(wpaProtocol, { wpaCipher }, EnforceConfigurationChange::Defer));
             }
@@ -628,8 +606,8 @@ TEST_CASE("Send SetCipherSuites() command (root)", "[wpa][hostapd][client][remot
 
         std::vector<WpaKeyManagement> keyManagementValidValues{};
 
-        for (const auto wpaProtocol : magic_enum::enum_values<WpaProtocol>() | std::views::filter(isValidProtocol)) {
-            for (const auto wpaCipher : AllWpaCiphers | std::views::filter(isValidCipher)) {
+        for (const auto wpaProtocol : magic_enum::enum_values<WpaProtocol>() | std::views::filter(IsWpaProtocolSupported)) {
+            for (const auto wpaCipher : WpaCiphersAll | std::views::filter(IsWpaCipherSupported)) {
                 protocolCipherMap[wpaProtocol].push_back(wpaCipher);
                 REQUIRE_NOTHROW(hostapd.SetCipherSuites(protocolCipherMap, EnforceConfigurationChange::Now));
                 REQUIRE_NOTHROW(hostapd.SetCipherSuites(protocolCipherMap, EnforceConfigurationChange::Defer));


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow configuration of AP ciphers.

### Technical Details

* Add and implement `IHostapd::SetCipherSuites` with unit tests.
* Add helpers to determine whether `WpaProtocol` and `WpaCipher` values are valid.
* Fix some typos in `IHostapd.hxx` and `Hostapd.hxx` from prior PRs.
* Add helper containers describing all `WpaKeyManagement` and `WpaCipher` values to work around the magic enum limitation requiring all enum values be in the range `[MAGIC_ENUM_RANGE_MIN, MAGIC_ENUM_RANGE_MAX]`.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Expose this functionality to upper layers, particularly `IAccessPointController`.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
