### PR TITLE
Add ability to configure pairwise ciphers from AccessPointEnable API

### DIFF
--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -162,7 +162,7 @@ message Dot11AccessPointConfiguration
     Dot11Ssid Ssid = 1;
     Dot11MacAddress Bssid = 2;
     Dot11PhyType PhyType = 3;
-    repeated Dot11CipherSuiteConfiguration CipherSuites = 4;
+    repeated Dot11CipherSuiteConfiguration PairwiseCipherSuites = 4;
     repeated Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 5;
     repeated Dot11FrequencyBand FrequencyBands = 6;
 }

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -462,9 +462,9 @@ NetRemoteService::WifiAccessPointEnableImpl(std::string_view accessPointId, cons
             }
         }
 
-        if (dot11AccessPointConfiguration->ciphersuites_size() > 0) {
-            auto dot11CipherSuites = ToDot11CipherSuiteConfigurations(dot11AccessPointConfiguration->ciphersuites());
-            wifiOperationStatus = WifiAccessPointSetCipherSuitesImpl(accessPointId, dot11CipherSuites, accessPointController);
+        if (dot11AccessPointConfiguration->pairwiseciphersuites_size() > 0) {
+            auto dot11PairwiseCipherSuites = ToDot11CipherSuiteConfigurations(dot11AccessPointConfiguration->pairwiseciphersuites());
+            wifiOperationStatus = WifiAccessPointSetPairwiseCipherSuitesImpl(accessPointId, dot11PairwiseCipherSuites, accessPointController);
             if (wifiOperationStatus.code() != WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded) {
                 return wifiOperationStatus;
             }
@@ -686,17 +686,17 @@ NetRemoteService::WifiAccessPointSetAuthenticationAlgorithsmImpl(std::string_vie
 }
 
 WifiAccessPointOperationStatus
-NetRemoteService::WifiAccessPointSetCipherSuitesImpl(std::string_view accessPointId, std::unordered_map<Dot11SecurityProtocol, std::vector<Dot11CipherSuite>>& dot11CipherSuites, std::shared_ptr<IAccessPointController> accessPointController)
+NetRemoteService::WifiAccessPointSetPairwiseCipherSuitesImpl(std::string_view accessPointId, std::unordered_map<Dot11SecurityProtocol, std::vector<Dot11CipherSuite>>& dot11PairwiseCipherSuites, std::shared_ptr<IAccessPointController> accessPointController)
 {
     WifiAccessPointOperationStatus wifiOperationStatus{};
 
     // Validate basic parameters in the request.
-    if (std::empty(dot11CipherSuites)) {
+    if (std::empty(dot11PairwiseCipherSuites)) {
         wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
         wifiOperationStatus.set_message("No cipher suites provided");
         return wifiOperationStatus;
     }
-    if (std::ranges::contains(dot11CipherSuites | std::views::keys, Dot11SecurityProtocol::Dot11SecurityProtocolUnknown)) {
+    if (std::ranges::contains(dot11PairwiseCipherSuites | std::views::keys, Dot11SecurityProtocol::Dot11SecurityProtocolUnknown)) {
         wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
         wifiOperationStatus.set_message("Invalid security protocol provided");
         return wifiOperationStatus;
@@ -715,7 +715,7 @@ NetRemoteService::WifiAccessPointSetCipherSuitesImpl(std::string_view accessPoin
     }
 
     // Convert to 802.11 neutral type.
-    auto ieee80211CipherSuites = FromDot11CipherSuiteConfigurations(dot11CipherSuites);
+    auto ieee80211CipherSuites = FromDot11CipherSuiteConfigurations(dot11PairwiseCipherSuites);
     if (std::ranges::contains(ieee80211CipherSuites | std::views::keys, Ieee80211SecurityProtocol::Unknown)) {
         wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
         wifiOperationStatus.set_message("Invalid security protocol provided");

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -723,8 +723,7 @@ NetRemoteService::WifiAccessPointSetPairwiseCipherSuitesImpl(std::string_view ac
     }
 
     // Set the cipher suites.
-    operationStatus.Code = AccessPointOperationStatusCode::OperationNotSupported;
-    // TODO: operationStatus = accessPointController->SetCipherSuites(std::move(ieee80211CipherSuites));
+    operationStatus = accessPointController->SetPairwiseCipherSuites(std::move(ieee80211CipherSuites));
     if (!operationStatus.Succeeded()) {
         wifiOperationStatus.set_code(ToDot11AccessPointOperationStatusCode(operationStatus.Code));
         wifiOperationStatus.set_message(std::format("Failed to set cipher suites for access point {} - {}", accessPointId, operationStatus.ToString()));

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -180,12 +180,12 @@ protected:
      * temporarily go offline while the change is being applied.
      *
      * @param accessPointId The access point identifier.
-     * @param dot11CipherSuites The new cipher suites to set.
+     * @param dot11PairwiseCipherSuites The new pairwise cipher suites to set.
      * @param accessPointController The access point controller for the specified access point (optional).
      * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
-    WifiAccessPointSetCipherSuitesImpl(std::string_view accessPointId, std::unordered_map<Microsoft::Net::Wifi::Dot11SecurityProtocol, std::vector<Microsoft::Net::Wifi::Dot11CipherSuite>>& dot11CipherSuites, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
+    WifiAccessPointSetPairwiseCipherSuitesImpl(std::string_view accessPointId, std::unordered_map<Microsoft::Net::Wifi::Dot11SecurityProtocol, std::vector<Microsoft::Net::Wifi::Dot11CipherSuite>>& dot11PairwiseCipherSuites, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
     /**
      * @brief Set the SSID of the access point.

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPointOperationStatus.hxx
@@ -60,7 +60,7 @@ struct AccessPointOperationStatus
             }
             pos = OperationName.find_last_of(':');
             if (pos != std::string::npos) {
-                OperationName.erase(0, pos);
+                OperationName.erase(0, pos + 1);
             }
         }
     }

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
@@ -95,11 +96,20 @@ struct IAccessPointController
     /**
      * @brief Set the authentication algorithms the access point should enable.
      *
-     * @param authenticationAlgorithms The authentication algorithms to be allow.
+     * @param authenticationAlgorithms The authentication algorithms to be allowed.
      * @return AccessPointOperationStatus
      */
     virtual AccessPointOperationStatus
     SetAuthenticationAlgorithms(std::vector<Ieee80211AuthenticationAlgorithm> authenticationAlgorithms) noexcept = 0;
+
+    /**
+     * @brief Set the pairwise cipher suites the access point should enable. These are used to encrypt unicast packets.
+     *
+     * @param pairwiseCipherSuites The pairwise cipher suites to enable.
+     * @return AccessPointOperationStatus
+     */
+    virtual AccessPointOperationStatus
+    SetPairwiseCipherSuites(std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> pairwiseCipherSuites) noexcept = 0;
 
     /**
      * @brief Set the SSID of the access point.

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -1,6 +1,5 @@
 
 #include <algorithm>
-#include <cstddef>
 #include <iterator>
 #include <ranges>
 #include <unordered_map>
@@ -12,7 +11,6 @@
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
 #include <microsoft/net/wifi/Ieee80211Dot11Adapters.hxx>
-#include <notstd/Exceptions.hxx>
 
 namespace Microsoft::Net::Wifi
 {
@@ -569,12 +567,6 @@ ToDot11AccessPointCapabilities(const Ieee80211AccessPointCapabilities& ieee80211
     };
 
     return dot11Capabilities;
-}
-
-Ieee80211AccessPointCapabilities
-FromDot11AccessPointCapabilities([[maybe_unused]] const Dot11AccessPointCapabilities& dot11AccessPointCapabilities) /* noexcept */
-{
-    throw notstd::NotImplementedException();
 }
 
 } // namespace Microsoft::Net::Wifi

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -203,15 +203,6 @@ FromDot11CipherSuiteConfigurations(const std::unordered_map<Microsoft::Net::Wifi
 Microsoft::Net::Wifi::Dot11AccessPointCapabilities
 ToDot11AccessPointCapabilities(const Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) noexcept;
 
-/**
- * @brief Convert the specified Dot11AccessPointCapabilities to the equivalent IEEE 802.11 access point capabilities.
- *
- * @param dot11AccessPointCapabilities The Dot11AccessPointCapabilities to convert.
- * @return Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities
- */
-Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities
-FromDot11AccessPointCapabilities(const Microsoft::Net::Wifi::Dot11AccessPointCapabilities& dot11AccessPointCapabilities) /* noexcept */;
-
 } // namespace Microsoft::Net::Wifi
 
 #endif // IEEE_80211_DOT11_ADAPTERS_HXX

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -286,6 +286,15 @@ AccessPointControllerLinux::SetPairwiseCipherSuites([[maybe_unused]] std::unorde
     AccessPointOperationStatus status{ GetInterfaceName() };
     const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
 
+    // Ensure at least one pairwise cipher suite is requested.
+    if (std::empty(pairwiseCipherSuites)) {
+        status.Code = AccessPointOperationStatusCode::InvalidParameter;
+        status.Details = "no pairwise cipher suites specified";
+        return status;
+    }
+
+    auto pairwiseCipherSuitesWpa = Ieee80211CipherSuitesToWpaCipherSuites(pairwiseCipherSuites);
+
     // TODO
 
     status.Code = AccessPointOperationStatusCode::Succeeded;

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -293,7 +293,7 @@ AccessPointControllerLinux::SetPairwiseCipherSuites([[maybe_unused]] std::unorde
         return status;
     }
 
-    auto pairwiseCipherSuitesWpa = Ieee80211CipherSuitesToWpaCipherSuites(pairwiseCipherSuites);
+    auto pairwiseCipherSuitesHostapd = Ieee80211CipherSuitesToWpaCipherSuites(pairwiseCipherSuites);
 
     // TODO
 

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -9,6 +9,7 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -276,6 +277,18 @@ AccessPointControllerLinux::SetAuthenticationAlgorithms(std::vector<Ieee80211Aut
 
     status.Code = AccessPointOperationStatusCode::Succeeded;
 
+    return status;
+}
+
+AccessPointOperationStatus
+AccessPointControllerLinux::SetPairwiseCipherSuites([[maybe_unused]] std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> pairwiseCipherSuites) noexcept
+{
+    AccessPointOperationStatus status{ GetInterfaceName() };
+    const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
+
+    // TODO
+
+    status.Code = AccessPointOperationStatusCode::Succeeded;
     return status;
 }
 

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -281,7 +281,7 @@ AccessPointControllerLinux::SetAuthenticationAlgorithms(std::vector<Ieee80211Aut
 }
 
 AccessPointOperationStatus
-AccessPointControllerLinux::SetPairwiseCipherSuites([[maybe_unused]] std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> pairwiseCipherSuites) noexcept
+AccessPointControllerLinux::SetPairwiseCipherSuites(std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> pairwiseCipherSuites) noexcept
 {
     AccessPointOperationStatus status{ GetInterfaceName() };
     const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
@@ -295,7 +295,13 @@ AccessPointControllerLinux::SetPairwiseCipherSuites([[maybe_unused]] std::unorde
 
     auto pairwiseCipherSuitesHostapd = Ieee80211CipherSuitesToWpaCipherSuites(pairwiseCipherSuites);
 
-    // TODO
+    try {
+        m_hostapd.SetPairwiseCipherSuites(pairwiseCipherSuitesHostapd, EnforceConfigurationChange::Now);
+    } catch (const Wpa::HostapdException& e) {
+        status.Code = AccessPointOperationStatusCode::InternalError;
+        status.Details = std::format("failed to set pairwise cipher suites - {}", e.what());
+        return status;
+    }
 
     status.Code = AccessPointOperationStatusCode::Succeeded;
     return status;

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
@@ -102,12 +102,72 @@ Ieee80211AuthenticationAlgorithmToWpaAuthenticationAlgorithm(Ieee80211Authentica
     }
 }
 
-std::unordered_map<WpaSecurityProtocol, WpaCipher>
-Ieee80211CipherSuitesToWpaCipherSuites([[maybe_unused]] const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuites) noexcept
+WpaSecurityProtocol
+Ieee80211SecurityProtocolToWpaSecurityProtocol(Ieee80211SecurityProtocol ieee80211SecurityProtocol) noexcept
 {
-    std::unordered_map<WpaSecurityProtocol, WpaCipher> wpaCipherSuites{};
+    switch (ieee80211SecurityProtocol) {
+    case Ieee80211SecurityProtocol::Wpa:
+        return WpaSecurityProtocol::Wpa;
+    case Ieee80211SecurityProtocol::Wpa2:
+        return WpaSecurityProtocol::Wpa2;
+    case Ieee80211SecurityProtocol::Wpa3:
+        return WpaSecurityProtocol::Wpa3;
+    case Ieee80211SecurityProtocol::Unknown:
+        [[fallthrough]];
+    default:
+        return WpaSecurityProtocol::Unknown;
+    }
+}
 
-    // TODO:
+WpaCipher
+Ieee80211CipherSuiteToWpaCipher(Ieee80211CipherSuite ieee80211CipherSuite) noexcept
+{
+    switch (ieee80211CipherSuite) {
+    case Ieee80211CipherSuite::BipCmac128:
+        return WpaCipher::Aes128Cmac;
+    case Ieee80211CipherSuite::BipCmac256:
+        return WpaCipher::BipCmac256;
+    case Ieee80211CipherSuite::BipGmac128:
+        return WpaCipher::BipGmac128;
+    case Ieee80211CipherSuite::BipGmac256:
+        return WpaCipher::BipGmac256;
+    case Ieee80211CipherSuite::Ccmp128:
+        return WpaCipher::Ccmp;
+    case Ieee80211CipherSuite::Ccmp256:
+        return WpaCipher::Ccmp256;
+    case Ieee80211CipherSuite::Gcmp128:
+        return WpaCipher::Gcmp;
+    case Ieee80211CipherSuite::Gcmp256:
+        return WpaCipher::Gcmp256;
+    case Ieee80211CipherSuite::GroupAddressesTrafficNotAllowed:
+        return WpaCipher::GtkNotUsed;
+    case Ieee80211CipherSuite::Tkip:
+        return WpaCipher::Tkip;
+    case Ieee80211CipherSuite::UseGroup:
+        return WpaCipher::None;
+    case Ieee80211CipherSuite::Wep104:
+        return WpaCipher::Wep104;
+    case Ieee80211CipherSuite::Wep40:
+        return WpaCipher::Wep40;
+    case Ieee80211CipherSuite::Unknown:
+        [[fallthrough]];
+    default:
+        return WpaCipher::Unknown;
+    }
+}
+
+std::unordered_map<WpaSecurityProtocol, std::vector<WpaCipher>>
+Ieee80211CipherSuitesToWpaCipherSuites(const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuitesConfigurations) noexcept
+{
+    std::unordered_map<WpaSecurityProtocol, std::vector<WpaCipher>> wpaCipherSuites{};
+
+    for (const auto& [ieee80211SecurityProtocol, ieee80211CipherSuites] : ieee80211CipherSuitesConfigurations) {
+        WpaSecurityProtocol wpaSecurityProtocol = Ieee80211SecurityProtocolToWpaSecurityProtocol(ieee80211SecurityProtocol);
+        std::vector<WpaCipher> cipherSuitesWpa(std::size(ieee80211CipherSuites));
+        std::ranges::transform(ieee80211CipherSuites, std::begin(cipherSuitesWpa), Ieee80211CipherSuiteToWpaCipher);
+
+        wpaCipherSuites.emplace(wpaSecurityProtocol, std::move(cipherSuitesWpa));
+    }
 
     return wpaCipherSuites;
 }

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
@@ -102,10 +102,10 @@ Ieee80211AuthenticationAlgorithmToWpaAuthenticationAlgorithm(Ieee80211Authentica
     }
 }
 
-std::unordered_map<WpaProtocol, WpaCipher>
+std::unordered_map<WpaSecurityProtocol, WpaCipher>
 Ieee80211CipherSuitesToWpaCipherSuites([[maybe_unused]] const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuites) noexcept
 {
-    std::unordered_map<WpaProtocol, WpaCipher> wpaCipherSuites{};
+    std::unordered_map<WpaSecurityProtocol, WpaCipher> wpaCipherSuites{};
 
     // TODO:
 

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
@@ -101,4 +101,14 @@ Ieee80211AuthenticationAlgorithmToWpaAuthenticationAlgorithm(Ieee80211Authentica
         return WpaAuthenticationAlgorithm::Invalid;
     }
 }
+
+std::unordered_map<WpaProtocol, WpaCipher>
+Ieee80211CipherSuitesToWpaCipherSuites([[maybe_unused]] const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuites) noexcept
+{
+    std::unordered_map<WpaProtocol, WpaCipher> wpaCipherSuites{};
+
+    // TODO:
+
+    return wpaCipherSuites;
+}
 } // namespace Microsoft::Net::Wifi

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
@@ -48,13 +48,31 @@ Wpa::WpaAuthenticationAlgorithm
 Ieee80211AuthenticationAlgorithmToWpaAuthenticationAlgorithm(Ieee80211AuthenticationAlgorithm ieee80211AuthenticationAlgorithm) noexcept;
 
 /**
+ * @brief Convert a Ieee80211SecurityProtocol to a WpaSecurityProtocol.
+ * 
+ * @param ieee80211SecurityProtocol The Ieee80211SecurityProtocol to convert.
+ * @return Wpa::WpaSecurityProtocol 
+ */
+Wpa::WpaSecurityProtocol
+Ieee80211SecurityProtocolToWpaSecurityProtocol(Ieee80211SecurityProtocol ieee80211SecurityProtocol) noexcept;
+
+/**
+ * @brief Convert a Ieee80211CipherSuite to a WpaCipher.
+ * 
+ * @param ieee80211CipherSuite The Ieee80211CipherSuite to convert.
+ * @return Wpa::WpaCipher 
+ */
+Wpa::WpaCipher
+Ieee80211CipherSuiteToWpaCipher(Ieee80211CipherSuite ieee80211CipherSuite) noexcept;
+
+/**
  * @brief Convert a map of Ieee80211SecurityProtocol to list of Ieee80211CipherSuite to a map of WpaSecurityProtocol to list of WpaCipher.
  * 
- * @param ieee80211CipherSuites The map of Ieee80211SecurityProtocol to list of Ieee80211CipherSuite to convert.
- * @return std::unordered_map<Wpa::WpaSecurityProtocol, Wpa::WpaCipher> 
+ * @param ieee80211CipherSuiteConfigurations The map of Ieee80211SecurityProtocol to list of Ieee80211CipherSuite to convert.
+ * @return std::unordered_map<Wpa::WpaSecurityProtocol, std::vector<Wpa::WpaCipher>> 
  */
-std::unordered_map<Wpa::WpaSecurityProtocol, Wpa::WpaCipher>
-Ieee80211CipherSuitesToWpaCipherSuites(const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuites) noexcept;
+std::unordered_map<Wpa::WpaSecurityProtocol, std::vector<Wpa::WpaCipher>>
+Ieee80211CipherSuitesToWpaCipherSuites(const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuiteConfigurations) noexcept;
 } // namespace Microsoft::Net::Wifi
 
 #endif // IEEE_80211_WPA_ADAPTERS_HXX

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <string_view>
+#include <unordered_map>
 
 #include <Wpa/ProtocolHostapd.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
@@ -45,6 +46,15 @@ IeeeFrequencyBandToHostapdBand(Ieee80211FrequencyBand ieeeFrequencyBand) noexcep
  */
 Wpa::WpaAuthenticationAlgorithm
 Ieee80211AuthenticationAlgorithmToWpaAuthenticationAlgorithm(Ieee80211AuthenticationAlgorithm ieee80211AuthenticationAlgorithm) noexcept;
+
+/**
+ * @brief Convert a map of Ieee80211SecurityProtocol to list of Ieee80211CipherSuite to a map of WpaProtocol to list of WpaCipher.
+ * 
+ * @param ieee80211CipherSuites The map of Ieee80211SecurityProtocol to list of Ieee80211CipherSuite to convert.
+ * @return std::unordered_map<Wpa::WpaProtocol, Wpa::WpaCipher> 
+ */
+std::unordered_map<Wpa::WpaProtocol, Wpa::WpaCipher>
+Ieee80211CipherSuitesToWpaCipherSuites(const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuites) noexcept;
 } // namespace Microsoft::Net::Wifi
 
 #endif // IEEE_80211_WPA_ADAPTERS_HXX

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
@@ -48,12 +48,12 @@ Wpa::WpaAuthenticationAlgorithm
 Ieee80211AuthenticationAlgorithmToWpaAuthenticationAlgorithm(Ieee80211AuthenticationAlgorithm ieee80211AuthenticationAlgorithm) noexcept;
 
 /**
- * @brief Convert a map of Ieee80211SecurityProtocol to list of Ieee80211CipherSuite to a map of WpaProtocol to list of WpaCipher.
+ * @brief Convert a map of Ieee80211SecurityProtocol to list of Ieee80211CipherSuite to a map of WpaSecurityProtocol to list of WpaCipher.
  * 
  * @param ieee80211CipherSuites The map of Ieee80211SecurityProtocol to list of Ieee80211CipherSuite to convert.
- * @return std::unordered_map<Wpa::WpaProtocol, Wpa::WpaCipher> 
+ * @return std::unordered_map<Wpa::WpaSecurityProtocol, Wpa::WpaCipher> 
  */
-std::unordered_map<Wpa::WpaProtocol, Wpa::WpaCipher>
+std::unordered_map<Wpa::WpaSecurityProtocol, Wpa::WpaCipher>
 Ieee80211CipherSuitesToWpaCipherSuites(const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuites) noexcept;
 } // namespace Microsoft::Net::Wifi
 

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include <Wpa/Hostapd.hxx>
@@ -98,6 +99,15 @@ struct AccessPointControllerLinux :
      */
     AccessPointOperationStatus
     SetAuthenticationAlgorithms(std::vector<Ieee80211AuthenticationAlgorithm> authenticationAlgorithms) noexcept override;
+
+    /**
+     * @brief Set the pairwise cipher suites the access point should enable. These are used to encrypt unicast packets.
+     *
+     * @param pairwiseCipherSuites The pairwise cipher suites to enable.
+     * @return AccessPointOperationStatus
+     */
+    AccessPointOperationStatus
+    SetPairwiseCipherSuites(std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> pairwiseCipherSuites) noexcept override;
 
     /**
      * @brief Set the SSID of the access point.

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -289,19 +289,19 @@ Hostapd::SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceC
 }
 
 void
-Hostapd::SetCipherSuites(WpaProtocol protocol, std::vector<WpaCipher> ciphers, EnforceConfigurationChange enforceConfigurationChange)
+Hostapd::SetPairwiseCipherSuites(WpaProtocol protocol, std::vector<WpaCipher> pairwiseCiphers, EnforceConfigurationChange enforceConfigurationChange)
 {
-    SetCipherSuites({ { protocol, std::move(ciphers) } }, enforceConfigurationChange);
+    SetPairwiseCipherSuites({ { protocol, std::move(pairwiseCiphers) } }, enforceConfigurationChange);
 }
 
 void
-Hostapd::SetCipherSuites(std::unordered_map<WpaProtocol, std::vector<WpaCipher>> protocolCipherMap, EnforceConfigurationChange enforceConfigurationChange)
+Hostapd::SetPairwiseCipherSuites(std::unordered_map<WpaProtocol, std::vector<WpaCipher>> protocolPairwiseCipherMap, EnforceConfigurationChange enforceConfigurationChange)
 {
-    if (std::empty(protocolCipherMap)) {
+    if (std::empty(protocolPairwiseCipherMap)) {
         throw HostapdException("No WPA cipher suites were provided");
     }
 
-    for (const auto& [protocol, ciphers] : protocolCipherMap) {
+    for (const auto& [protocol, ciphers] : protocolPairwiseCipherMap) {
         if (std::empty(ciphers)) {
             throw HostapdException(std::format("No WPA cipher suites were provided for protocol '{}'", magic_enum::enum_name(protocol)));
         }

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -234,7 +234,7 @@ Hostapd::SetAuthenticationAlgorithms(std::vector<WpaAuthenticationAlgorithm> alg
 }
 
 void
-Hostapd::SetWpaProtocols(std::vector<WpaProtocol> protocols, EnforceConfigurationChange enforceConfigurationChange)
+Hostapd::SetWpaSecurityProtocols(std::vector<WpaSecurityProtocol> protocols, EnforceConfigurationChange enforceConfigurationChange)
 {
     if (std::empty(protocols)) {
         throw HostapdException("No WPA protocols were provided");
@@ -242,18 +242,18 @@ Hostapd::SetWpaProtocols(std::vector<WpaProtocol> protocols, EnforceConfiguratio
 
     uint32_t protocolsToSet = 0;
     for (const auto protocol : protocols) {
-        const auto protocolValue = WpaProtocolPropertyValue(protocol);
-        if ((protocolValue & ~WpaProtocolMask) != 0) {
+        const auto protocolValue = WpaSecurityProtocolPropertyValue(protocol);
+        if ((protocolValue & ~WpaSecurityProtocolMask) != 0) {
             throw HostapdException(std::format("Invalid WPA protocol value '{}'", protocolValue));
         }
         protocolsToSet |= protocolValue;
     }
 
-    protocolsToSet &= WpaProtocolMask;
+    protocolsToSet &= WpaSecurityProtocolMask;
 
     const auto protocolsValue = std::format("{}", protocolsToSet);
     try {
-        SetProperty(ProtocolHostapd::PropertyNameWpaProtocol, protocolsValue, enforceConfigurationChange);
+        SetProperty(ProtocolHostapd::PropertyNameWpaSecurityProtocol, protocolsValue, enforceConfigurationChange);
     } catch (HostapdException& e) {
         throw HostapdException(std::format("Failed to set hostapd 'wpa' property to '{}' ({})", protocolsValue, e.what()));
     }
@@ -289,13 +289,13 @@ Hostapd::SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceC
 }
 
 void
-Hostapd::SetPairwiseCipherSuites(WpaProtocol protocol, std::vector<WpaCipher> pairwiseCiphers, EnforceConfigurationChange enforceConfigurationChange)
+Hostapd::SetPairwiseCipherSuites(WpaSecurityProtocol protocol, std::vector<WpaCipher> pairwiseCiphers, EnforceConfigurationChange enforceConfigurationChange)
 {
     SetPairwiseCipherSuites({ { protocol, std::move(pairwiseCiphers) } }, enforceConfigurationChange);
 }
 
 void
-Hostapd::SetPairwiseCipherSuites(std::unordered_map<WpaProtocol, std::vector<WpaCipher>> protocolPairwiseCipherMap, EnforceConfigurationChange enforceConfigurationChange)
+Hostapd::SetPairwiseCipherSuites(std::unordered_map<WpaSecurityProtocol, std::vector<WpaCipher>> protocolPairwiseCipherMap, EnforceConfigurationChange enforceConfigurationChange)
 {
     if (std::empty(protocolPairwiseCipherMap)) {
         throw HostapdException("No WPA cipher suites were provided");

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -115,7 +115,7 @@ struct Hostapd :
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     void
-    SetWpaProtocols(std::vector<WpaProtocol> protocols, EnforceConfigurationChange enforceConfigurationChange = EnforceConfigurationChange::Now) override;
+    SetWpaSecurityProtocols(std::vector<WpaSecurityProtocol> protocols, EnforceConfigurationChange enforceConfigurationChange = EnforceConfigurationChange::Now) override;
 
     /**
      * @brief Set the allowed key management algorithms for the interfacallowed key management algorithms for the interface.
@@ -134,7 +134,7 @@ struct Hostapd :
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     void
-    SetPairwiseCipherSuites(WpaProtocol protocol, std::vector<WpaCipher> pairwiseCiphers, EnforceConfigurationChange enforceConfigurationChange) override;
+    SetPairwiseCipherSuites(WpaSecurityProtocol protocol, std::vector<WpaCipher> pairwiseCiphers, EnforceConfigurationChange enforceConfigurationChange) override;
 
     /**
      * @brief Set the allowed pairwise cipher suites for the interface.
@@ -143,7 +143,7 @@ struct Hostapd :
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     void
-    SetPairwiseCipherSuites(std::unordered_map<WpaProtocol, std::vector<WpaCipher>> protocolPairwiseCipherMap, EnforceConfigurationChange enforceConfigurationChange) override;
+    SetPairwiseCipherSuites(std::unordered_map<WpaSecurityProtocol, std::vector<WpaCipher>> protocolPairwiseCipherMap, EnforceConfigurationChange enforceConfigurationChange) override;
 
 private:
     const std::string m_interface;

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -127,23 +127,23 @@ struct Hostapd :
     SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceConfigurationChange enforceConfigurationChange = EnforceConfigurationChange::Now) override;
 
     /**
-     * @brief Set the allowed cipher suites for the interface.
+     * @brief Set the allowed pairwise cipher suites for the interface.
      *
      * @param protocol The WPA protocol to set the cipher suites for.
-     * @param ciphers The ciphers to allow.
+     * @param pairwiseCiphers The ciphers to allow.
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     void
-    SetCipherSuites(WpaProtocol protocol, std::vector<WpaCipher> ciphers, EnforceConfigurationChange enforceConfigurationChange) override;
+    SetPairwiseCipherSuites(WpaProtocol protocol, std::vector<WpaCipher> pairwiseCiphers, EnforceConfigurationChange enforceConfigurationChange) override;
 
     /**
-     * @brief Set the allowed cipher suites for the interface.
+     * @brief Set the allowed pairwise cipher suites for the interface.
      *
-     * @param protocolCipherMap map specifying the ciphers to allow for each protocol.
+     * @param protocolPairwiseCipherMap Map specifying the pairwise ciphers to allow for each protocol.
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     void
-    SetCipherSuites(std::unordered_map<WpaProtocol, std::vector<WpaCipher>> protocolCipherMap, EnforceConfigurationChange enforceConfigurationChange) override;
+    SetPairwiseCipherSuites(std::unordered_map<WpaProtocol, std::vector<WpaCipher>> protocolPairwiseCipherMap, EnforceConfigurationChange enforceConfigurationChange) override;
 
 private:
     const std::string m_interface;

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -140,7 +140,7 @@ struct IHostapd
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     virtual void
-    SetWpaProtocols(std::vector<WpaProtocol> protocols, EnforceConfigurationChange enforceConfigurationChange) = 0;
+    SetWpaSecurityProtocols(std::vector<WpaSecurityProtocol> protocols, EnforceConfigurationChange enforceConfigurationChange) = 0;
 
     /**
      * @brief Set the allowed key management algorithms for the interfacallowed key management algorithms for the interface.
@@ -159,7 +159,7 @@ struct IHostapd
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     virtual void
-    SetPairwiseCipherSuites(WpaProtocol protocol, std::vector<WpaCipher> ciphers, EnforceConfigurationChange enforceConfigurationChange) = 0;
+    SetPairwiseCipherSuites(WpaSecurityProtocol protocol, std::vector<WpaCipher> ciphers, EnforceConfigurationChange enforceConfigurationChange) = 0;
 
     /**
      * @brief Set the allowed pairwise cipher suites for the interface.
@@ -168,7 +168,7 @@ struct IHostapd
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     virtual void
-    SetPairwiseCipherSuites(std::unordered_map<WpaProtocol, std::vector<WpaCipher>> protocolCipherMap, EnforceConfigurationChange enforceConfigurationChange) = 0;
+    SetPairwiseCipherSuites(std::unordered_map<WpaSecurityProtocol, std::vector<WpaCipher>> protocolCipherMap, EnforceConfigurationChange enforceConfigurationChange) = 0;
 };
 
 /**

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -152,23 +152,23 @@ struct IHostapd
     SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceConfigurationChange enforceConfigurationChange) = 0;
 
     /**
-     * @brief Set the allowed cipher suites for the interface.
+     * @brief Set the allowed pairwise cipher suites for the interface.
      *
      * @param protocol The WPA protocol to set the cipher suites for.
-     * @param ciphers The ciphers to allow.
+     * @param ciphers The pairwise ciphers to allow.
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     virtual void
-    SetCipherSuites(WpaProtocol protocol, std::vector<WpaCipher> ciphers, EnforceConfigurationChange enforceConfigurationChange) = 0;
+    SetPairwiseCipherSuites(WpaProtocol protocol, std::vector<WpaCipher> ciphers, EnforceConfigurationChange enforceConfigurationChange) = 0;
 
     /**
-     * @brief Set the allowed cipher suites for the interface.
+     * @brief Set the allowed pairwise cipher suites for the interface.
      *
-     * @param protocolCipherMap map specifying the ciphers to allow for each protocol.
+     * @param protocolCipherMap Map specifying the pairwise ciphers to allow for each protocol.
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     virtual void
-    SetCipherSuites(std::unordered_map<WpaProtocol, std::vector<WpaCipher>> protocolCipherMap, EnforceConfigurationChange enforceConfigurationChange) = 0;
+    SetPairwiseCipherSuites(std::unordered_map<WpaProtocol, std::vector<WpaCipher>> protocolCipherMap, EnforceConfigurationChange enforceConfigurationChange) = 0;
 };
 
 /**

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -89,7 +89,7 @@ inline constexpr std::underlying_type_t<WpaAuthenticationAlgorithm> WpaAuthentic
 /**
  * @brief Determine if the specified WpaAuthenticationAlgorithm is supported by hostapd.
  *
- * @param wpaProtocol The WpaAuthenticationAlgorithm to check.
+ * @param WpaSecurityProtocol The WpaAuthenticationAlgorithm to check.
  * @return true The authentication algorithm is supported.
  * @return false The authentication algorithm is not supported.
  */
@@ -107,7 +107,7 @@ IsWpaAuthenticationAlgorithmSupported(WpaAuthenticationAlgorithm wpaAuthenticati
  *
  * Values obtained from hostap/src/common/defs.h.
  */
-enum class WpaProtocol : uint32_t {
+enum class WpaSecurityProtocol : uint32_t {
     Wpa = (1U << 0U),
     Wpa2 = (1U << 1U),
     Wapi = (1U << 2U),
@@ -117,34 +117,34 @@ enum class WpaProtocol : uint32_t {
 };
 
 /**
- * @brief Array of all unsupported WpaProtocol values.
+ * @brief Array of all unsupported WpaSecurityProtocol values.
  */
-inline constexpr std::array<WpaProtocol, 2> WpaProtocolsUnsupported = {
-    WpaProtocol::Wapi,
-    WpaProtocol::Osen,
+inline constexpr std::array<WpaSecurityProtocol, 2> WpaSecurityProtocolsUnsupported = {
+    WpaSecurityProtocol::Wapi,
+    WpaSecurityProtocol::Osen,
 };
 
 /**
- * @brief Determine if the specified WpaProtocol is supported by hostapd.
+ * @brief Determine if the specified WpaSecurityProtocol is supported by hostapd.
  *
- * @param wpaProtocol The WpaProtocol to check.
+ * @param WpaSecurityProtocol The WpaSecurityProtocol to check.
  * @return true The protocol is supported.
  * @return false The protocol is not supported.
  */
 constexpr bool
-IsWpaProtocolSupported(WpaProtocol wpaProtocol) noexcept
+IsWpaSecurityProtocolSupported(WpaSecurityProtocol WpaSecurityProtocol) noexcept
 {
-    return !std::ranges::contains(WpaProtocolsUnsupported, wpaProtocol);
+    return !std::ranges::contains(WpaSecurityProtocolsUnsupported, WpaSecurityProtocol);
 }
 
 /**
- * @brief Numerical bitmask of valid WpaProtocol values.
+ * @brief Numerical bitmask of valid WpaSecurityProtocol values.
  */
-static constexpr std::underlying_type_t<WpaProtocol> WpaProtocolMask =
-    std::to_underlying(WpaProtocol::Wpa) |
-    std::to_underlying(WpaProtocol::Wpa2) |
-    std::to_underlying(WpaProtocol::Wapi) |
-    std::to_underlying(WpaProtocol::Osen);
+static constexpr std::underlying_type_t<WpaSecurityProtocol> WpaSecurityProtocolMask =
+    std::to_underlying(WpaSecurityProtocol::Wpa) |
+    std::to_underlying(WpaSecurityProtocol::Wpa2) |
+    std::to_underlying(WpaSecurityProtocol::Wapi) |
+    std::to_underlying(WpaSecurityProtocol::Osen);
 
 /**
  * @brief WPA encoding of IEEE 802.11 cipher types.
@@ -668,16 +668,16 @@ WpaCipherPropertyValue(WpaCipher wpaCipher) noexcept
  * Hostapd uses different configuration properties for WPA and WPA2/RSN protocols. This function maps the protocol to
  * the associated property name.
  *
- * @param wpaProtocol The wpa protocol to get the cipher name property for.
+ * @param WpaSecurityProtocol The wpa protocol to get the cipher name property for.
  * @return constexpr std::string_view
  */
 constexpr std::string_view
-WpaCipherPropertyName(WpaProtocol wpaProtocol) noexcept
+WpaCipherPropertyName(WpaSecurityProtocol WpaSecurityProtocol) noexcept
 {
-    switch (wpaProtocol) {
-    case WpaProtocol::Wpa:
+    switch (WpaSecurityProtocol) {
+    case WpaSecurityProtocol::Wpa:
         return ProtocolHostapd::PropertyNameWpaPairwise;
-    case WpaProtocol::Rsn:
+    case WpaSecurityProtocol::Rsn:
         return ProtocolHostapd::PropertyNameRsnPairwise;
     default:
         return ProtocolHostapd::PropertyNameInvalid;
@@ -685,15 +685,15 @@ WpaCipherPropertyName(WpaProtocol wpaProtocol) noexcept
 }
 
 /**
- * @brief Get the hostapd property value for the specified WpaProtocol.
+ * @brief Get the hostapd property value for the specified WpaSecurityProtocol.
  *
- * @param wpaProtocol The WpaProtocol to get the property value for.
- * @return constexpr std::underlying_type_t<WpaProtocol>
+ * @param WpaSecurityProtocol The WpaSecurityProtocol to get the property value for.
+ * @return constexpr std::underlying_type_t<WpaSecurityProtocol>
  */
-constexpr std::underlying_type_t<WpaProtocol>
-WpaProtocolPropertyValue(WpaProtocol wpaProtocol) noexcept
+constexpr std::underlying_type_t<WpaSecurityProtocol>
+WpaSecurityProtocolPropertyValue(WpaSecurityProtocol WpaSecurityProtocol) noexcept
 {
-    return std::to_underlying(wpaProtocol);
+    return std::to_underlying(WpaSecurityProtocol);
 }
 
 /**

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -108,33 +108,23 @@ IsWpaAuthenticationAlgorithmSupported(WpaAuthenticationAlgorithm wpaAuthenticati
  * Values obtained from hostap/src/common/defs.h.
  */
 enum class WpaSecurityProtocol : uint32_t {
+    Unknown = 0,
     Wpa = (1U << 0U),
     Wpa2 = (1U << 1U),
-    Wapi = (1U << 2U),
-    Osen = (1U << 3U),
-    // Aliases
-    Rsn = Wpa2,
-};
-
-/**
- * @brief Array of all unsupported WpaSecurityProtocol values.
- */
-inline constexpr std::array<WpaSecurityProtocol, 2> WpaSecurityProtocolsUnsupported = {
-    WpaSecurityProtocol::Wapi,
-    WpaSecurityProtocol::Osen,
+    Wpa3 = (1U << 1U), // intentionally the same as Wpa3, see note above.
 };
 
 /**
  * @brief Determine if the specified WpaSecurityProtocol is supported by hostapd.
  *
- * @param WpaSecurityProtocol The WpaSecurityProtocol to check.
+ * @param wpaSecurityProtocol The WpaSecurityProtocol to check.
  * @return true The protocol is supported.
  * @return false The protocol is not supported.
  */
 constexpr bool
-IsWpaSecurityProtocolSupported(WpaSecurityProtocol WpaSecurityProtocol) noexcept
+IsWpaSecurityProtocolSupported(WpaSecurityProtocol wpaSecurityProtocol) noexcept
 {
-    return !std::ranges::contains(WpaSecurityProtocolsUnsupported, WpaSecurityProtocol);
+    return wpaSecurityProtocol != WpaSecurityProtocol::Unknown;
 }
 
 /**
@@ -143,8 +133,7 @@ IsWpaSecurityProtocolSupported(WpaSecurityProtocol WpaSecurityProtocol) noexcept
 static constexpr std::underlying_type_t<WpaSecurityProtocol> WpaSecurityProtocolMask =
     std::to_underlying(WpaSecurityProtocol::Wpa) |
     std::to_underlying(WpaSecurityProtocol::Wpa2) |
-    std::to_underlying(WpaSecurityProtocol::Wapi) |
-    std::to_underlying(WpaSecurityProtocol::Osen);
+    std::to_underlying(WpaSecurityProtocol::Wpa3);
 
 /**
  * @brief WPA encoding of IEEE 802.11 cipher types.
@@ -152,6 +141,7 @@ static constexpr std::underlying_type_t<WpaSecurityProtocol> WpaSecurityProtocol
  * Values obtained from hostap/src/common/defs.h.
  */
 enum class WpaCipher : uint32_t {
+    Unknown = 0U,
     None = (1U << 0U),
     Wep40 = (1U << 1U),
     Wep104 = (1U << 2U),
@@ -174,7 +164,8 @@ enum class WpaCipher : uint32_t {
  *
  * magic_enum::enum_values() cannot be used since the enum values exceed [MAGIC_ENUM_RANGE_MIN, MAGIC_ENUM_RANGE_MAX].
  */
-inline constexpr std::array<WpaCipher, 14> WpaCiphersAll = {
+inline constexpr std::array<WpaCipher, 15> WpaCiphersAll = {
+    WpaCipher::Unknown,
     WpaCipher::None,
     WpaCipher::Wep40,
     WpaCipher::Wep104,
@@ -194,7 +185,8 @@ inline constexpr std::array<WpaCipher, 14> WpaCiphersAll = {
 /**
  * @brief Array of all unsupported WpaCipher values.
  */
-inline constexpr std::array<WpaCipher, 4> WpaCiphersUnsupported = {
+inline constexpr std::array<WpaCipher, 5> WpaCiphersUnsupported = {
+    WpaCipher::Unknown,
     WpaCipher::None,
     WpaCipher::Wep40,
     WpaCipher::Wep104,
@@ -677,7 +669,8 @@ WpaCipherPropertyName(WpaSecurityProtocol WpaSecurityProtocol) noexcept
     switch (WpaSecurityProtocol) {
     case WpaSecurityProtocol::Wpa:
         return ProtocolHostapd::PropertyNameWpaPairwise;
-    case WpaSecurityProtocol::Rsn:
+    case WpaSecurityProtocol::Wpa2:
+    // case WpaSecurityProtocol::Wpa3: // duplicate case value not allowed
         return ProtocolHostapd::PropertyNameRsnPairwise;
     default:
         return ProtocolHostapd::PropertyNameInvalid;

--- a/src/linux/wpa-controller/include/Wpa/ProtocolWpa.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolWpa.hxx
@@ -53,7 +53,7 @@ struct ProtocolWpa
     static constexpr auto CommandPayloadReload = "RELOAD";
 
     // Common property names.
-    static constexpr auto PropertyNameWpaProtocol = "wpa";
+    static constexpr auto PropertyNameWpaSecurityProtocol = "wpa";
 
     // Response payloads.
     static constexpr auto ResponsePayloadOk = "OK";

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -127,7 +127,7 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
         Dot11AccessPointConfiguration apConfiguration{};
         apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
         apConfiguration.mutable_ssid()->set_name(SsidName);
-        apConfiguration.mutable_ciphersuites()->Add(std::move(dot11CipherSuiteConfigurationWpa1));
+        apConfiguration.mutable_pairwiseciphersuites()->Add(std::move(dot11CipherSuiteConfigurationWpa1));
         apConfiguration.mutable_authenticationalgorithms()->Add(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
@@ -175,7 +175,7 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
         Dot11AccessPointConfiguration apConfiguration{};
         apConfiguration.set_phytype(Dot11PhyType::Dot11PhyTypeA);
         apConfiguration.mutable_ssid()->set_name(SsidName);
-        apConfiguration.mutable_ciphersuites()->Add(std::move(dot11CipherSuiteConfigurationWpa1));
+        apConfiguration.mutable_pairwiseciphersuites()->Add(std::move(dot11CipherSuiteConfigurationWpa1));
         apConfiguration.mutable_authenticationalgorithms()->Add(Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmSharedKey);
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
 

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -381,57 +381,57 @@ TEST_CASE("Send SetSsid() command (root)", "[wpa][hostapd][client][remote]")
     }
 }
 
-TEST_CASE("Send SetWpaProtocols() command (root)", "[wpa][hostapd][client][remote]")
+TEST_CASE("Send SetWpaSecurityProtocols() command (root)", "[wpa][hostapd][client][remote]")
 {
     using namespace Wpa;
 
-    static constexpr auto WpaProtocolInvalid = static_cast<WpaProtocol>(std::numeric_limits<std::underlying_type_t<WpaProtocol>>::max());
+    static constexpr auto WpaSecurityProtocolInvalid = static_cast<WpaSecurityProtocol>(std::numeric_limits<std::underlying_type_t<WpaSecurityProtocol>>::max());
 
     Hostapd hostapd(WpaDaemonManager::InterfaceNameDefault);
 
     SECTION("Doesn't throw")
     {
-        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa }, EnforceConfigurationChange::Defer));
-        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa, WpaSecurityProtocol::Wpa2 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa, WpaSecurityProtocol::Wpa2 }, EnforceConfigurationChange::Defer));
     }
 
     SECTION("Fails with empty input")
     {
-        REQUIRE_THROWS_AS(hostapd.SetWpaProtocols({}, EnforceConfigurationChange::Now), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.SetWpaSecurityProtocols({}, EnforceConfigurationChange::Now), HostapdException);
     }
 
     SECTION("Fails with invalid input")
     {
-        REQUIRE_THROWS_AS(hostapd.SetWpaProtocols({ WpaProtocolInvalid }, EnforceConfigurationChange::Now), HostapdException);
-        REQUIRE_THROWS_AS(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocolInvalid }, EnforceConfigurationChange::Now), HostapdException);
-        REQUIRE_THROWS_AS(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocolInvalid, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Now), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocolInvalid }, EnforceConfigurationChange::Now), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa, WpaSecurityProtocolInvalid }, EnforceConfigurationChange::Now), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa, WpaSecurityProtocolInvalid, WpaSecurityProtocol::Wpa2 }, EnforceConfigurationChange::Now), HostapdException);
 
-        REQUIRE_THROWS_AS(hostapd.SetWpaProtocols({ WpaProtocolInvalid }, EnforceConfigurationChange::Defer), HostapdException);
-        REQUIRE_THROWS_AS(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocolInvalid }, EnforceConfigurationChange::Defer), HostapdException);
-        REQUIRE_THROWS_AS(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocolInvalid, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Defer), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocolInvalid }, EnforceConfigurationChange::Defer), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa, WpaSecurityProtocolInvalid }, EnforceConfigurationChange::Defer), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa, WpaSecurityProtocolInvalid, WpaSecurityProtocol::Wpa2 }, EnforceConfigurationChange::Defer), HostapdException);
     }
 
     SECTION("Succeeds with valid, single input")
     {
-        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa }, EnforceConfigurationChange::Defer));
     }
 
     SECTION("Succeeds with valid, multiple inputs")
     {
-        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa, WpaSecurityProtocol::Wpa2 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa, WpaSecurityProtocol::Wpa2 }, EnforceConfigurationChange::Defer));
     }
 
     SECTION("Succeeds with valid, duplicate inputs")
     {
-        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa, WpaProtocol::Wpa }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa, WpaSecurityProtocol::Wpa }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa, WpaSecurityProtocol::Wpa }, EnforceConfigurationChange::Defer));
 
