### PR TITLE
Rename Ieee80211Protocol to Ieee80211PhyType.

### DIFF
--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -533,10 +533,10 @@ NetRemoteService::WifiAccessPointSetPhyTypeImpl(std::string_view accessPointId, 
         }
     }
 
-    // Convert PHY type to Ieee80211 protocol.
-    auto ieee80211Protocol = FromDot11PhyType(dot11PhyType);
+    // Convert dot11 PHY type to Ieee80211 PHY type.
+    auto ieee80211PhyType = FromDot11PhyType(dot11PhyType);
 
-    // Check if Ieee80211 protocol is supported by AP.
+    // Check if Ieee80211 PHY type is supported by AP.
     Ieee80211AccessPointCapabilities accessPointCapabilities{};
     operationStatus = accessPointController->GetCapabilities(accessPointCapabilities);
     if (!operationStatus) {
@@ -545,15 +545,15 @@ NetRemoteService::WifiAccessPointSetPhyTypeImpl(std::string_view accessPointId, 
         return wifiOperationStatus;
     }
 
-    const auto& supportedIeee80211Protocols = accessPointCapabilities.Protocols;
-    if (!std::ranges::contains(supportedIeee80211Protocols, ieee80211Protocol)) {
+    const auto& supportedIeee80211PhyTypes = accessPointCapabilities.PhyTypes;
+    if (!std::ranges::contains(supportedIeee80211PhyTypes, ieee80211PhyType)) {
         wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeOperationNotSupported);
-        wifiOperationStatus.set_message(std::format("PHY type '{}' not supported by access point {}", magic_enum::enum_name(ieee80211Protocol), accessPointId));
+        wifiOperationStatus.set_message(std::format("PHY type '{}' not supported by access point {}", magic_enum::enum_name(ieee80211PhyType), accessPointId));
         return wifiOperationStatus;
     }
 
-    // Set the Ieee80211 protocol.
-    operationStatus = accessPointController->SetProtocol(ieee80211Protocol);
+    // Set the Ieee80211 PHY type.
+    operationStatus = accessPointController->SetPhyType(ieee80211PhyType);
     if (!operationStatus) {
         wifiOperationStatus.set_code(ToDot11AccessPointOperationStatusCode(operationStatus.Code));
         wifiOperationStatus.set_message(std::format("Failed to set PHY type for access point {} - {}", accessPointId, operationStatus.ToString()));

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -74,7 +74,7 @@ private:
     WifiAccessPointDisable(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointDisableRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointDisableResult* result) override;
 
     /**
-     * @brief Set the active PHY type or protocol of the access point. The access point must be enabled. This will cause
+     * @brief Set the active PHY type of the access point. The access point must be enabled. This will cause
      * the access point to temporarily go offline while the change is being applied.
      *
      * @param context
@@ -140,7 +140,7 @@ protected:
     WifiAccessPointEnableImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11AccessPointConfiguration* dot11AccessPointConfiguration, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
     /**
-     * @brief Set the active PHY type or protocol of the access point. The access point must be enabled. This will cause
+     * @brief Set the active PHY type of the access point. The access point must be enabled. This will cause
      * the access point to temporarily go offline while the change is being applied.
      *
      * @param accessPointId The access point identifier.

--- a/src/common/wifi/core/Ieee80211AccessPointCapabilities.cxx
+++ b/src/common/wifi/core/Ieee80211AccessPointCapabilities.cxx
@@ -12,9 +12,9 @@ Ieee80211AccessPointCapabilities::ToString() const
 {
     std::ostringstream result{};
 
-    result << "Protocols: ";
-    for (const auto& protocol : Protocols) {
-        result << magic_enum::enum_name(protocol);
+    result << "PHY Types: ";
+    for (const auto& phyType : PhyTypes) {
+        result << magic_enum::enum_name(phyType);
         result << ' ';
     }
 

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -75,13 +75,13 @@ struct IAccessPointController
     SetOperationalState(AccessPointOperationalState operationalState) noexcept = 0;
 
     /**
-     * @brief Set the Ieee80211 protocol of the access point.
+     * @brief Set the Ieee80211 PHY type of the access point.
      *
-     * @param ieeeProtocol The Ieee80211 protocol to be set.
+     * @param ieeePhyType The Ieee80211 PHY type to be set.
      * @return AccessPointOperationStatus
      */
     virtual AccessPointOperationStatus
-    SetProtocol(Ieee80211Protocol ieeeProtocol) noexcept = 0;
+    SetPhyType(Ieee80211PhyType ieeePhyType) noexcept = 0;
 
     /**
      * @brief Set the frquency bands the access point should enable.

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -74,7 +74,7 @@ operator"" _MHz(unsigned long long int value) noexcept
 }
 } // namespace Literals
 
-enum class Ieee80211Protocol {
+enum class Ieee80211PhyType {
     Unknown,
     B,
     G,

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
@@ -14,7 +14,7 @@ namespace Microsoft::Net::Wifi
  */
 struct Ieee80211AccessPointCapabilities
 {
-    std::vector<Ieee80211Protocol> Protocols;
+    std::vector<Ieee80211PhyType> PhyTypes;
     std::vector<Ieee80211FrequencyBand> FrequencyBands;
     std::vector<Ieee80211AkmSuite> AkmSuites;
     std::vector<Ieee80211CipherSuite> CipherSuites;

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -63,57 +63,57 @@ FromDot11AccessPointOperationStatusCode(WifiAccessPointOperationStatusCode wifiA
 }
 
 using Microsoft::Net::Wifi::Dot11PhyType;
-using Microsoft::Net::Wifi::Ieee80211Protocol;
+using Microsoft::Net::Wifi::Ieee80211PhyType;
 
 Dot11PhyType
-ToDot11PhyType(const Ieee80211Protocol ieee80211Protocol) noexcept
+ToDot11PhyType(const Ieee80211PhyType ieee80211PhyType) noexcept
 {
-    switch (ieee80211Protocol) {
-    case Ieee80211Protocol::Unknown:
+    switch (ieee80211PhyType) {
+    case Ieee80211PhyType::Unknown:
         return Dot11PhyType::Dot11PhyTypeUnknown;
-    case Ieee80211Protocol::B:
+    case Ieee80211PhyType::B:
         return Dot11PhyType::Dot11PhyTypeB;
-    case Ieee80211Protocol::G:
+    case Ieee80211PhyType::G:
         return Dot11PhyType::Dot11PhyTypeG;
-    case Ieee80211Protocol::N:
+    case Ieee80211PhyType::N:
         return Dot11PhyType::Dot11PhyTypeN;
-    case Ieee80211Protocol::A:
+    case Ieee80211PhyType::A:
         return Dot11PhyType::Dot11PhyTypeA;
-    case Ieee80211Protocol::AC:
+    case Ieee80211PhyType::AC:
         return Dot11PhyType::Dot11PhyTypeAC;
-    case Ieee80211Protocol::AD:
+    case Ieee80211PhyType::AD:
         return Dot11PhyType::Dot11PhyTypeAD;
-    case Ieee80211Protocol::AX:
+    case Ieee80211PhyType::AX:
         return Dot11PhyType::Dot11PhyTypeAX;
-    case Ieee80211Protocol::BE:
+    case Ieee80211PhyType::BE:
         return Dot11PhyType::Dot11PhyTypeBE;
     }
 
     return Dot11PhyType::Dot11PhyTypeUnknown;
 }
 
-Ieee80211Protocol
+Ieee80211PhyType
 FromDot11PhyType(const Dot11PhyType dot11PhyType) noexcept
 {
     switch (dot11PhyType) {
     case Dot11PhyType::Dot11PhyTypeB:
-        return Ieee80211Protocol::B;
+        return Ieee80211PhyType::B;
     case Dot11PhyType::Dot11PhyTypeG:
-        return Ieee80211Protocol::G;
+        return Ieee80211PhyType::G;
     case Dot11PhyType::Dot11PhyTypeN:
-        return Ieee80211Protocol::N;
+        return Ieee80211PhyType::N;
     case Dot11PhyType::Dot11PhyTypeA:
-        return Ieee80211Protocol::A;
+        return Ieee80211PhyType::A;
     case Dot11PhyType::Dot11PhyTypeAC:
-        return Ieee80211Protocol::AC;
+        return Ieee80211PhyType::AC;
     case Dot11PhyType::Dot11PhyTypeAD:
-        return Ieee80211Protocol::AD;
+        return Ieee80211PhyType::AD;
     case Dot11PhyType::Dot11PhyTypeAX:
-        return Ieee80211Protocol::AX;
+        return Ieee80211PhyType::AX;
     case Dot11PhyType::Dot11PhyTypeBE:
-        return Ieee80211Protocol::BE;
+        return Ieee80211PhyType::BE;
     default:
-        return Ieee80211Protocol::Unknown;
+        return Ieee80211PhyType::Unknown;
     }
 }
 
@@ -455,8 +455,8 @@ ToDot11AccessPointCapabilities(const Ieee80211AccessPointCapabilities& ieee80211
 {
     Dot11AccessPointCapabilities dot11Capabilities{};
 
-    std::vector<Dot11PhyType> phyTypes(std::size(ieee80211AccessPointCapabilities.Protocols));
-    std::ranges::transform(ieee80211AccessPointCapabilities.Protocols, std::begin(phyTypes), ToDot11PhyType);
+    std::vector<Dot11PhyType> phyTypes(std::size(ieee80211AccessPointCapabilities.PhyTypes));
+    std::ranges::transform(ieee80211AccessPointCapabilities.PhyTypes, std::begin(phyTypes), ToDot11PhyType);
 
     *dot11Capabilities.mutable_phytypes() = {
         std::make_move_iterator(std::begin(phyTypes)),

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -33,19 +33,19 @@ FromDot11AccessPointOperationStatusCode(Microsoft::Net::Remote::Wifi::WifiAccess
 /**
  * @brief Convert the specified Dot11PhyType to the equivalent IEEE 802.11 protocol.
  *
- * @param ieee80211Protocol The IEEE 802.11 protocol to convert.
+ * @param ieee80211PhyType The IEEE 802.11 PHY type to convert.
  * @return Microsoft::Net::Wifi::Dot11PhyType
  */
 Microsoft::Net::Wifi::Dot11PhyType
-ToDot11PhyType(Microsoft::Net::Wifi::Ieee80211Protocol ieee80211Protocol) noexcept;
+ToDot11PhyType(Microsoft::Net::Wifi::Ieee80211PhyType ieee80211PhyType) noexcept;
 
 /**
  * @brief Convert the specified Dot11PhyType to the equivalent IEEE 802.11 protocol.
  *
  * @param dot11PhyType The Dot11PhyType to convert.
- * @return Microsoft::Net::Wifi::Ieee80211Protocol
+ * @return Microsoft::Net::Wifi::Ieee80211PhyType
  */
-Microsoft::Net::Wifi::Ieee80211Protocol
+Microsoft::Net::Wifi::Ieee80211PhyType
 FromDot11PhyType(Microsoft::Net::Wifi::Dot11PhyType dot11PhyType) noexcept;
 
 /**

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -54,8 +54,8 @@ AccessPointControllerLinux::GetCapabilities(Ieee80211AccessPointCapabilities& ie
 
     Ieee80211AccessPointCapabilities capabilities{};
 
-    // Convert protocols.
-    capabilities.Protocols = Nl80211WiphyToIeee80211Protocols(wiphy.value());
+    // Convert phy types.
+    capabilities.PhyTypes = Nl80211WiphyToIeee80211PhyTypes(wiphy.value());
 
     // Convert frequency bands.
     capabilities.FrequencyBands = std::vector<Ieee80211FrequencyBand>(std::size(wiphy->Bands));
@@ -134,31 +134,31 @@ AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState oper
 }
 
 AccessPointOperationStatus
-AccessPointControllerLinux::SetProtocol(Ieee80211Protocol ieeeProtocol) noexcept
+AccessPointControllerLinux::SetPhyType(Ieee80211PhyType ieeePhyType) noexcept
 {
-    const auto ieeeProtocolName = std::format("802.11 {}", magic_enum::enum_name(ieeeProtocol));
-    AccessPointOperationStatus status{ GetInterfaceName(), std::format("SetProtocol {}", ieeeProtocolName) };
+    const auto ieeePhyTypeName = std::format("802.11 {}", magic_enum::enum_name(ieeePhyType));
+    AccessPointOperationStatus status{ GetInterfaceName(), std::format("SetPhyType {}", ieeePhyTypeName) };
     const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
 
     // Populate a list of required properties to set.
     std::vector<std::pair<std::string_view, std::string_view>> propertiesToSet{};
 
     // Add the hw_mode property.
-    const auto hwMode = IeeeProtocolToHostapdHwMode(ieeeProtocol);
+    const auto hwMode = IeeePhyTypeToHostapdHwMode(ieeePhyType);
     const auto hwModeValue = HostapdHwModeToPropertyValue(hwMode);
     propertiesToSet.emplace_back(Wpa::ProtocolHostapd::PropertyNameHwMode, hwModeValue);
 
     // Additively set other hostapd properties based on the protocol.
-    switch (ieeeProtocol) {
-    case Ieee80211Protocol::AX:
+    switch (ieeePhyType) {
+    case Ieee80211PhyType::AX:
         propertiesToSet.emplace_back(Wpa::ProtocolHostapd::PropertyNameIeee80211AX, Wpa::ProtocolHostapd::PropertyEnabled);
         propertiesToSet.emplace_back(Wpa::ProtocolHostapd::PropertyNameDisable11AX, Wpa::ProtocolHostapd::PropertyDisabled);
         [[fallthrough]];
-    case Ieee80211Protocol::AC:
+    case Ieee80211PhyType::AC:
         propertiesToSet.emplace_back(Wpa::ProtocolHostapd::PropertyNameIeee80211AC, Wpa::ProtocolHostapd::PropertyEnabled);
         propertiesToSet.emplace_back(Wpa::ProtocolHostapd::PropertyNameDisable11AC, Wpa::ProtocolHostapd::PropertyDisabled);
         [[fallthrough]];
-    case Ieee80211Protocol::N:
+    case Ieee80211PhyType::N:
         propertiesToSet.emplace_back(Wpa::ProtocolHostapd::PropertyNameWmmEnabled, Wpa::ProtocolHostapd::PropertyEnabled);
         propertiesToSet.emplace_back(Wpa::ProtocolHostapd::PropertyNameIeee80211N, Wpa::ProtocolHostapd::PropertyEnabled);
         propertiesToSet.emplace_back(Wpa::ProtocolHostapd::PropertyNameDisable11N, Wpa::ProtocolHostapd::PropertyDisabled);

--- a/src/linux/wifi/core/Ieee80211Nl80211Adapters.cxx
+++ b/src/linux/wifi/core/Ieee80211Nl80211Adapters.cxx
@@ -48,30 +48,30 @@ Nl80211BandToIeee80211FrequencyBand(nl80211_band nl80211Band) noexcept
     }
 }
 
-std::vector<Ieee80211Protocol>
-Nl80211WiphyToIeee80211Protocols(const Nl80211Wiphy& nl80211Wiphy)
+std::vector<Ieee80211PhyType>
+Nl80211WiphyToIeee80211PhyTypes(const Nl80211Wiphy& nl80211Wiphy)
 {
     // Ieee80211 B & G are always supported.
-    std::vector<Ieee80211Protocol> protocols{
-        Ieee80211Protocol::B,
-        Ieee80211Protocol::G,
+    std::vector<Ieee80211PhyType> phyTypes{
+        Ieee80211PhyType::B,
+        Ieee80211PhyType::G,
     };
 
     for (const auto& band : std::views::values(nl80211Wiphy.Bands)) {
         if (band.HtCapabilities != 0) {
-            protocols.push_back(Ieee80211Protocol::N);
+            phyTypes.push_back(Ieee80211PhyType::N);
         }
         if (band.VhtCapabilities != 0) {
-            protocols.push_back(Ieee80211Protocol::AC);
+            phyTypes.push_back(Ieee80211PhyType::AC);
         }
         // TODO: once Nl80211WiphyBand is updated to support HE (AX) and EHT (BE), add them here.
     }
 
     // Remove duplicates.
-    std::ranges::sort(protocols);
-    protocols.erase(std::ranges::begin(std::ranges::unique(protocols)), std::ranges::end(protocols));
+    std::ranges::sort(phyTypes);
+    phyTypes.erase(std::ranges::begin(std::ranges::unique(phyTypes)), std::ranges::end(phyTypes));
 
-    return protocols;
+    return phyTypes;
 }
 
 } // namespace Microsoft::Net::Wifi

--- a/src/linux/wifi/core/Ieee80211Nl80211Adapters.hxx
+++ b/src/linux/wifi/core/Ieee80211Nl80211Adapters.hxx
@@ -42,13 +42,13 @@ Ieee80211FrequencyBand
 Nl80211BandToIeee80211FrequencyBand(nl80211_band nl80211Band) noexcept;
 
 /**
- * @brief Obtain a list of Ieee80211Protocols from a Nl80211Wiphy.
+ * @brief Obtain a list of Ieee80211PhyTypes from a Nl80211Wiphy.
  *
  * @param nl80211Wiphy The Nl80211Wiphy to obtain the protocols from.
- * @return std::vector<Ieee80211Protocol>
+ * @return std::vector<Ieee80211PhyType>
  */
-std::vector<Ieee80211Protocol>
-Nl80211WiphyToIeee80211Protocols(const Microsoft::Net::Netlink::Nl80211::Nl80211Wiphy& nl80211Wiphy);
+std::vector<Ieee80211PhyType>
+Nl80211WiphyToIeee80211PhyTypes(const Microsoft::Net::Netlink::Nl80211::Nl80211Wiphy& nl80211Wiphy);
 } // namespace Microsoft::Net::Wifi
 
 #endif // IEEE_80211_NL80211_ADAPTERS_HXX

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
@@ -15,24 +15,24 @@ namespace Microsoft::Net::Wifi
 using namespace Wpa;
 
 HostapdHwMode
-IeeeProtocolToHostapdHwMode(Ieee80211Protocol ieeeProtocol) noexcept
+IeeePhyTypeToHostapdHwMode(Ieee80211PhyType ieeePhyType) noexcept
 {
-    switch (ieeeProtocol) {
-    case Ieee80211Protocol::B:
+    switch (ieeePhyType) {
+    case Ieee80211PhyType::B:
         return HostapdHwMode::Ieee80211b;
-    case Ieee80211Protocol::G:
+    case Ieee80211PhyType::G:
         return HostapdHwMode::Ieee80211g;
-    case Ieee80211Protocol::N:
+    case Ieee80211PhyType::N:
         return HostapdHwMode::Ieee80211a; // TODO: Could be a or g depending on band
-    case Ieee80211Protocol::A:
+    case Ieee80211PhyType::A:
         return HostapdHwMode::Ieee80211a;
-    case Ieee80211Protocol::AC:
+    case Ieee80211PhyType::AC:
         return HostapdHwMode::Ieee80211a;
-    case Ieee80211Protocol::AD:
+    case Ieee80211PhyType::AD:
         return HostapdHwMode::Ieee80211ad;
-    case Ieee80211Protocol::AX:
+    case Ieee80211PhyType::AX:
         return HostapdHwMode::Ieee80211a;
-    case Ieee80211Protocol::BE:
+    case Ieee80211PhyType::BE:
         return HostapdHwMode::Ieee80211a; // TODO: Assuming a, although hostapd docs don't mention it
     default:
         return HostapdHwMode::Unknown;

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
@@ -11,13 +11,13 @@
 namespace Microsoft::Net::Wifi
 {
 /**
- * @brief Convert a WPA "hwmode" value from a Ieee80211Protocol value.
+ * @brief Convert a WPA "hwmode" value from a Ieee80211PhyType value.
  *
- * @param ieeeProtocol The Ieee80211Protocol value to convert.
+ * @param ieeePhyType The Ieee80211PhyType value to convert.
  * @return Wpa::HostapdHwMode
  */
 Wpa::HostapdHwMode
-IeeeProtocolToHostapdHwMode(Ieee80211Protocol ieeeProtocol) noexcept;
+IeeePhyTypeToHostapdHwMode(Ieee80211PhyType ieeePhyType) noexcept;
 
 /**
  * @brief Get a string representation of a HostapdHwMode.

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -73,13 +73,13 @@ struct AccessPointControllerLinux :
     SetOperationalState(AccessPointOperationalState operationalState) noexcept override;
 
     /**
-     * @brief Set the Ieee80211 protocol.
+     * @brief Set the Ieee80211 PHY type.
      *
-     * @param ieeeProtocol The Ieee80211 protocol to be set.
+     * @param ieeePhyType The Ieee80211 PHY type to be set.
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    SetProtocol(Ieee80211Protocol ieeeProtocol) noexcept override;
+    SetPhyType(Ieee80211PhyType ieeePhyType) noexcept override;
 
     /**
      * @brief Set the frquency bands the access point should enable.

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -26,7 +26,7 @@
 
 namespace Microsoft::Net::Remote::Test
 {
-constexpr auto AllProtocols = magic_enum::enum_values<Microsoft::Net::Wifi::Ieee80211Protocol>();
+constexpr auto AllPhyTypes = magic_enum::enum_values<Microsoft::Net::Wifi::Ieee80211PhyType>();
 constexpr auto AllBands = magic_enum::enum_values<Microsoft::Net::Wifi::Ieee80211FrequencyBand>();
 } // namespace Microsoft::Net::Remote::Test
 
@@ -98,7 +98,7 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
 
     auto apManagerTest = std::make_shared<AccessPointManagerTest>();
     const Ieee80211AccessPointCapabilities apCapabilities{
-        .Protocols{ std::cbegin(AllProtocols), std::cend(AllProtocols) },
+        .PhyTypes{ std::cbegin(AllPhyTypes), std::cend(AllPhyTypes) },
         .FrequencyBands{ std::cbegin(AllBands), std::cend(AllBands) }
     };
 
@@ -224,7 +224,7 @@ TEST_CASE("WifiAccessPointDisable API", "[basic][rpc][client][remote]")
 
     auto apManagerTest = std::make_shared<AccessPointManagerTest>();
     const Ieee80211AccessPointCapabilities apCapabilities{
-        .Protocols{ std::cbegin(AllProtocols), std::cend(AllProtocols) }
+        .PhyTypes{ std::cbegin(AllPhyTypes), std::cend(AllPhyTypes) }
     };
 
     auto apTest1 = std::make_shared<AccessPointTest>(InterfaceName1, apCapabilities);
@@ -323,7 +323,7 @@ TEST_CASE("WifiAccessPointSetPhyType API", "[basic][rpc][client][remote]")
 
     auto apManagerTest = std::make_shared<AccessPointManagerTest>();
     const Ieee80211AccessPointCapabilities apCapabilities{
-        .Protocols{ std::cbegin(AllProtocols), std::cend(AllProtocols) }
+        .PhyTypes{ std::cbegin(AllPhyTypes), std::cend(AllPhyTypes) }
     };
     auto apTest = std::make_shared<AccessPointTest>(InterfaceName, apCapabilities);
     apManagerTest->AddAccessPoint(apTest);

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -72,7 +72,7 @@ AccessPointControllerTest::SetOperationalState(AccessPointOperationalState opera
 }
 
 AccessPointOperationStatus
-AccessPointControllerTest::SetProtocol(Ieee80211Protocol ieeeProtocol) noexcept
+AccessPointControllerTest::SetPhyType(Ieee80211PhyType ieeePhyType) noexcept
 {
     assert(AccessPoint != nullptr);
 
@@ -80,7 +80,7 @@ AccessPointControllerTest::SetProtocol(Ieee80211Protocol ieeeProtocol) noexcept
         return AccessPointOperationStatus::InvalidAccessPoint("null AccessPoint");
     }
 
-    AccessPoint->Protocol = ieeeProtocol;
+    AccessPoint->PhyType = ieeePhyType;
     return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -86,13 +86,13 @@ struct AccessPointControllerTest final :
     SetOperationalState(AccessPointOperationalState operationalState) noexcept override;
 
     /**
-     * @brief Set the Ieee80211 protocol of the access point.
+     * @brief Set the Ieee80211 PHY type of the access point.
      *
-     * @param ieeeProtocol The Ieee80211 protocol to be set
+     * @param ieeePhyType The Ieee80211 PHY type to be set
      * @return AccessPointOperationStatus
      */
     AccessPointOperationStatus
-    SetProtocol(Microsoft::Net::Wifi::Ieee80211Protocol ieeeProtocol) noexcept override;
+    SetPhyType(Microsoft::Net::Wifi::Ieee80211PhyType ieeePhyType) noexcept override;
 
     /**
      * @brief Set the frquency bands the access point should enable.

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -26,7 +26,7 @@ struct AccessPointTest final :
     std::string Ssid;
     std::string InterfaceName;
     Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities Capabilities;
-    Microsoft::Net::Wifi::Ieee80211Protocol Protocol{ Microsoft::Net::Wifi::Ieee80211Protocol::Unknown };
+    Microsoft::Net::Wifi::Ieee80211PhyType PhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> FrequencyBands;
     std::vector<Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm> AuthenticationAlgorithms;
     AccessPointOperationalState OperationalState{ AccessPointOperationalState::Disabled };


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Ensure consistent nomenclature is used throughout the stack.

### Technical Details

* Rename `Ieee80211Protocol` to `Ieee80211PhyType` to distinguish the two. The former should refer to all-encompassing protocols (WPA, WPA2, RSN) and the latter should refer to the physical characteristics of the hardware.

### Test Results

* None

### Reviewer Focus

* None

### Future Work

* Expose functionality to set the protocol in the higher layers.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
