### PR TITLE
Change list of cipher suites in configuration api structure to map of security protocols -> cipher suites

### DIFF
--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -156,7 +156,7 @@ message Dot11AccessPointConfiguration
     Dot11Ssid Ssid = 1;
     Dot11MacAddress Bssid = 2;
     Dot11PhyType PhyType = 3;
-    Dot11CipherSuite CipherSuite = 4;
+    repeated Dot11CipherSuite CipherSuites = 4;
     repeated Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 5;
     repeated Dot11FrequencyBand FrequencyBands = 6;
 }

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -151,12 +151,18 @@ message Dot11SharedKey
     }
 }
 
+message Dot11CipherSuiteConfiguration
+{
+    Dot11SecurityProtocol SecurityProtocol = 1;
+    repeated Dot11CipherSuite CipherSuites = 2;
+}
+
 message Dot11AccessPointConfiguration
 {
     Dot11Ssid Ssid = 1;
     Dot11MacAddress Bssid = 2;
     Dot11PhyType PhyType = 3;
-    repeated Dot11CipherSuite CipherSuites = 4;
+    repeated Dot11CipherSuiteConfiguration CipherSuites = 4;
     repeated Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 5;
     repeated Dot11FrequencyBand FrequencyBands = 6;
 }

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -461,7 +461,7 @@ NetRemoteService::WifiAccessPointEnableImpl(std::string_view accessPointId, cons
             }
         }
 