-        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa2, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetWpaProtocols({ WpaProtocol::Wpa2, WpaProtocol::Wpa2 }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa2, WpaSecurityProtocol::Wpa2 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetWpaSecurityProtocols({ WpaSecurityProtocol::Wpa2, WpaSecurityProtocol::Wpa2 }, EnforceConfigurationChange::Defer));
     }
 }
 
@@ -533,17 +533,17 @@ TEST_CASE("Send SetPairwiseCipherSuites() command (root)", "[wpa][hostapd][clien
 
     SECTION("Doesn't throw")
     {
-        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaProtocol::Wpa, { WpaCipher::Ccmp }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaProtocol::Wpa, { WpaCipher::Ccmp }, EnforceConfigurationChange::Defer));
-        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites({ { WpaProtocol::Wpa, { WpaCipher::Ccmp } } }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites({ { WpaProtocol::Wpa, { WpaCipher::Ccmp } } }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaSecurityProtocol::Wpa, { WpaCipher::Ccmp }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaSecurityProtocol::Wpa, { WpaCipher::Ccmp }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites({ { WpaSecurityProtocol::Wpa, { WpaCipher::Ccmp } } }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites({ { WpaSecurityProtocol::Wpa, { WpaCipher::Ccmp } } }, EnforceConfigurationChange::Defer));
     }
 
     SECTION("Fails with empty inputs")
     {
         // Empty cipher list.
-        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites(WpaProtocol::Wpa, {}, EnforceConfigurationChange::Now), HostapdException);
-        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites(WpaProtocol::Wpa, {}, EnforceConfigurationChange::Defer), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites(WpaSecurityProtocol::Wpa, {}, EnforceConfigurationChange::Now), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites(WpaSecurityProtocol::Wpa, {}, EnforceConfigurationChange::Defer), HostapdException);
 
         // Empty protocol list.
         REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({}, EnforceConfigurationChange::Now), HostapdException);
