### PR TITLE
Add Dot11SecurityProtocol to API

### DIFF
--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -163,10 +163,11 @@ message Dot11AccessPointConfiguration
 
 message Dot11AccessPointCapabilities
 {
-    repeated Microsoft.Net.Wifi.Dot11FrequencyBand FrequencyBands = 1;
+    repeated Microsoft.Net.Wifi.Dot11SecurityProtocol SecurityProtocols = 1;
     repeated Microsoft.Net.Wifi.Dot11PhyType PhyTypes = 2;
-    repeated Microsoft.Net.Wifi.Dot11AkmSuite AkmSuites = 3;
+    repeated Microsoft.Net.Wifi.Dot11FrequencyBand FrequencyBands = 3;
     repeated Microsoft.Net.Wifi.Dot11CipherSuite CipherSuites = 4;
+    repeated Microsoft.Net.Wifi.Dot11AkmSuite AkmSuites = 5;
 }
 
 enum Dot11AccessPointState

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -21,6 +21,21 @@ enum Dot11FrequencyBand
     Dot11FrequencyBandSixGHz = 3;
 }
 
+// 802.11 Security Protocol types.
+// This encompasses the major overall security characteristics and options for Wi-Fi networks.
+enum Dot11SecurityProtocol
+{
+    option allow_alias = true;
+
+    Wpa1 = 0;
+    Wpa2 = 1;
+    Wpa3 = 2;
+
+    // Aliases
+    Wpa = 0;
+    Rsn = 2;
+}
+
 // 802.11 PHY Types.
 // Values map to those defined in IEEE 802.11-2020, Annex C, Page 3934, 'dot11PHYType'.
 enum Dot11PhyType

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -27,13 +27,14 @@ enum Dot11SecurityProtocol
 {
     option allow_alias = true;
 
-    Wpa1 = 0;
-    Wpa2 = 1;
-    Wpa3 = 2;
+    Dot11SecurityProtocolUnknown = 0;
+    Dot11SecurityProtocolWpa1 = 1;
+    Dot11SecurityProtocolWpa2 = 2; 
+    Dot11SecurityProtocolWpa3 = 3;
 
     // Aliases
-    Wpa = 0;
-    Rsn = 2;
+    Dot11SecurityProtocolWpa = 1;
+    Dot11SecurityProtocolRsn = 3;
 }
 
 // 802.11 PHY Types.

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -45,6 +45,16 @@ NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::Dot11Access
 
     std::stringstream ss;
 
+    constexpr auto SecurityProtocolPrefixLength = std::size(std::string_view("Dot11SecurityProtocol"));
+    ss << indent0
+       << "Security Protocols: ";
+    for (const auto& securityProtocol : accessPointCapabilities.securityprotocols()) {
+        std::string_view securityProtocolName(magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11SecurityProtocol>(securityProtocol)));
+        securityProtocolName.remove_prefix(SecurityProtocolPrefixLength);
+        ss << '\n'
+           << indent1 << securityProtocolName;
+    }
+
     constexpr auto PhyTypePrefixLength = std::size(std::string_view("Dot11PhyType"));
     ss << indent0
        << "Phy Types: ";