-        if (dot11AccessPointConfiguration->ciphersuite() != Dot11CipherSuite::Dot11CipherSuiteUnknown) {
+        if (dot11AccessPointConfiguration->ciphersuites_size() > 0) {
             // TODO: set cipher suite.
         }
 

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -185,7 +185,7 @@ protected:
      * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
-    WifiAccessPointSetCipherSuitesImpl(std::string_view accessPointId, std::vector<Microsoft::Net::Wifi::Dot11CipherSuite>& dot11CipherSuites, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
+    WifiAccessPointSetCipherSuitesImpl(std::string_view accessPointId, std::unordered_map<Microsoft::Net::Wifi::Dot11SecurityProtocol, std::vector<Microsoft::Net::Wifi::Dot11CipherSuite>>& dot11CipherSuites, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
     /**
      * @brief Set the SSID of the access point.

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -176,6 +176,18 @@ protected:
     WifiAccessPointSetAuthenticationAlgorithsmImpl(std::string_view accessPointId, std::vector<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm>& dot11AuthenticationAlgorithms, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
     /**
+     * @brief Set the active cipher suites of the access point. If the access point is online, this will cause it to
+     * temporarily go offline while the change is being applied.
+     *
+     * @param accessPointId The access point identifier.
+     * @param dot11CipherSuites The new cipher suites to set.
+     * @param accessPointController The access point controller for the specified access point (optional).
+     * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+     */
+    Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+    WifiAccessPointSetCipherSuitesImpl(std::string_view accessPointId, std::vector<Microsoft::Net::Wifi::Dot11CipherSuite>& dot11CipherSuites, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
+
+    /**
      * @brief Set the SSID of the access point.
      *
      * @param accessPointId The access point identifier.

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <iterator>
 #include <ranges>
+#include <unordered_map>
 #include <vector>
 
 #include <microsoft/net/remote/protocol/NetRemoteWifi.pb.h>
@@ -482,6 +483,21 @@ FromDot11CipherSuite(const Dot11CipherSuite dot11CipherSuite) noexcept
     default:
         return Ieee80211CipherSuite::Unknown;
     }
+}
+
+std::unordered_map<Ieee80211SecurityProtocol, Ieee80211CipherSuite>
+FromDot11CipherSuiteConfigurations(const google::protobuf::RepeatedField<Dot11CipherSuiteConfiguration>& dot11CipherSuiteConfigurations) noexcept
+{
+    std::unordered_map<Ieee80211SecurityProtocol, Ieee80211CipherSuite> ieee80211CipherSuites{};
+
+    for (const auto& dot11CipherSuiteConfiguration : dot11CipherSuiteConfigurations) {
+        const auto& dot11CipherSuites = dot11CipherSuiteConfiguration.ciphersuites();
+        for (const auto& dot11CipherSuite : dot11CipherSuites) {
+            ieee80211CipherSuites.emplace(FromDot11SecurityProtocol(dot11CipherSuiteConfiguration.securityprotocol()), FromDot11CipherSuite(static_cast<Dot11CipherSuite>(dot11CipherSuite)));
+        }
+    }
+
+    return ieee80211CipherSuites;
 }
 
 using Microsoft::Net::Wifi::Dot11AccessPointCapabilities;

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -2,6 +2,7 @@
 #ifndef IEEE_80211_DOT11_ADAPTERS_HXX
 #define IEEE_80211_DOT11_ADAPTERS_HXX
 
+#include <unordered_map>
 #include <vector>
 
 #include <microsoft/net/remote/protocol/NetRemoteWifi.pb.h>
@@ -174,6 +175,15 @@ ToDot11CipherSuite(Microsoft::Net::Wifi::Ieee80211CipherSuite ieee80211CipherSui
  */
 Microsoft::Net::Wifi::Ieee80211CipherSuite
 FromDot11CipherSuite(Microsoft::Net::Wifi::Dot11CipherSuite dot11CipherSuite) noexcept;
+
+/**
+ * @brief Convert the list of Dot11CipherSuiteConfigurations to the equivalent list of IEEE 802.11 cipher suite configurations.
+ *
+ * @param dot11CipherSuiteConfigurations The list of Dot11CipherSuiteConfigurations to convert.
+ * @return std::unordered_map<Ieee80211SecurityProtocol, Ieee80211CipherSuite>
+ */
+std::unordered_map<Microsoft::Net::Wifi::Ieee80211SecurityProtocol, Microsoft::Net::Wifi::Ieee80211CipherSuite>
+FromDot11CipherSuiteConfigurations(const google::protobuf::RepeatedField<Microsoft::Net::Wifi::Dot11CipherSuiteConfiguration>& dot11CipherSuiteConfigurations) noexcept;
 
 /**
  * @brief Convert the specified IEEE 802.11 access point capabilities to the equivalent Dot11AccessPointCapabilities.

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -177,13 +177,22 @@ Microsoft::Net::Wifi::Ieee80211CipherSuite
 FromDot11CipherSuite(Microsoft::Net::Wifi::Dot11CipherSuite dot11CipherSuite) noexcept;
 
 /**
- * @brief Convert the list of Dot11CipherSuiteConfigurations to the equivalent list of IEEE 802.11 cipher suite configurations.
+ * @brief Convert the specified repeated field of Dot11CipherSuiteConfigurations to the equivalent map of Dot11SecurityProtocol to Dot11CipherSuite.
  *
- * @param dot11CipherSuiteConfigurations The list of Dot11CipherSuiteConfigurations to convert.
- * @return std::unordered_map<Ieee80211SecurityProtocol, Ieee80211CipherSuite>
+ * @param dot11CipherSuiteConfigurations The repeated field of Dot11CipherSuiteConfigurations to convert.
+ * @return std::unordered_map<Microsoft::Net::Wifi::Dot11SecurityProtocol, std::vector<Microsoft::Net::Wifi::Dot11CipherSuite>>
  */
-std::unordered_map<Microsoft::Net::Wifi::Ieee80211SecurityProtocol, Microsoft::Net::Wifi::Ieee80211CipherSuite>
-FromDot11CipherSuiteConfigurations(const google::protobuf::RepeatedField<Microsoft::Net::Wifi::Dot11CipherSuiteConfiguration>& dot11CipherSuiteConfigurations) noexcept;
+std::unordered_map<Microsoft::Net::Wifi::Dot11SecurityProtocol, std::vector<Microsoft::Net::Wifi::Dot11CipherSuite>>
+ToDot11CipherSuiteConfigurations(const google::protobuf::RepeatedPtrField<Microsoft::Net::Wifi::Dot11CipherSuiteConfiguration>& dot11CipherSuiteConfigurations) noexcept;
+
+/**
+ * @brief Convert the specified map of Dot11SecurityProtocol to Dot11CipherSuite to the equivalent map of IEEE 802.11 security protocol to cipher suite.
+ *
+ * @param dot11CipherSuiteConfigurations The map of Dot11SecurityProtocol to Dot11CipherSuite to convert.
+ * @return std::unordered_map<Microsoft::Net::Wifi::Ieee80211SecurityProtocol, std::vector<Microsoft::Net::Wifi::Ieee80211CipherSuite>>
+ */
+std::unordered_map<Microsoft::Net::Wifi::Ieee80211SecurityProtocol, std::vector<Microsoft::Net::Wifi::Ieee80211CipherSuite>>
+FromDot11CipherSuiteConfigurations(const std::unordered_map<Microsoft::Net::Wifi::Dot11SecurityProtocol, std::vector<Microsoft::Net::Wifi::Dot11CipherSuite>>& dot11CipherSuiteConfigurations) noexcept;
 
 /**
  * @brief Convert the specified IEEE 802.11 access point capabilities to the equivalent Dot11AccessPointCapabilities.

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -123,7 +123,7 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
         Dot11AccessPointConfiguration apConfiguration{};
         apConfiguration.mutable_ssid()->set_name(SsidName);
         apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
-        apConfiguration.set_ciphersuite(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
+        apConfiguration.mutable_ciphersuites()->Add(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
         apConfiguration.mutable_authenticationalgorithms()->Add(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
@@ -147,7 +147,7 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
     SECTION("Fails with invalid access point")
     {
         WifiAccessPointEnableRequest request{};
-        *request.mutable_configuration() = {}; 
+        *request.mutable_configuration() = {};
         request.set_accesspointid(InterfaceNameInvalid);
 
         WifiAccessPointEnableResult result{};
@@ -167,7 +167,7 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
         Dot11AccessPointConfiguration apConfiguration{};
         apConfiguration.mutable_ssid()->set_name(SsidName);
         apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
-        apConfiguration.set_ciphersuite(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
+        apConfiguration.mutable_ciphersuites()->Add(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
         apConfiguration.mutable_authenticationalgorithms()->Add(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
 

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -120,10 +120,14 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
 
     SECTION("Can be called")
     {
+        Dot11CipherSuiteConfiguration dot11CipherSuiteConfigurationWpa1{};
+        dot11CipherSuiteConfigurationWpa1.set_securityprotocol(Dot11SecurityProtocol::Dot11SecurityProtocolWpa);
+        dot11CipherSuiteConfigurationWpa1.mutable_ciphersuites()->Add(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
+
         Dot11AccessPointConfiguration apConfiguration{};
-        apConfiguration.mutable_ssid()->set_name(SsidName);
         apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
-        apConfiguration.mutable_ciphersuites()->Add(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
+        apConfiguration.mutable_ssid()->set_name(SsidName);
+        apConfiguration.mutable_ciphersuites()->Add(std::move(dot11CipherSuiteConfigurationWpa1));
         apConfiguration.mutable_authenticationalgorithms()->Add(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
@@ -163,11 +167,15 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
 
     SECTION("Succeeds without access point configuration if already configured")
     {
+        Dot11CipherSuiteConfiguration dot11CipherSuiteConfigurationWpa1{};
+        dot11CipherSuiteConfigurationWpa1.set_securityprotocol(Dot11SecurityProtocol::Dot11SecurityProtocolWpa);
+        dot11CipherSuiteConfigurationWpa1.mutable_ciphersuites()->Add(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
+
         // Perform initial enable with configuration.
         Dot11AccessPointConfiguration apConfiguration{};
-        apConfiguration.mutable_ssid()->set_name(SsidName);
         apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
-        apConfiguration.mutable_ciphersuites()->Add(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
+        apConfiguration.mutable_ssid()->set_name(SsidName);
+        apConfiguration.mutable_ciphersuites()->Add(std::move(dot11CipherSuiteConfigurationWpa1));
         apConfiguration.mutable_authenticationalgorithms()->Add(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [X] Breaking change
- [ ] Non-functional change

### Goals

* Ensure cipher suites are associated with overall security protocol since multiple security protocols can be supported, and each can expose its own set of supported ciphers.

### Technical Details

* Change `Dot11AccessPointConfiguration::CipherSuite` single member field to be a list of `Dot11CipherSuiteConfiguration` items. 
    * The `Dot11CipherSuiteConfiguration` message is defined to essentially be a single dimension of a map entry, with a `Dot11SecurityProtocol` as key and a list of `Dot11CipherSuite` as value. 
    * This enables the top-level `CipherSuites` field to act as a map, working around the restriction that protobuf map values cannot be `repeated` fields.
* Add `WifiAccessPointSetCipherSuitesImpl` and call this from `WifiAccessPointEnableImpl`.
* Add Dot11 <-> 802.11 adaption helper functions.

### Test Results

* All unit tests pass.

### Reviewer Focus

* The design is currently influenced by hostapd's interface which allows multiple ciphers per "WPA protocol". This might not be the case for other AP control software, so it's important to ensure this encoding can satisfy other frameworks. Consider whether there are any other encodings that could be more suitable.

### Future Work

* Additional unit tests for the updated field would be useful.
* Implement setting cipher suites in `IAccessPointController`.
* Expose ability to enable/disable APs from cli.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