@@ -552,31 +552,31 @@ TEST_CASE("Send SetPairwiseCipherSuites() command (root)", "[wpa][hostapd][clien
         // clang-format off
         // Empty protocol list in map entry.
         REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
-            { WpaProtocol::Wpa, {} },
-            { WpaProtocol::Wpa2, { WpaCipher::Aes128Cmac } },
+            { WpaSecurityProtocol::Wpa, {} },
+            { WpaSecurityProtocol::Wpa2, { WpaCipher::Aes128Cmac } },
         }, EnforceConfigurationChange::Now), HostapdException);
         REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
-            { WpaProtocol::Wpa, {} },
-            { WpaProtocol::Wpa2, { WpaCipher::Aes128Cmac } },
+            { WpaSecurityProtocol::Wpa, {} },
+            { WpaSecurityProtocol::Wpa2, { WpaCipher::Aes128Cmac } },
         }, EnforceConfigurationChange::Defer), HostapdException);
 
         // Empty protocol list in map entry.
         REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
-            { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac } },
-            { WpaProtocol::Wpa2, { } },
+            { WpaSecurityProtocol::Wpa, { WpaCipher::Aes128Cmac } },
+            { WpaSecurityProtocol::Wpa2, { } },
         }, EnforceConfigurationChange::Now), HostapdException);
         REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
