### PR TITLE
Eliminate unnecessary argument from FunctionTracer and derived classes

### DIFF
--- a/src/common/service/NetRemoteApiTrace.cxx
+++ b/src/common/service/NetRemoteApiTrace.cxx
@@ -8,6 +8,6 @@
 
 using namespace Microsoft::Net::Remote::Service::Tracing;
 
-NetRemoteApiTrace::NetRemoteApiTrace(bool deferEnter, plog::Severity logSeverityEnter, plog::Severity logSeverityExit, std::source_location location) :
-    logging::FunctionTracer(logSeverityEnter, logSeverityExit, LogTracePrefix, {}, deferEnter, location)
+NetRemoteApiTrace::NetRemoteApiTrace(bool deferEnter, plog::Severity logSeverity, std::source_location location) :
+    logging::FunctionTracer(logSeverity, LogTracePrefix, {}, deferEnter, location)
 {}

--- a/src/common/service/NetRemoteApiTrace.hxx
+++ b/src/common/service/NetRemoteApiTrace.hxx
@@ -19,11 +19,10 @@ struct NetRemoteApiTrace :
      * @brief Construct a new NetRemoteApiTrace object.
      *
      * @param deferEnter Whether to defer the entry log message upon construction.
-     * @param logSeverityEnter The log severity to use when tracing function entrance.
-     * @param logSeverityExit The log severity to use when tracing function exit.
+     * @param logSeverity The default log severity to use when tracing.
      * @param location The source code location of the function call.
      */
-    NetRemoteApiTrace(bool deferEnter = false, plog::Severity logSeverityEnter = LogSeverityDefaultApi, plog::Severity logSeverityExit = LogSeverityDefaultApi, std::source_location location = std::source_location::current());
+    NetRemoteApiTrace(bool deferEnter = false, plog::Severity logSeverity = LogSeverityDefaultApi, std::source_location location = std::source_location::current());
 
 protected:
     static constexpr auto LogSeverityDefaultApi{ plog::Severity::info };

--- a/src/common/service/NetRemoteWifiApiTrace.cxx
+++ b/src/common/service/NetRemoteWifiApiTrace.cxx
@@ -16,8 +16,8 @@ using namespace Microsoft::Net::Remote::Service::Tracing;
 using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus;
 using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode;
 
