### PR TITLE
Reduce test default log verbosity from verbose to debug

### DIFF
--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -18,6 +18,16 @@
 
 using logging::FunctionTracer;
 
+/**
+ * @brief Helper wrapper structure to trace function entry and exit with a verbose log level.
+ */
+struct FunctionTracerVerbose :
+    public FunctionTracer
+{
+    FunctionTracerVerbose(std::source_location location = std::source_location::current()) :
+        FunctionTracer(plog::Severity::verbose, {}, {}, false, location) {}
+};
+
 namespace Microsoft::Net::Remote::Service::Reactors::Helpers
 {
 DataGenerator::DataGenerator()
@@ -59,7 +69,7 @@ DataStreamReader::DataStreamReader(DataStreamUploadResult* result) :
 void
 DataStreamReader::OnReadDone(bool isOk)
 {
-    const FunctionTracer traceMe{};
+    const FunctionTracerVerbose traceMe{};
 
     if (isOk) {
         m_numberOfDataBlocksReceived++;
@@ -134,7 +144,7 @@ DataStreamWriter::DataStreamWriter(const DataStreamDownloadRequest* request) :
 void
 DataStreamWriter::OnWriteDone(bool isOk)
 {
-    const FunctionTracer traceMe{};
+    const FunctionTracerVerbose traceMe{};
 
     // Client may have canceled the RPC, so check for cancelation to prevent writing more data
     // when we shouldn't.
@@ -184,7 +194,7 @@ DataStreamWriter::OnDone()
 void
 DataStreamWriter::NextWrite()
 {
-    const FunctionTracer traceMe{};
+    const FunctionTracerVerbose traceMe{};
 
     // Client may have canceled the RPC, so check for cancelation to prevent writing more data
     // when we shouldn't.
@@ -249,7 +259,7 @@ DataStreamReaderWriter::DataStreamReaderWriter()
 void
 DataStreamReaderWriter::OnReadDone(bool isOk)
 {
-    const FunctionTracer traceMe{};
+    const FunctionTracerVerbose traceMe{};
 
     if (isOk) {
         m_numberOfDataBlocksReceived++;
@@ -269,7 +279,7 @@ DataStreamReaderWriter::OnReadDone(bool isOk)
 void
 DataStreamReaderWriter::OnWriteDone(bool isOk)
 {
-    const FunctionTracer traceMe{};
+    const FunctionTracerVerbose traceMe{};
 
     // Client may have canceled the RPC, so check for cancelation to prevent writing more data
     // when we shouldn't.
@@ -319,7 +329,7 @@ DataStreamReaderWriter::OnDone()
 void
 DataStreamReaderWriter::NextWrite()
 {
-    const FunctionTracer traceMe{};
+    const FunctionTracerVerbose traceMe{};
 
     // Client may have canceled the RPC, so check for cancelation to prevent writing more data
     // when we shouldn't.

--- a/src/linux/tools/apmonitor/Main.cxx
+++ b/src/linux/tools/apmonitor/Main.cxx
@@ -26,7 +26,7 @@ main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
 {
     // Configure console logging.
     static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
-    plog::init(plog::verbose, &colorConsoleAppender);
+    plog::init(plog::debug, &colorConsoleAppender);
 
     // Configure monitoring with the netlink protocol.
     auto accessPointControllerFactory = std::make_unique<AccessPointControllerLinuxFactory>();

--- a/src/linux/tools/cli/Main.cxx
+++ b/src/linux/tools/cli/Main.cxx
@@ -19,7 +19,7 @@ int
 main(int argc, char *argv[])
 {
     static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
-    plog::init(plog::verbose, &colorConsoleAppender);
+    plog::init(plog::debug, &colorConsoleAppender);
 
     auto cliData = std::make_shared<NetRemoteCliData>();
     auto cliHandler = std::make_shared<NetRemoteCliHandler>(std::make_unique<NetRemoteCliHandlerOperationsFactory>());

--- a/tests/unit/Main.cxx
+++ b/tests/unit/Main.cxx
@@ -10,7 +10,7 @@ main(int argc, char* argv[])
 {
     static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
 
-    plog::init(plog::verbose, &colorConsoleAppender);
+    plog::init(plog::debug, &colorConsoleAppender);
 
     return Catch::Session().run(argc, argv);
 }

--- a/tests/unit/linux/wifi/apmanager/Main.cxx
+++ b/tests/unit/linux/wifi/apmanager/Main.cxx
@@ -10,7 +10,7 @@ main(int argc, char* argv[])
 {
     static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
 
-    plog::init(plog::verbose, &colorConsoleAppender);
+    plog::init(plog::debug, &colorConsoleAppender);
 
     return Catch::Session().run(argc, argv);
 }

--- a/tests/unit/linux/wpa-controller/Main.cxx
+++ b/tests/unit/linux/wpa-controller/Main.cxx
@@ -9,7 +9,7 @@ int main(int argc, char* argv[])
 {
     static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
 
-    plog::init(plog::verbose, &colorConsoleAppender);
+    plog::init(plog::debug, &colorConsoleAppender);
 
     return Catch::Session().run(argc, argv);
 }

--- a/tests/unit/wifi/core/Main.cxx
+++ b/tests/unit/wifi/core/Main.cxx
@@ -10,7 +10,7 @@ main(int argc, char* argv[])
 {
     static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
 
-    plog::init(plog::verbose, &colorConsoleAppender);
+    plog::init(plog::debug, &colorConsoleAppender);
 
     return Catch::Session().run(argc, argv);
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Prevent ultra-verbose messages from appearing in test logs by default.

### Technical Details

* The `plog::verbose` severity is the maximum that can be used and is now by convention, limited to wildly detailed information such as hex dumps of messages or other extremely verbose tracing information. As such, reduce the default log severity of all of the unit tests from `plog::verbose` to `plog::debug`.
* Drop the severity from some data streaming internal operations (eg. `ReadDone`, `WriteDone`, `NextWrite`) from `plog::verbose` to `plog::debug` as these were generating a lot of noise in the unit tests and were not necessary to be shown by default. Added a wrapper structure `FunctionTraceVerbose` for these more detailed invocations.

### Test Results

* Re-ran unit tests and validated much fewer messages were printed.

### Reviewer Focus

*  None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
