### PR TITLE
Free wpa control socket resources on destruction

### DIFF
--- a/src/linux/wpa-controller/WpaController.cxx
+++ b/src/linux/wpa-controller/WpaController.cxx
@@ -36,6 +36,14 @@ WpaController::WpaController(std::string_view interfaceName, WpaType type, std::
 {
 }
 
+WpaController::~WpaController()
+{
+    if (m_controlSocketCommand != nullptr) {
+        wpa_ctrl_close(m_controlSocketCommand);
+        m_controlSocketCommand = nullptr;
+    }
+}
+
 WpaType
 WpaController::Type() const noexcept
 {

--- a/src/linux/wpa-controller/include/Wpa/WpaController.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaController.hxx
@@ -51,6 +51,11 @@ struct WpaController
     WpaController(std::string_view interfaceName, WpaType type, std::filesystem::path controlSocketPath);
 
     /**
+     * @brief Destroy the WpaController object.
+     */
+    virtual ~WpaController();
+
+    /**
      * @brief The type of daemon this object is controlling.
      *
      * @return WpaType


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure usage of `WpaController` does not cause memory leaks.

### Technical Details

* Free file resources obtained from `wpa_ctrl_open` upon `WpaController` destruction. This was previously leaking the allocated memory for the underlying socket.

### Test Results

* `wpa_controller-test_unit` passes and LeakSanitizer shows no leaks.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