-            { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac } },
-            { WpaProtocol::Wpa2, { } },
+            { WpaSecurityProtocol::Wpa, { WpaCipher::Aes128Cmac } },
+            { WpaSecurityProtocol::Wpa2, { } },
         }, EnforceConfigurationChange::Defer), HostapdException);
 
         // Empty protocol list and empty cipher list in map entry.
         REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
-            { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac } },
+            { WpaSecurityProtocol::Wpa, { WpaCipher::Aes128Cmac } },
             { {}, {} },
         }, EnforceConfigurationChange::Now), HostapdException);
         REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
-            { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac } },
+            { WpaSecurityProtocol::Wpa, { WpaCipher::Aes128Cmac } },
             { {}, {} },
         }, EnforceConfigurationChange::Defer), HostapdException);
 
@@ -592,23 +592,23 @@ TEST_CASE("Send SetPairwiseCipherSuites() command (root)", "[wpa][hostapd][clien
 
     SECTION("Succeeds with all valid, single inputs")
     {
-        for (const auto wpaProtocol : magic_enum::enum_values<WpaProtocol>() | std::views::filter(IsWpaProtocolSupported)) {
+        for (const auto WpaSecurityProtocol : magic_enum::enum_values<WpaSecurityProtocol>() | std::views::filter(IsWpaSecurityProtocolSupported)) {
             for (const auto wpaCipher : WpaCiphersAll | std::views::filter(IsWpaCipherSupported)) {
-                REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(wpaProtocol, { wpaCipher }, EnforceConfigurationChange::Now));
-                REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(wpaProtocol, { wpaCipher }, EnforceConfigurationChange::Defer));
+                REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaSecurityProtocol, { wpaCipher }, EnforceConfigurationChange::Now));
+                REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaSecurityProtocol, { wpaCipher }, EnforceConfigurationChange::Defer));
             }
         }
     }
 
     SECTION("Succeeds with valid, multiple inputs")
     {
-        std::unordered_map<WpaProtocol, std::vector<WpaCipher>> protocolCipherMap{};
+        std::unordered_map<WpaSecurityProtocol, std::vector<WpaCipher>> protocolCipherMap{};
 
         std::vector<WpaKeyManagement> keyManagementValidValues{};
 
-        for (const auto wpaProtocol : magic_enum::enum_values<WpaProtocol>() | std::views::filter(IsWpaProtocolSupported)) {
+        for (const auto WpaSecurityProtocol : magic_enum::enum_values<WpaSecurityProtocol>() | std::views::filter(IsWpaSecurityProtocolSupported)) {
             for (const auto wpaCipher : WpaCiphersAll | std::views::filter(IsWpaCipherSupported)) {
-                protocolCipherMap[wpaProtocol].push_back(wpaCipher);
+                protocolCipherMap[WpaSecurityProtocol].push_back(wpaCipher);
                 REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(protocolCipherMap, EnforceConfigurationChange::Now));
                 REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(protocolCipherMap, EnforceConfigurationChange::Defer));
             }
@@ -617,11 +617,11 @@ TEST_CASE("Send SetPairwiseCipherSuites() command (root)", "[wpa][hostapd][clien
 
     SECTION("Succeeds with valid, duplicate inputs")
     {
-        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaSecurityProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaSecurityProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac }, EnforceConfigurationChange::Defer));
 
