### PR TITLE
Enable LLVM AddressSanitizer for debug builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,11 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GN
     endif()
   # clang specific options
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # Enable AddressSanitizer for all targets in Debug builds.
+    add_compile_options("$<$<CONFIG:Debug>:-fsanitize=address>")
+    add_compile_options("$<$<CONFIG:Debug>:-fno-omit-frame-pointer>")
+    add_link_options("$<$<CONFIG:Debug>:-fsanitize=address>")
+
     if (NETREMOTE_CODE_COVERAGE)
       add_compile_options(
         -fprofile-instr-generate


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Enable catching memory leaks and other memory problems in project.

### Technical Details

* Enable [LLVM AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) globally for all projects for `Debug` build flavors.

### Test Results

* Project compiles under `Debug` as expected.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