-NetRemoteWifiApiTrace::NetRemoteWifiApiTrace(std::optional<std::string> accessPointId, const WifiAccessPointOperationStatus* operationStatus, plog::Severity logSeverityEnter, plog::Severity logSeverityExit, std::source_location location) :
-    NetRemoteApiTrace(/* deferEnter= */ true, logSeverityEnter, logSeverityExit, location),
+NetRemoteWifiApiTrace::NetRemoteWifiApiTrace(std::optional<std::string> accessPointId, const WifiAccessPointOperationStatus* operationStatus, plog::Severity logSeverity, std::source_location location) :
+    NetRemoteApiTrace(/* deferEnter= */ true, logSeverity, location),
     m_accessPointId(std::move(accessPointId)),
     m_operationStatus(operationStatus)
 {

--- a/src/common/service/NetRemoteWifiApiTrace.hxx
+++ b/src/common/service/NetRemoteWifiApiTrace.hxx
@@ -28,7 +28,7 @@ struct NetRemoteWifiApiTrace :
      * @param operationStatus The result status of the operation, if present.
      * @param location The source code location of the function call.
      */
-    NetRemoteWifiApiTrace(std::optional<std::string> accessPointId = std::nullopt, const Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus* operationStatus = nullptr, plog::Severity logSeverityEnter = LogSeverityDefaultApi, plog::Severity logSeverityExit = LogSeverityDefaultApi, std::source_location location = std::source_location::current());
+    NetRemoteWifiApiTrace(std::optional<std::string> accessPointId = std::nullopt, const Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus* operationStatus = nullptr, plog::Severity logSeverity = LogSeverityDefaultApi, std::source_location location = std::source_location::current());
 
     /**
      * @brief Destroy the NetRemoteWifiApiTrace object.

--- a/src/common/shared/logging/FunctionTracer.cxx
+++ b/src/common/shared/logging/FunctionTracer.cxx
@@ -39,9 +39,9 @@ BuildValueList(const std::vector<std::pair<std::string, std::string>>& values, s
 }
 } // namespace detail
 
-FunctionTracer::FunctionTracer(plog::Severity logSeverityEnter, plog::Severity logSeverityExit, std::string logPrefix, std::vector<std::pair<std::string, std::string>> arguments, bool deferEnter, std::source_location location) :
-    m_logSeverityEnter(logSeverityEnter),
-    m_logSeverityExit(logSeverityExit),
+FunctionTracer::FunctionTracer(plog::Severity logSeverity, std::string logPrefix, std::vector<std::pair<std::string, std::string>> arguments, bool deferEnter, std::source_location location) :
+    m_logSeverityEnter(logSeverity),
+    m_logSeverityExit(logSeverity),
     m_logPrefix(std::move(logPrefix)),
     m_location(location),
     m_functionName(m_location.function_name()),
@@ -119,13 +119,13 @@ FunctionTracer::SetFailed() noexcept
 }
 
 void
-FunctionTracer::SetEnterLogSeverity(plog::Severity logSeverityEnter) noexcept
+FunctionTracer::SetEnterLogSeverity(plog::Severity logSeverity) noexcept
 {
     if (m_entered) {
         LOGW << "warning: calling SetEnterLogSeverity after entered log has already been printed; this will have no effect.";
     }
 
-    m_logSeverityEnter = logSeverityEnter;
+    m_logSeverityEnter = logSeverity;
 }
 
 void

--- a/src/common/shared/logging/include/logging/FunctionTracer.hxx
+++ b/src/common/shared/logging/include/logging/FunctionTracer.hxx
@@ -24,14 +24,13 @@ struct FunctionTracer
     /**
      * @brief Construct a new FunctionTracer object.
      *
-     * @param logSeverityEnter The severity to log entrance with.
-     * @param logSeverityExit The severity to log exit with.
+     * @param logSeverity The default severity to log with.
      * @param logPrefix The prefix to use for both log messages.
      * @param arguments The arguments the function was called with.
      * @param deferEnter Whether to defer the call to Enter().
      * @param location The source location information of the caller.
      */
-    FunctionTracer(plog::Severity logSeverityEnter = LogSeverityEnterDefault, plog::Severity logSeverityExit = LogSeverityExitDefault, std::string logPrefix = {}, std::vector<std::pair<std::string, std::string>> arguments = {}, bool deferEnter = false, std::source_location location = std::source_location::current());
+    FunctionTracer(plog::Severity logSeverity = LogSeverityEnterDefault, std::string logPrefix = {}, std::vector<std::pair<std::string, std::string>> arguments = {}, bool deferEnter = false, std::source_location location = std::source_location::current());
 
     /**
      * @brief Destroy the FunctionTracer object.
@@ -84,10 +83,10 @@ struct FunctionTracer
      * @brief Manually set the log severity for the enter log message. This only has an effect if the object was created
      * with deferEnter = true.
      *
-     * @param logSeverityEnter The log severity to use when printing the entrance log message.
+     * @param logSeverity The log severity to use when printing the entrance log message.
      */
     void
-    SetEnterLogSeverity(plog::Severity logSeverityEnter) noexcept;
+    SetEnterLogSeverity(plog::Severity logSeverity) noexcept;
 
     /**
      * @brief Manually set the log severity for the exit log message. This overrides the SetSucceeded and SetFailed methods.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Reduce the number of arguments needed when customizing function tracing.

### Technical Details

* The `logSeverityExit` argument in the `FunctionTracer` constructor didn't make a lot of sense since it would be unusual for callers to want to use a different exit log severity from the enter log severity when the object is first created. Thus, the `logSeverityExit` argument is removed (including from all derived classes), and the `logSeverityStart` argument is renamed to `logSeverity`, and its value used for both function enter and exit traces.

### Test Results

* Ran unit tests and ensured the same log verbosity prior to this change was maintained.

### Reviewer Focus

* Consider whether the assumption made above 

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
