### PR TITLE
Fix some memory access issues

### DIFF
--- a/src/linux/libnl-helpers/Netlink80211Interface.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Interface.cxx
@@ -66,7 +66,7 @@ Nl80211Interface::Parse(struct nl_msg *nl80211Message) noexcept
 
     // Parse the message.
     std::array<struct nlattr *, NL80211_ATTR_MAX + 1> newInterfaceMessageAttributes{};
-    int ret = nla_parse(std::data(newInterfaceMessageAttributes), std::size(newInterfaceMessageAttributes), genlmsg_attrdata(genl80211MessageHeader, 0), genlmsg_attrlen(genl80211MessageHeader, 0), nullptr);
+    int ret = nla_parse(std::data(newInterfaceMessageAttributes), std::size(newInterfaceMessageAttributes) - 1, genlmsg_attrdata(genl80211MessageHeader, 0), genlmsg_attrlen(genl80211MessageHeader, 0), nullptr);
     if (ret < 0) {
         LOGE << std::format("Failed to parse netlink message attributes with error {} ({})", ret, strerror(-ret));
         return std::nullopt;

--- a/src/linux/libnl-helpers/Netlink80211WiphyBandFrequency.cxx
+++ b/src/linux/libnl-helpers/Netlink80211WiphyBandFrequency.cxx
@@ -27,7 +27,7 @@ WiphyBandFrequency::Parse(struct nlattr *wiphyBandFrequencyNlAttribute) noexcept
 {
     // Parse the attribute message.
     std::array<struct nlattr *, NL80211_FREQUENCY_ATTR_MAX + 1> wiphyBandFrequenciesAttributes{};
-    int ret = nla_parse(std::data(wiphyBandFrequenciesAttributes), std::size(wiphyBandFrequenciesAttributes), static_cast<struct nlattr *>(nla_data(wiphyBandFrequencyNlAttribute)), nla_len(wiphyBandFrequencyNlAttribute), nullptr);
+    int ret = nla_parse(std::data(wiphyBandFrequenciesAttributes), std::size(wiphyBandFrequenciesAttributes) - 1, static_cast<struct nlattr *>(nla_data(wiphyBandFrequencyNlAttribute)), nla_len(wiphyBandFrequencyNlAttribute), nullptr);
     if (ret < 0) {
         LOGE << std::format("Failed to parse wiphy band frequency attributes with error {} ({})", ret, nl_geterror(ret));
         return std::nullopt;

--- a/tests/unit/linux/libnl-helpers/CMakeLists.txt
+++ b/tests/unit/linux/libnl-helpers/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(libnl-helpers-test-unit)
 
 target_sources(libnl-helpers-test-unit
     PRIVATE
+        Main.cxx
         TestNetlink80211Interface.cxx
         TestNetlink80211ProtocolState.cxx
 )
@@ -14,7 +15,7 @@ target_include_directories(libnl-helpers-test-unit
 
 target_link_libraries(libnl-helpers-test-unit
     PRIVATE
-        Catch2::Catch2WithMain
+        Catch2::Catch2
         libnl-helpers
         magic_enum::magic_enum
 )

--- a/tests/unit/linux/libnl-helpers/Main.cxx
+++ b/tests/unit/linux/libnl-helpers/Main.cxx
@@ -1,0 +1,16 @@
+
+#include <catch2/catch_session.hpp>
+#include <plog/Appenders/ColorConsoleAppender.h>
+#include <plog/Formatters/MessageOnlyFormatter.h>
+#include <plog/Init.h>
+#include <plog/Severity.h>
+
+int
+main(int argc, char* argv[])
+{
+    static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
+
+    plog::init(plog::debug, &colorConsoleAppender);
+
+    return Catch::Session().run(argc, argv);
+}

--- a/tests/unit/linux/wifi/core/TestAccessPointFactoryLinux.cxx
+++ b/tests/unit/linux/wifi/core/TestAccessPointFactoryLinux.cxx
@@ -1,5 +1,6 @@
 
 #include <memory>
+#include <optional>
 #include <utility>
 
 #include <catch2/catch_test_macros.hpp>
@@ -45,8 +46,9 @@ TEST_CASE("Destroy an AccessPointFactoryLinux instance", "[wifi][core][ap][linux
 
     SECTION("Destroy doesn't cause a crash")
     {
-        AccessPointFactoryLinux accessPointFactory{ std::make_unique<Test::AccessPointControllerFactoryTest>() };
-        REQUIRE_NOTHROW(accessPointFactory.~AccessPointFactoryLinux());
+        std::optional<AccessPointFactoryLinux> accessPointFactory{};
+        accessPointFactory.emplace(std::make_unique<Test::AccessPointControllerFactoryTest>());
+        REQUIRE_NOTHROW(accessPointFactory.reset());
     }
 }
 

--- a/tests/unit/wifi/core/TestAccessPoint.cxx
+++ b/tests/unit/wifi/core/TestAccessPoint.cxx
@@ -37,8 +37,9 @@ TEST_CASE("Destroy an AccessPoint instance", "[wifi][core][ap]")
 
     SECTION("Destroy doesn't cause a crash")
     {
-        AccessPoint accessPoint{ Test::InterfaceNameDefault, std::make_unique<Test::AccessPointControllerFactoryTest>() };
-        REQUIRE_NOTHROW(accessPoint.~AccessPoint());
+        std::optional<AccessPoint> accessPoint{};
+        accessPoint.emplace(Test::InterfaceNameDefault, std::make_shared<Test::AccessPointControllerFactoryTest>());
+        REQUIRE_NOTHROW(accessPoint.reset());
     }
 }
 


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Fix use-after-free instances.
* Fix stack buffer overflow instances.

### Technical Details

* Avoid calling object destructors explicitly in tests, since this will result in it being called twice, causing use-after-free bugs.
* Fix off-by-1 array size being passed to `nla_parse` causing a stack buffer overflow.

### Test Results

* All unit tests pass with clean ASAN output.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