-        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites({ { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac } } }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites({ { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac } } }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites({ { WpaSecurityProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac } } }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites({ { WpaSecurityProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac } } }, EnforceConfigurationChange::Defer));
     }
 }
 

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -525,7 +525,7 @@ TEST_CASE("Send SetKeyManagement() command (root)", "[wpa][hostapd][client][remo
     }
 }
 
-TEST_CASE("Send SetCipherSuites() command (root)", "[wpa][hostapd][client][remote]")
+TEST_CASE("Send SetPairwiseCipherSuites() command (root)", "[wpa][hostapd][client][remote]")
 {
     using namespace Wpa;
 
@@ -533,58 +533,58 @@ TEST_CASE("Send SetCipherSuites() command (root)", "[wpa][hostapd][client][remot
 
     SECTION("Doesn't throw")
     {
-        REQUIRE_NOTHROW(hostapd.SetCipherSuites(WpaProtocol::Wpa, { WpaCipher::Ccmp }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetCipherSuites(WpaProtocol::Wpa, { WpaCipher::Ccmp }, EnforceConfigurationChange::Defer));
-        REQUIRE_NOTHROW(hostapd.SetCipherSuites({ { WpaProtocol::Wpa, { WpaCipher::Ccmp } } }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetCipherSuites({ { WpaProtocol::Wpa, { WpaCipher::Ccmp } } }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaProtocol::Wpa, { WpaCipher::Ccmp }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaProtocol::Wpa, { WpaCipher::Ccmp }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites({ { WpaProtocol::Wpa, { WpaCipher::Ccmp } } }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites({ { WpaProtocol::Wpa, { WpaCipher::Ccmp } } }, EnforceConfigurationChange::Defer));
     }
 
     SECTION("Fails with empty inputs")
     {
         // Empty cipher list.
-        REQUIRE_THROWS_AS(hostapd.SetCipherSuites(WpaProtocol::Wpa, {}, EnforceConfigurationChange::Now), HostapdException);
-        REQUIRE_THROWS_AS(hostapd.SetCipherSuites(WpaProtocol::Wpa, {}, EnforceConfigurationChange::Defer), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites(WpaProtocol::Wpa, {}, EnforceConfigurationChange::Now), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites(WpaProtocol::Wpa, {}, EnforceConfigurationChange::Defer), HostapdException);
 
         // Empty protocol list.
-        REQUIRE_THROWS_AS(hostapd.SetCipherSuites({}, EnforceConfigurationChange::Now), HostapdException);
-        REQUIRE_THROWS_AS(hostapd.SetCipherSuites({}, EnforceConfigurationChange::Defer), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({}, EnforceConfigurationChange::Now), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({}, EnforceConfigurationChange::Defer), HostapdException);
 
         // clang-format off
         // Empty protocol list in map entry.
-        REQUIRE_THROWS_AS(hostapd.SetCipherSuites({
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
             { WpaProtocol::Wpa, {} },
             { WpaProtocol::Wpa2, { WpaCipher::Aes128Cmac } },
         }, EnforceConfigurationChange::Now), HostapdException);
-        REQUIRE_THROWS_AS(hostapd.SetCipherSuites({
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
             { WpaProtocol::Wpa, {} },
             { WpaProtocol::Wpa2, { WpaCipher::Aes128Cmac } },
         }, EnforceConfigurationChange::Defer), HostapdException);
 
         // Empty protocol list in map entry.
-        REQUIRE_THROWS_AS(hostapd.SetCipherSuites({
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
             { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac } },
             { WpaProtocol::Wpa2, { } },
         }, EnforceConfigurationChange::Now), HostapdException);
-        REQUIRE_THROWS_AS(hostapd.SetCipherSuites({
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
             { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac } },
             { WpaProtocol::Wpa2, { } },
         }, EnforceConfigurationChange::Defer), HostapdException);
 
         // Empty protocol list and empty cipher list in map entry.
-        REQUIRE_THROWS_AS(hostapd.SetCipherSuites({
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
             { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac } },
             { {}, {} },
         }, EnforceConfigurationChange::Now), HostapdException);
-        REQUIRE_THROWS_AS(hostapd.SetCipherSuites({
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
             { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac } },
             { {}, {} },
         }, EnforceConfigurationChange::Defer), HostapdException);
 
         // Only empty protocol and cipher lists in map.
-        REQUIRE_THROWS_AS(hostapd.SetCipherSuites({
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
             { {}, {} },
         }, EnforceConfigurationChange::Now), HostapdException);
-        REQUIRE_THROWS_AS(hostapd.SetCipherSuites({
+        REQUIRE_THROWS_AS(hostapd.SetPairwiseCipherSuites({
             { {}, {} },
         }, EnforceConfigurationChange::Defer), HostapdException);
         // clang-format on
@@ -594,8 +594,8 @@ TEST_CASE("Send SetCipherSuites() command (root)", "[wpa][hostapd][client][remot
     {
         for (const auto wpaProtocol : magic_enum::enum_values<WpaProtocol>() | std::views::filter(IsWpaProtocolSupported)) {
             for (const auto wpaCipher : WpaCiphersAll | std::views::filter(IsWpaCipherSupported)) {
-                REQUIRE_NOTHROW(hostapd.SetCipherSuites(wpaProtocol, { wpaCipher }, EnforceConfigurationChange::Now));
-                REQUIRE_NOTHROW(hostapd.SetCipherSuites(wpaProtocol, { wpaCipher }, EnforceConfigurationChange::Defer));
+                REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(wpaProtocol, { wpaCipher }, EnforceConfigurationChange::Now));
+                REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(wpaProtocol, { wpaCipher }, EnforceConfigurationChange::Defer));
             }
         }
     }
@@ -609,19 +609,19 @@ TEST_CASE("Send SetCipherSuites() command (root)", "[wpa][hostapd][client][remot
         for (const auto wpaProtocol : magic_enum::enum_values<WpaProtocol>() | std::views::filter(IsWpaProtocolSupported)) {
             for (const auto wpaCipher : WpaCiphersAll | std::views::filter(IsWpaCipherSupported)) {
                 protocolCipherMap[wpaProtocol].push_back(wpaCipher);
-                REQUIRE_NOTHROW(hostapd.SetCipherSuites(protocolCipherMap, EnforceConfigurationChange::Now));
-                REQUIRE_NOTHROW(hostapd.SetCipherSuites(protocolCipherMap, EnforceConfigurationChange::Defer));
+                REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(protocolCipherMap, EnforceConfigurationChange::Now));
+                REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(protocolCipherMap, EnforceConfigurationChange::Defer));
             }
         }
     }
 
     SECTION("Succeeds with valid, duplicate inputs")
     {
-        REQUIRE_NOTHROW(hostapd.SetCipherSuites(WpaProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetCipherSuites(WpaProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites(WpaProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac }, EnforceConfigurationChange::Defer));
 
-        REQUIRE_NOTHROW(hostapd.SetCipherSuites({ { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac } } }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.SetCipherSuites({ { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac } } }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites({ { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac } } }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetPairwiseCipherSuites({ { WpaProtocol::Wpa, { WpaCipher::Aes128Cmac, WpaCipher::Aes128Cmac } } }, EnforceConfigurationChange::Defer));
     }
 }
 

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -6,6 +6,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -121,6 +122,19 @@ AccessPointControllerTest::SetAuthenticationAlgorithms([[maybe_unused]] std::vec
     // If so, ensure authenticationAlgorithms is subset of those in AccessPointCapabilities.AuthenticationAlgorithms.
 
     AccessPoint->AuthenticationAlgorithms = std::move(authenticationAlgorithms);
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
+}
+
+AccessPointOperationStatus
+AccessPointControllerTest::SetPairwiseCipherSuites(std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> pairwiseCipherSuites) noexcept
+{
+    assert(AccessPoint != nullptr);
+
+    if (AccessPoint == nullptr) {
+        return AccessPointOperationStatus::InvalidAccessPoint("null AccessPoint");
+    }
+
+    AccessPoint->CipherSuites = std::move(pairwiseCipherSuites);
     return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -113,6 +113,15 @@ struct AccessPointControllerTest final :
     SetAuthenticationAlgorithms(std::vector<Ieee80211AuthenticationAlgorithm> authenticationAlgorithms) noexcept override;
 
     /**
+     * @brief Set the pairwise cipher suites the access point should enable. These are used to encrypt unicast packets.
+     *
+     * @param pairwiseCipherSuites The pairwise cipher suites to enable.
+     * @return AccessPointOperationStatus
+     */
+    AccessPointOperationStatus
+    SetPairwiseCipherSuites(std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> pairwiseCipherSuites) noexcept override;
+
+    /**
      * @brief Set the SSID of the access point.
      *
      * @param ssid The SSID to be set.

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include <microsoft/net/wifi/IAccessPoint.hxx>
@@ -29,6 +30,7 @@ struct AccessPointTest final :
     Microsoft::Net::Wifi::Ieee80211PhyType PhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> FrequencyBands;
     std::vector<Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm> AuthenticationAlgorithms;
+    std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> CipherSuites;
     AccessPointOperationalState OperationalState{ AccessPointOperationalState::Disabled };
 
     /**


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow configuring pairwise ciphers for an access point. 

### Technical Details

* Add `IAccessPointController::SetPairwiseCipherSuites` and implementation in `AccessPointControllerLinux`.
* Add adapters for converting to/from Ieee80211/Wpa security protocols and ciphers.
* Add `Unknown` field to `WpaSecurityProtocol` enumeration.
* Remove `Wapi` and `Osen` field values from `WpaSecurityProtocol` as they won't be used.
* Add `Unknown` field to `WpaCipher` enumeration.
* Rename `WpaProtocol` to `WpaSecurityProtocol` for consistency with nomenclature throughout the stack.
* Fix off-by-1 error in operation name calculation expression.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