--- a/src/common/wifi/core/Ieee80211AccessPointCapabilities.cxx
+++ b/src/common/wifi/core/Ieee80211AccessPointCapabilities.cxx
@@ -12,7 +12,14 @@ Ieee80211AccessPointCapabilities::ToString() const
 {
     std::ostringstream result{};
 
-    result << "PHY Types: ";
+    result << "Security Protocols: ";
+    for (const auto& securityProtocol : SecurityProtocols) {
+        result << magic_enum::enum_name(securityProtocol);
+        result << ' ';
+    }
+
+    result << '\n'
+           << "PHY Types: ";
     for (const auto& phyType : PhyTypes) {
         result << magic_enum::enum_name(phyType);
         result << ' ';

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -11,6 +11,16 @@
 
 namespace Microsoft::Net::Wifi
 {
+/**
+ * @brief Overall security protocol for an IEEE 802.11 network.
+ */
+enum class Ieee80211SecurityProtocol {
+    Unknown,
+    Wpa,
+    Wpa2,
+    Wpa3,
+};
+
 enum class Ieee80211FrequencyBand {
     Unknown,
     TwoPointFourGHz,

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
@@ -14,6 +14,7 @@ namespace Microsoft::Net::Wifi
  */
 struct Ieee80211AccessPointCapabilities
 {
+    std::vector<Ieee80211SecurityProtocol> SecurityProtocols;
     std::vector<Ieee80211PhyType> PhyTypes;
     std::vector<Ieee80211FrequencyBand> FrequencyBands;
     std::vector<Ieee80211AkmSuite> AkmSuites;

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -62,6 +62,43 @@ FromDot11AccessPointOperationStatusCode(WifiAccessPointOperationStatusCode wifiA
     }
 }
 
+using Microsoft::Net::Wifi::Dot11SecurityProtocol;
+using Microsoft::Net::Wifi::Ieee80211SecurityProtocol;
+
+Dot11SecurityProtocol
+ToDot11SecurityProtocol(Ieee80211SecurityProtocol ieee80211SecurityProtocol) noexcept
+{
+    switch (ieee80211SecurityProtocol) {
+    case Ieee80211SecurityProtocol::Wpa:
+        return Dot11SecurityProtocol::Dot11SecurityProtocolWpa1;
+    case Ieee80211SecurityProtocol::Wpa2:
+        return Dot11SecurityProtocol::Dot11SecurityProtocolWpa2;
+    case Ieee80211SecurityProtocol::Wpa3:
+        return Dot11SecurityProtocol::Dot11SecurityProtocolWpa3;
+    case Ieee80211SecurityProtocol::Unknown:
+        [[fallthrough]];
+    default:
+        return Dot11SecurityProtocol::Dot11SecurityProtocolUnknown;
+    }
+}
+
+Ieee80211SecurityProtocol
+FromDot11SecurityProtocol(Dot11SecurityProtocol dot11SecurityProtocol) noexcept
+{
+    switch (dot11SecurityProtocol) {
+    case Dot11SecurityProtocol::Dot11SecurityProtocolWpa1:
+        return Ieee80211SecurityProtocol::Wpa;
+    case Dot11SecurityProtocol::Dot11SecurityProtocolWpa2:
+        return Ieee80211SecurityProtocol::Wpa2;
+    case Dot11SecurityProtocol::Dot11SecurityProtocolWpa3:
+        return Ieee80211SecurityProtocol::Wpa3;
+    case Dot11SecurityProtocol::Dot11SecurityProtocolUnknown:
+        [[fallthrough]];
+    default:
+        return Ieee80211SecurityProtocol::Unknown;
+    }
+}
+
 using Microsoft::Net::Wifi::Dot11PhyType;
 using Microsoft::Net::Wifi::Ieee80211PhyType;
 
@@ -173,7 +210,7 @@ constexpr auto toDot11AuthenticationAlgorithm = [](const auto& authenticationAlg
 constexpr auto toDot11FrequencyBand = [](const auto& frequencyBand) {
     return static_cast<Dot11FrequencyBand>(frequencyBand);
 };
-} // details
+} // namespace detail
 
 std::vector<Dot11AuthenticationAlgorithm>
 ToDot11AuthenticationAlgorithms(const Dot11AccessPointConfiguration& dot11AccessPointConfiguration) noexcept
@@ -454,6 +491,8 @@ Dot11AccessPointCapabilities
 ToDot11AccessPointCapabilities(const Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) noexcept
 {
     Dot11AccessPointCapabilities dot11Capabilities{};
+
+    std::vector<Dot11SecurityProtocol> securityProtocols(std::size(ieee80211AccessPointCapabilities.SecurityProtocols));
 
     std::vector<Dot11PhyType> phyTypes(std::size(ieee80211AccessPointCapabilities.PhyTypes));
     std::ranges::transform(ieee80211AccessPointCapabilities.PhyTypes, std::begin(phyTypes), ToDot11PhyType);

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -493,6 +493,12 @@ ToDot11AccessPointCapabilities(const Ieee80211AccessPointCapabilities& ieee80211
     Dot11AccessPointCapabilities dot11Capabilities{};
 
     std::vector<Dot11SecurityProtocol> securityProtocols(std::size(ieee80211AccessPointCapabilities.SecurityProtocols));
+    std::ranges::transform(ieee80211AccessPointCapabilities.SecurityProtocols, std::begin(securityProtocols), ToDot11SecurityProtocol);
+
+    *dot11Capabilities.mutable_securityprotocols() = {
+        std::make_move_iterator(std::begin(securityProtocols)),
+        std::make_move_iterator(std::end(securityProtocols))
+    };
 
     std::vector<Dot11PhyType> phyTypes(std::size(ieee80211AccessPointCapabilities.PhyTypes));
     std::ranges::transform(ieee80211AccessPointCapabilities.PhyTypes, std::begin(phyTypes), ToDot11PhyType);

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -31,6 +31,24 @@ Microsoft::Net::Wifi::AccessPointOperationStatusCode
 FromDot11AccessPointOperationStatusCode(Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode wifiAccessPointOperationStatusCode) noexcept;
 
 /**
+ * @brief Convert the specified Ieee80211SecurityProtocol to the equivalent Dot11SecurityProtocol.
+ *
+ * @param ieee80211SecurityProtocol The IEEE 802.11 security protocol to convert.
+ * @return Microsoft::Net::Wifi::Dot11SecurityProtocol
+ */
+Microsoft::Net::Wifi::Dot11SecurityProtocol
+ToDot11SecurityProtocol(Microsoft::Net::Wifi::Ieee80211SecurityProtocol ieee80211SecurityProtocol) noexcept;
+
+/**
+ * @brief Convert the specified Dot11SecurityProtocol to the equivalent Ieee80211SecurityProtocol.
+ *
+ * @param dot11SecurityProtocol The Dot11SecurityProtocol to convert.
+ * @return Microsoft::Net::Wifi::Ieee80211SecurityProtocol
+ */
+Microsoft::Net::Wifi::Ieee80211SecurityProtocol
+FromDot11SecurityProtocol(Microsoft::Net::Wifi::Dot11SecurityProtocol dot11SecurityProtocol) noexcept;
+
+/**
  * @brief Convert the specified Dot11PhyType to the equivalent IEEE 802.11 protocol.
  *
  * @param ieee80211PhyType The IEEE 802.11 PHY type to convert.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure security protocol(s) can be configured on an AP.

### Technical Details

* Add `Dot11SecurityProtocol` enumeration to protobuf API.

### Test Results

* None

### Reviewer Focus

* None

### Future Work

* The API needs to be adjusted such that supported ciphers are bound to security protocols.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
