### PR TITLE
Add commands to enable and disable APs from netremote-cli

### DIFF
--- a/src/common/tools/cli/CMakeLists.txt
+++ b/src/common/tools/cli/CMakeLists.txt
@@ -27,9 +27,10 @@ target_link_libraries(${PROJECT_NAME}-cli
         magic_enum::magic_enum
         notstd
         plog::plog
-        wifi-core-adapter-dot11
     PUBLIC
         ${PROJECT_NAME}-client
+        wifi-core
+        wifi-core-adapter-dot11
 )
 
 install(

--- a/src/common/tools/cli/CMakeLists.txt
+++ b/src/common/tools/cli/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(${PROJECT_NAME}-cli
         magic_enum::magic_enum
         notstd
         plog::plog
+        wifi-core-adapter-dot11
     PUBLIC
         ${PROJECT_NAME}-client
 )

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -86,6 +86,8 @@ NetRemoteCli::AddSubcommandWifi(CLI::App* parent)
 
     // Sub-commands.
     m_cliAppWifiEnumerateAccessPoints = AddSubcommandWifiEnumerateAccessPoints(wifiApp);
+    m_cliAppWifiAccessPointEnable = AddSubcommandWifiAccessPointEnable(wifiApp);
+    m_cliAppWifiAccessPointDisable = AddSubcommandWifiAccessPointDisable(wifiApp);
 
     return wifiApp;
 }
@@ -100,6 +102,32 @@ NetRemoteCli::AddSubcommandWifiEnumerateAccessPoints(CLI::App* parent)
     });
 
     return cliAppWifiEnumerateAccessPoints;
+}
+
+CLI::App*
+NetRemoteCli::AddSubcommandWifiAccessPointEnable(CLI::App* parent)
+{
+    auto* cliAppWifiAccessPointEnable = parent->add_subcommand("access-point-enable", "Enable a Wi-Fi access point");
+    cliAppWifiAccessPointEnable->alias("ap-enable");
+    cliAppWifiAccessPointEnable->callback([this] {
+        OnWifiAccessPointEnable();
+    });
+
+    return cliAppWifiAccessPointEnable;
+}
+
+CLI::App*
+NetRemoteCli::AddSubcommandWifiAccessPointDisable(CLI::App* parent)
+{
+    auto* cliAppWifiAccessPointDisable = parent->add_subcommand("access-point-disable", "Disable a Wi-Fi access point");
+    cliAppWifiAccessPointDisable->alias("ap-disable");
+    cliAppWifiAccessPointDisable->callback([this] {
+        OnWifiAccessPointEnable();
+    });
+
+    cliAppWifiAccessPointDisable->add_option("id", m_cliData->WifiAccessPointId, "The identifier of the access point to disable")->required();
+
+    return cliAppWifiAccessPointDisable;
 }
 
 void
@@ -128,4 +156,16 @@ void
 NetRemoteCli::OnWifiEnumerateAccessPoints()
 {
     m_cliHandler->HandleCommandWifiEnumerateAccessPoints();
+}
+
+void
+NetRemoteCli::OnWifiAccessPointEnable()
+{
+    m_cliHandler->HandleCommandWifiAccessPointEnable(m_cliData->WifiAccessPointId);
+}
+
+void
+NetRemoteCli::OnWifiAccessPointDisable()
+{
+    m_cliHandler->HandleCommandWifiAccessPointDisable(m_cliData->WifiAccessPointId);
 }

--- a/src/common/tools/cli/NetRemoteCliHandler.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandler.cxx
@@ -1,5 +1,6 @@
 
 #include <memory>
+#include <string_view>
 #include <utility>
 
 #include <microsoft/net/remote/INetRemoteCliHandlerOperations.hxx>
@@ -50,4 +51,42 @@ NetRemoteCliHandler::HandleCommandWifiEnumerateAccessPoints()
 
     LOGD << "Executing command WifiEnumerateAccessPoints";
     m_operations->WifiEnumerateAccessPoints();
+}
+
+void
+NetRemoteCliHandler::HandleCommandWifiAccessPointEnable(std::string_view accessPointId)
+{
+    if (!m_operations) {
+        LOGE << "No operations instance available to handle command";
+        return;
+    }
+
+    auto parentStrong{ GetParentStrongRef() };
+    if (parentStrong == nullptr) {
+        LOGW << "Parent cli object is no longer valid, aborting command";
+        return;
+    }
+
+    LOGD << "Executing command WifiAccessPointEnable";
+
+    m_operations->WifiAccessPointEnable(accessPointId);
+}
+
+void
+NetRemoteCliHandler::HandleCommandWifiAccessPointDisable(std::string_view accessPointId)
+{
+    if (!m_operations) {
+        LOGE << "No operations instance available to handle command";
+        return;
+    }
+
+    auto parentStrong{ GetParentStrongRef() };
+    if (parentStrong == nullptr) {
+        LOGW << "Parent cli object is no longer valid, aborting command";
+        return;
+    }
+
+    LOGD << "Executing command WifiAccessPointDisable";
+
+    m_operations->WifiAccessPointDisable(accessPointId);
 }

--- a/src/common/tools/cli/NetRemoteCliHandler.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandler.cxx
@@ -1,5 +1,6 @@
 
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <utility>
 
@@ -7,6 +8,7 @@
 #include <microsoft/net/remote/NetRemoteCli.hxx>
 #include <microsoft/net/remote/NetRemoteCliHandler.hxx>
 #include <microsoft/net/remote/NetRemoteServerConnection.hxx>
+#include <microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx>
 #include <plog/Log.h>
 
 using namespace Microsoft::Net::Remote;
@@ -53,8 +55,10 @@ NetRemoteCliHandler::HandleCommandWifiEnumerateAccessPoints()
     m_operations->WifiEnumerateAccessPoints();
 }
 
+using Microsoft::Net::Wifi::Ieee80211AccessPointConfiguration;
+
 void
-NetRemoteCliHandler::HandleCommandWifiAccessPointEnable(std::string_view accessPointId)
+NetRemoteCliHandler::HandleCommandWifiAccessPointEnable(std::string_view accessPointId, const std::optional<Ieee80211AccessPointConfiguration>& ieee80211AccessPointConfiguration)
 {
     if (!m_operations) {
         LOGE << "No operations instance available to handle command";
@@ -69,7 +73,7 @@ NetRemoteCliHandler::HandleCommandWifiAccessPointEnable(std::string_view accessP
 
     LOGD << "Executing command WifiAccessPointEnable";
 
-    m_operations->WifiAccessPointEnable(accessPointId);
+    m_operations->WifiAccessPointEnable(accessPointId, ieee80211AccessPointConfiguration);
 }
 
 void

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -136,6 +136,38 @@ NetRemoteCliHandlerOperations::WifiEnumerateAccessPoints()
     }
 }
 
+void
+NetRemoteCliHandlerOperations::WifiAccessPointEnable(std::string_view accessPointId)
+{
+    WifiAccessPointEnableRequest request{};
+    WifiAccessPointEnableResult result{};
+    grpc::ClientContext clientContext{};
+
+    request.set_accesspointid(std::string(accessPointId));
+
+    auto status = m_connection->Client->WifiAccessPointEnable(&clientContext, request, &result);
+    if (!status.ok()) {
+        LOGE << std::format("Failed to enable WiFi access point, error={} details={} message={}", magic_enum::enum_name(status.error_code()), status.error_details(), status.error_message());
+        return;
+    }
+}
+
+void
+NetRemoteCliHandlerOperations::WifiAccessPointDisable(std::string_view accessPointId)
+{
+    WifiAccessPointDisableRequest request{};
+    WifiAccessPointDisableResult result{};
+    grpc::ClientContext clientContext{};
+
+    request.set_accesspointid(std::string(accessPointId));
+
+    auto status = m_connection->Client->WifiAccessPointDisable(&clientContext, request, &result);
+    if (!status.ok()) {
+        LOGE << std::format("Failed to disable WiFi access point, error={} details={} message={}", magic_enum::enum_name(status.error_code()), status.error_details(), status.error_message());
+        return;
+    }
+}
+
 std::unique_ptr<INetRemoteCliHandlerOperations>
 NetRemoteCliHandlerOperationsFactory::Create(std::shared_ptr<NetRemoteServerConnection> connection)
 {

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -163,7 +163,11 @@ NetRemoteCliHandlerOperations::WifiAccessPointEnable(std::string_view accessPoin
 
         // Populate pairwise cipher suites if present.
         if (!std::empty(ieee80211AccessPointConfiguration->PairwiseCipherSuites)) {
-            // TODO
+            auto dot11PairwiseCipherSuites = ToDot11CipherSuiteConfigurations(ieee80211AccessPointConfiguration->PairwiseCipherSuites);
+            *dot11AccessPointConfiguration.mutable_pairwiseciphersuites() = {
+                std::make_move_iterator(std::begin(dot11PairwiseCipherSuites)),
+                std::make_move_iterator(std::end(dot11PairwiseCipherSuites))
+            };
         }
 
         // Populate authentication algorithms if present.

--- a/src/common/tools/cli/include/microsoft/net/remote/INetRemoteCliHandlerOperations.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/INetRemoteCliHandlerOperations.hxx
@@ -3,6 +3,7 @@
 #define I_NET_REMOTE_CLI_HANDLER_OPERATIONS_HXX
 
 #include <memory>
+#include <string_view>
 
 #include <microsoft/net/remote/NetRemoteServerConnection.hxx>
 
@@ -21,15 +22,36 @@ struct INetRemoteCliHandlerOperations
      * Prevent copying and moving of INetRemoteCliHandlerOperations objects.
      */
     INetRemoteCliHandlerOperations(const INetRemoteCliHandlerOperations&) = delete;
-    INetRemoteCliHandlerOperations& operator=(const INetRemoteCliHandlerOperations&) = delete;
+
     INetRemoteCliHandlerOperations(INetRemoteCliHandlerOperations&&) = delete;
-    INetRemoteCliHandlerOperations& operator=(INetRemoteCliHandlerOperations&&) = delete;
+
+    INetRemoteCliHandlerOperations&
+    operator=(const INetRemoteCliHandlerOperations&) = delete;
+
+    INetRemoteCliHandlerOperations&
+    operator=(INetRemoteCliHandlerOperations&&) = delete;
 
     /**
      * @brief Enumerate available WiFi access points.
      */
     virtual void
     WifiEnumerateAccessPoints() = 0;
+
+    /**
+     * @brief Enable the specified WiFi access point.
+     *
+     * @param accessPointId The identifier of the access point to enable.
+     */
+    virtual void
+    WifiAccessPointEnable(std::string_view accessPointId) = 0;
+
+    /**
+     * @brief Disable the specified WiFi access point.
+     *
+     * @param accessPointId The identifier of the access point to disable.
+     */
+    virtual void
+    WifiAccessPointDisable(std::string_view accessPointId) = 0;
 };
 
 /**
@@ -42,12 +64,17 @@ struct INetRemoteCliHandlerOperationsFactory
     virtual ~INetRemoteCliHandlerOperationsFactory() = default;
 
     /**
-     * Prevent copying and moving of INetRemoteCliHandlerOperationsFactory objects. 
+     * Prevent copying and moving of INetRemoteCliHandlerOperationsFactory objects.
      */
     INetRemoteCliHandlerOperationsFactory(const INetRemoteCliHandlerOperationsFactory&) = delete;
-    INetRemoteCliHandlerOperationsFactory& operator=(const INetRemoteCliHandlerOperationsFactory&) = delete;
+
     INetRemoteCliHandlerOperationsFactory(INetRemoteCliHandlerOperationsFactory&&) = delete;
-    INetRemoteCliHandlerOperationsFactory& operator=(INetRemoteCliHandlerOperationsFactory&&) = delete;
+
+    INetRemoteCliHandlerOperationsFactory&
+    operator=(const INetRemoteCliHandlerOperationsFactory&) = delete;
+
+    INetRemoteCliHandlerOperationsFactory&
+    operator=(INetRemoteCliHandlerOperationsFactory&&) = delete;
 
     /**
      * @brief Create a new INetRemoteCliHandlerOperationsFactory instance with the specified server connection.

--- a/src/common/tools/cli/include/microsoft/net/remote/INetRemoteCliHandlerOperations.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/INetRemoteCliHandlerOperations.hxx
@@ -3,9 +3,11 @@
 #define I_NET_REMOTE_CLI_HANDLER_OPERATIONS_HXX
 
 #include <memory>
+#include <optional>
 #include <string_view>
 
 #include <microsoft/net/remote/NetRemoteServerConnection.hxx>
+#include <microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx>
 
 namespace Microsoft::Net::Remote
 {
@@ -41,9 +43,10 @@ struct INetRemoteCliHandlerOperations
      * @brief Enable the specified WiFi access point.
      *
      * @param accessPointId The identifier of the access point to enable.
+     * @param ieee80211AccessPointConfiguration The optional configuration to apply to the access point.
      */
     virtual void
-    WifiAccessPointEnable(std::string_view accessPointId) = 0;
+    WifiAccessPointEnable(std::string_view accessPointId, const std::optional<Microsoft::Net::Wifi::Ieee80211AccessPointConfiguration>& ieee80211AccessPointConfiguration) = 0;
 
     /**
      * @brief Disable the specified WiFi access point.

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
@@ -95,6 +95,24 @@ private:
     AddSubcommandWifiEnumerateAccessPoints(CLI::App* parent);
 
     /**
+     * @brief Add the 'wifi ap-enable' sub-command.
+     * 
+     * @param parent The parent app to add the sub-command to.
+     * @return CLI::App* 
+     */
+    CLI::App*
+    AddSubcommandWifiAccessPointEnable(CLI::App* parent);
+
+    /**
+     * @brief Add the 'wifi ap-disable' sub-command.
+     * 
+     * @param parent The parent app to add the sub-command to.
+     * @return CLI::App* 
+     */
+    CLI::App*
+    AddSubcommandWifiAccessPointDisable(CLI::App* parent);
+
+    /**
      * @brief Handle the 'server' option.
      *
      * @param serverAddress The server address to connect to.
@@ -108,6 +126,18 @@ private:
     void
     OnWifiEnumerateAccessPoints();
 
+    /**
+     * @brief Handle the 'wifi ap-enable' command.
+     */
+    void
+    OnWifiAccessPointEnable();
+
+    /**
+     * @brief Handle the 'wifi ap-disable' command.
+     */
+    void
+    OnWifiAccessPointDisable();
+
 private:
     std::shared_ptr<NetRemoteCliData> m_cliData;
     std::shared_ptr<NetRemoteCliHandler> m_cliHandler;
@@ -118,6 +148,8 @@ private:
     CLI::Option* m_cliAppServerAddress{ nullptr };
     CLI::App* m_cliAppWifi{ nullptr };
     CLI::App* m_cliAppWifiEnumerateAccessPoints{ nullptr };
+    CLI::App* m_cliAppWifiAccessPointEnable{ nullptr };
+    CLI::App* m_cliAppWifiAccessPointDisable{ nullptr };
 };
 } // namespace Microsoft::Net::Remote
 

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
@@ -19,6 +19,8 @@ struct NetRemoteCliData
 {
     std::string ServerAddress{ Protocol::NetRemoteProtocol::AddressDefault };
     NetRemoteCommandId Command{ NetRemoteCommandId::None };
+
+    std::string WifiAccessPointId{};
 };
 } // namespace Microsoft::Net::Remote
 

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandler.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandler.hxx
@@ -3,6 +3,7 @@
 #define NET_REMOTE_CLI_HANDLER_HXX
 
 #include <memory>
+#include <string_view>
 
 #include <microsoft/net/remote/NetRemoteServerConnection.hxx>
 
@@ -22,12 +23,17 @@ struct NetRemoteCliHandler
     virtual ~NetRemoteCliHandler() = default;
 
     /**
-     * Prevent copying and moving of NetRemoteCliHandler objects. 
+     * Prevent copying and moving of NetRemoteCliHandler objects.
      */
     NetRemoteCliHandler(const NetRemoteCliHandler&) = delete;
-    NetRemoteCliHandler& operator=(const NetRemoteCliHandler&) = delete;
+
     NetRemoteCliHandler(NetRemoteCliHandler&&) = delete;
-    NetRemoteCliHandler& operator=(NetRemoteCliHandler&&) = delete;
+
+    NetRemoteCliHandler&
+    operator=(const NetRemoteCliHandler&) = delete;
+
+    NetRemoteCliHandler&
+    operator=(NetRemoteCliHandler&&) = delete;
 
     /**
      * @brief Construct a new NetRemoteCliHandler object.
@@ -57,6 +63,22 @@ struct NetRemoteCliHandler
      */
     void
     HandleCommandWifiEnumerateAccessPoints();
+
+    /**
+     * @brief Handle a command to enable a Wi-Fi access point.
+     *
+     * @param accessPointId The identifier of the access point to enable.
+     */
+    void
+    HandleCommandWifiAccessPointEnable(std::string_view accessPointId);
+
+    /**
+     * @brief Handle a command to disable a Wi-Fi access point.
+     *
+     * @param accessPointId The identifier of the access point to enable.
+     */
+    void
+    HandleCommandWifiAccessPointDisable(std::string_view accessPointId);
 
 private:
     /**

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandler.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandler.hxx
@@ -3,9 +3,11 @@
 #define NET_REMOTE_CLI_HANDLER_HXX
 
 #include <memory>
+#include <optional>
 #include <string_view>
 
 #include <microsoft/net/remote/NetRemoteServerConnection.hxx>
+#include <microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx>
 
 namespace Microsoft::Net::Remote
 {
@@ -68,9 +70,10 @@ struct NetRemoteCliHandler
      * @brief Handle a command to enable a Wi-Fi access point.
      *
      * @param accessPointId The identifier of the access point to enable.
+     * @param ieee80211AccessPointConfiguration The optional configuration to apply to the access point.
      */
     void
-    HandleCommandWifiAccessPointEnable(std::string_view accessPointId);
+    HandleCommandWifiAccessPointEnable(std::string_view accessPointId, const std::optional<Microsoft::Net::Wifi::Ieee80211AccessPointConfiguration>& ieee80211AccessPointConfiguration = std::nullopt);
 
     /**
      * @brief Handle a command to disable a Wi-Fi access point.

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandlerOperations.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandlerOperations.hxx
@@ -21,12 +21,17 @@ struct NetRemoteCliHandlerOperations :
     NetRemoteCliHandlerOperations() = delete;
 
     /**
-     * Prevent copying and moving of this object. 
+     * Prevent copying and moving of this object.
      */
     NetRemoteCliHandlerOperations(const NetRemoteCliHandlerOperations&) = delete;
+
     NetRemoteCliHandlerOperations(NetRemoteCliHandlerOperations&&) = delete;
-    NetRemoteCliHandlerOperations& operator=(const NetRemoteCliHandlerOperations&) = delete;
-    NetRemoteCliHandlerOperations& operator=(NetRemoteCliHandlerOperations&&) = delete;
+
+    NetRemoteCliHandlerOperations&
+    operator=(const NetRemoteCliHandlerOperations&) = delete;
+
+    NetRemoteCliHandlerOperations&
+    operator=(NetRemoteCliHandlerOperations&&) = delete;
 
     /**
      * @brief Construct a new NetRemoteCliHandlerOperations object with the specified server connection.
@@ -41,6 +46,22 @@ struct NetRemoteCliHandlerOperations :
     void
     WifiEnumerateAccessPoints() override;
 
+    /**
+     * @brief Enable the specified WiFi access point.
+     *
+     * @param accessPointId The identifier of the access point to enable.
+     */
+    void
+    WifiAccessPointEnable(std::string_view accessPointId) override;
+
+    /**
+     * @brief Disable the specified WiFi access point.
+     *
+     * @param accessPointId The identifier of the access point to disable.
+     */
+    void
+    WifiAccessPointDisable(std::string_view accessPointId) override;
+
 private:
     std::shared_ptr<NetRemoteServerConnection> m_connection;
 };
@@ -53,12 +74,17 @@ struct NetRemoteCliHandlerOperationsFactory :
     ~NetRemoteCliHandlerOperationsFactory() override = default;
 
     /**
-     * Prevent copying and moving of this object. 
+     * Prevent copying and moving of this object.
      */
     NetRemoteCliHandlerOperationsFactory(const NetRemoteCliHandlerOperationsFactory&) = delete;
+
     NetRemoteCliHandlerOperationsFactory(NetRemoteCliHandlerOperationsFactory&&) = delete;
-    NetRemoteCliHandlerOperationsFactory& operator=(const NetRemoteCliHandlerOperationsFactory&) = delete;
-    NetRemoteCliHandlerOperationsFactory& operator=(NetRemoteCliHandlerOperationsFactory&&) = delete;
+
+    NetRemoteCliHandlerOperationsFactory&
+    operator=(const NetRemoteCliHandlerOperationsFactory&) = delete;
+
+    NetRemoteCliHandlerOperationsFactory&
+    operator=(NetRemoteCliHandlerOperationsFactory&&) = delete;
 
     /**
      * @brief Create a new INetRemoteCliHandlerOperationsFactory instance with the specified server connection.

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandlerOperations.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandlerOperations.hxx
@@ -3,9 +3,11 @@
 #define NET_REMOTE_CLI_HANDLER_OPERATIONS_HXX
 
 #include <memory>
+#include <optional>
 
 #include <microsoft/net/remote/INetRemoteCliHandlerOperations.hxx>
 #include <microsoft/net/remote/NetRemoteServerConnection.hxx>
+#include <microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx>
 
 namespace Microsoft::Net::Remote
 {
@@ -50,9 +52,10 @@ struct NetRemoteCliHandlerOperations :
      * @brief Enable the specified WiFi access point.
      *
      * @param accessPointId The identifier of the access point to enable.
+     * @param ieee80211AccessPointConfiguration The optional configuration to apply to the access point.
      */
     void
-    WifiAccessPointEnable(std::string_view accessPointId) override;
+    WifiAccessPointEnable(std::string_view accessPointId, const std::optional<Microsoft::Net::Wifi::Ieee80211AccessPointConfiguration>& ieee80211AccessPointConfiguration) override;
 
     /**
      * @brief Disable the specified WiFi access point.

--- a/src/common/wifi/core/CMakeLists.txt
+++ b/src/common/wifi/core/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(wifi-core
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/IAccessPointController.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/Ieee80211.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/Ieee80211AccessPointCapabilities.hxx
+        ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/Ieee80211AccessPointConfiguration.hxx
 )
 
 target_link_libraries(wifi-core

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx
@@ -1,0 +1,28 @@
+
+#ifndef IEEE_80211_ACCESS_POINT_CONFIGURATION
+#define IEEE_80211_ACCESS_POINT_CONFIGURATION
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <microsoft/net/wifi/Ieee80211.hxx>
+
+namespace Microsoft::Net::Wifi
+{
+/**
+ * @brief Configuration for an IEEE 802.11 access point.
+ */
+struct Ieee80211AccessPointConfiguration
+{
+    std::optional<std::string> Ssid;
+    std::optional<Ieee80211Bssid> Bssid;
+    std::optional<Ieee80211PhyType> PhyType;
+    std::unordered_map<Ieee80211SecurityProtocol, Ieee80211CipherSuite> PairwiseCipherSuites;
+    std::vector<Ieee80211AuthenticationAlgorithm> AuthenticationAlgorithms;
+    std::vector<Ieee80211FrequencyBand> FrequencyBands;
+};
+} // namespace Microsoft::Net::Wifi
+
+#endif // IEEE_80211_ACCESS_POINT_CONFIGURATION

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx
@@ -19,7 +19,7 @@ struct Ieee80211AccessPointConfiguration
     std::optional<std::string> Ssid;
     std::optional<Ieee80211Bssid> Bssid;
     std::optional<Ieee80211PhyType> PhyType;
-    std::unordered_map<Ieee80211SecurityProtocol, Ieee80211CipherSuite> PairwiseCipherSuites;
+    std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> PairwiseCipherSuites;
     std::vector<Ieee80211AuthenticationAlgorithm> AuthenticationAlgorithms;
     std::vector<Ieee80211FrequencyBand> FrequencyBands;
 };

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -522,6 +522,28 @@ ToDot11CipherSuiteConfigurations(const google::protobuf::RepeatedPtrField<Dot11C
     return dot11CipherSuiteConfigurationsStrong;
 }
 
+std::vector<Dot11CipherSuiteConfiguration>
+ToDot11CipherSuiteConfigurations(const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuiteConfigurations) noexcept
+{
+    std::vector<Dot11CipherSuiteConfiguration> dot11CipherSuiteConfigurations(std::size(ieee80211CipherSuiteConfigurations));
+
+    std::ranges::transform(ieee80211CipherSuiteConfigurations, std::begin(dot11CipherSuiteConfigurations), [](const auto& ieee80211CipherSuiteConfiguration) {
+        const auto dot11SecurityProtocol = ToDot11SecurityProtocol(ieee80211CipherSuiteConfiguration.first);
+        std::vector<Dot11CipherSuite> dot11CipherSuites(std::size(ieee80211CipherSuiteConfiguration.second));
+        std::ranges::transform(ieee80211CipherSuiteConfiguration.second, std::begin(dot11CipherSuites), ToDot11CipherSuite);
+
+        Dot11CipherSuiteConfiguration dot11CipherSuiteConfiguration{};
+        dot11CipherSuiteConfiguration.set_securityprotocol(dot11SecurityProtocol);
+        *dot11CipherSuiteConfiguration.mutable_ciphersuites() = {
+            std::make_move_iterator(std::begin(dot11CipherSuites)),
+            std::make_move_iterator(std::end(dot11CipherSuites))
+        };
+        return dot11CipherSuiteConfiguration;
+    });
+
+    return dot11CipherSuiteConfigurations;
+}
+
 std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>
 FromDot11CipherSuiteConfigurations(const std::unordered_map<Dot11SecurityProtocol, std::vector<Dot11CipherSuite>>& dot11CipherSuiteConfigurations) noexcept
 {

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -1,5 +1,6 @@
 
 #include <algorithm>
+#include <cstdlib>
 #include <iterator>
 #include <ranges>
 #include <unordered_map>
@@ -15,7 +16,6 @@
 namespace Microsoft::Net::Wifi
 {
 using Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode;
-using Microsoft::Net::Wifi::AccessPointOperationStatusCode;
 
 WifiAccessPointOperationStatusCode
 ToDot11AccessPointOperationStatusCode(AccessPointOperationStatusCode& accessPointOperationStatusCode) noexcept
@@ -61,9 +61,6 @@ FromDot11AccessPointOperationStatusCode(WifiAccessPointOperationStatusCode wifiA
     }
 }
 
-using Microsoft::Net::Wifi::Dot11SecurityProtocol;
-using Microsoft::Net::Wifi::Ieee80211SecurityProtocol;
-
 Dot11SecurityProtocol
 ToDot11SecurityProtocol(Ieee80211SecurityProtocol ieee80211SecurityProtocol) noexcept
 {
@@ -97,9 +94,6 @@ FromDot11SecurityProtocol(Dot11SecurityProtocol dot11SecurityProtocol) noexcept
         return Ieee80211SecurityProtocol::Unknown;
     }
 }
-
-using Microsoft::Net::Wifi::Dot11PhyType;
-using Microsoft::Net::Wifi::Ieee80211PhyType;
 
 Dot11PhyType
 ToDot11PhyType(const Ieee80211PhyType ieee80211PhyType) noexcept
@@ -152,9 +146,6 @@ FromDot11PhyType(const Dot11PhyType dot11PhyType) noexcept
         return Ieee80211PhyType::Unknown;
     }
 }
-
-using Microsoft::Net::Wifi::Dot11FrequencyBand;
-using Microsoft::Net::Wifi::Ieee80211FrequencyBand;
 
 Dot11FrequencyBand
 ToDot11FrequencyBand(const Ieee80211FrequencyBand ieee80211FrequencyBand) noexcept
@@ -265,9 +256,6 @@ FromDot11SetFrequencyBandsRequest(const WifiAccessPointSetFrequencyBandsRequest&
     return ieee80211FrequencyBands;
 }
 
-using Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm;
-using Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm;
-
 Dot11AuthenticationAlgorithm
 ToDot11AuthenticationAlgorithm(const Ieee80211AuthenticationAlgorithm ieee80211AuthenticationAlgorithm) noexcept
 {
@@ -328,9 +316,6 @@ FromDot11AuthenticationAlgorithm(const Dot11AuthenticationAlgorithm dot11Authent
         return Ieee80211AuthenticationAlgorithm::Unknown;
     }
 }
-
-using Microsoft::Net::Wifi::Dot11AkmSuite;
-using Microsoft::Net::Wifi::Ieee80211AkmSuite;
 
 Dot11AkmSuite
 ToDot11AkmSuite(const Ieee80211AkmSuite ieee80211AkmSuite) noexcept
@@ -433,9 +418,6 @@ FromDot11AkmSuite(const Dot11AkmSuite dot11AkmSuite) noexcept
         return Ieee80211AkmSuite::Reserved0; // FIXME: this needs to be an invalid value instead
     }
 }
-
-using Microsoft::Net::Wifi::Dot11CipherSuite;
-using Microsoft::Net::Wifi::Ieee80211CipherSuite;
 
 Dot11CipherSuite
 ToDot11CipherSuite(const Ieee80211CipherSuite ieee80211CipherSuite) noexcept
@@ -558,9 +540,6 @@ FromDot11CipherSuiteConfigurations(const std::unordered_map<Dot11SecurityProtoco
 
     return ieee80211CipherSuiteConfigurations;
 }
-
-using Microsoft::Net::Wifi::Dot11AccessPointCapabilities;
-using Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities;
 
 Dot11AccessPointCapabilities
 ToDot11AccessPointCapabilities(const Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) noexcept

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -171,6 +171,15 @@ ToDot11FrequencyBand(const Ieee80211FrequencyBand ieee80211FrequencyBand) noexce
     }
 }
 
+std::vector<Dot11FrequencyBand>
+ToDot11FrequencyBands(const std::vector<Ieee80211FrequencyBand>& ieee80211FrequencyBands) noexcept
+{
+    std::vector<Dot11FrequencyBand> dot11FrequencyBands(static_cast<std::size_t>(std::size(ieee80211FrequencyBands)));
+    std::ranges::transform(ieee80211FrequencyBands, std::begin(dot11FrequencyBands), ToDot11FrequencyBand);
+
+    return dot11FrequencyBands;
+}
+
 Ieee80211FrequencyBand
 FromDot11FrequencyBand(const Dot11FrequencyBand dot11FrequencyBand) noexcept
 {
@@ -283,6 +292,15 @@ ToDot11AuthenticationAlgorithm(const Ieee80211AuthenticationAlgorithm ieee80211A
     default:
         return Dot11AuthenticationAlgorithm::Dot11AuthenticationAlgorithmUnknown;
     }
+}
+
+std::vector<Dot11AuthenticationAlgorithm>
+ToDot11AuthenticationAlgorithms(const std::vector<Ieee80211AuthenticationAlgorithm>& ieee80211AuthenticationAlgorithms) noexcept
+{
+    std::vector<Dot11AuthenticationAlgorithm> dot11AuthenticationAlgorithms(static_cast<std::size_t>(std::size(ieee80211AuthenticationAlgorithms)));
+    std::ranges::transform(ieee80211AuthenticationAlgorithms, std::begin(dot11AuthenticationAlgorithms), ToDot11AuthenticationAlgorithm);
+
+    return dot11AuthenticationAlgorithms;
 }
 
 Ieee80211AuthenticationAlgorithm

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -528,8 +528,9 @@ ToDot11CipherSuiteConfigurations(const std::unordered_map<Ieee80211SecurityProto
     std::vector<Dot11CipherSuiteConfiguration> dot11CipherSuiteConfigurations(std::size(ieee80211CipherSuiteConfigurations));
 
     std::ranges::transform(ieee80211CipherSuiteConfigurations, std::begin(dot11CipherSuiteConfigurations), [](const auto& ieee80211CipherSuiteConfiguration) {
-        const auto dot11SecurityProtocol = ToDot11SecurityProtocol(ieee80211CipherSuiteConfiguration.first);
-        std::vector<Dot11CipherSuite> dot11CipherSuites(std::size(ieee80211CipherSuiteConfiguration.second));
+        const auto& [ieee80211SecurityProtocol, ieee80211CipherSuites] = ieee80211CipherSuiteConfiguration;
+        const auto dot11SecurityProtocol = ToDot11SecurityProtocol(ieee80211SecurityProtocol);
+        std::vector<Dot11CipherSuite> dot11CipherSuites(std::size(ieee80211CipherSuites));
         std::ranges::transform(ieee80211CipherSuiteConfiguration.second, std::begin(dot11CipherSuites), ToDot11CipherSuite);
 
         Dot11CipherSuiteConfiguration dot11CipherSuiteConfiguration{};

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -204,6 +204,15 @@ std::unordered_map<Microsoft::Net::Wifi::Dot11SecurityProtocol, std::vector<Micr
 ToDot11CipherSuiteConfigurations(const google::protobuf::RepeatedPtrField<Microsoft::Net::Wifi::Dot11CipherSuiteConfiguration>& dot11CipherSuiteConfigurations) noexcept;
 
 /**
+ * @brief Convert the specified map of Ieee80211SecurityProtocol to Ieee80211CipherSuite to the equivalent vector of Dot11CipherSuiteConfiguratios.
+ *
+ * @param ieee80211CipherSuiteConfigurations The map of Ieee80211SecurityProtocol to Ieee80211CipherSuite to convert.
+ * @return std::vector<Microsoft::Net::Wifi::Dot11CipherSuiteConfiguration>
+ */
+std::vector<Microsoft::Net::Wifi::Dot11CipherSuiteConfiguration>
+ToDot11CipherSuiteConfigurations(const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuiteConfigurations) noexcept;
+
+/**
  * @brief Convert the specified map of Dot11SecurityProtocol to Dot11CipherSuite to the equivalent map of IEEE 802.11 security protocol to cipher suite.
  *
  * @param dot11CipherSuiteConfigurations The map of Dot11SecurityProtocol to Dot11CipherSuite to convert.

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -77,6 +77,15 @@ Microsoft::Net::Wifi::Dot11FrequencyBand
 ToDot11FrequencyBand(Microsoft::Net::Wifi::Ieee80211FrequencyBand ieee80211FrequencyBand) noexcept;
 
 /**
+ * @brief Convert the specified IEEE 802.11 frequency bands to the equivalent Dot11FrequencyBands.
+ *
+ * @param ieee80211FrequencyBands The IEEE 802.11 frequency bands to convert.
+ * @return std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>
+ */
+std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>
+ToDot11FrequencyBands(const std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand>& ieee80211FrequencyBands) noexcept;
+
+/**
  * @brief Obtain a vector of Dot11FrequencyBands from the specified WifiAccessPointSetFrequencyBandsRequest.
  *
  * @param request The request to extract the Dot11FrequencyBands from.
@@ -121,6 +130,15 @@ FromDot11SetFrequencyBandsRequest(const Microsoft::Net::Remote::Wifi::WifiAccess
  */
 Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm
 ToDot11AuthenticationAlgorithm(Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm ieee80211AuthenticationAlgorithm) noexcept;
+
+/**
+ * @brief Convert the specified IEEE 802.11 authentication algorithms to the equivalent Dot11AuthenticationAlgorithms.
+ *
+ * @param ieee80211AuthenticationAlgorithms The IEEE 802.11 authentication algorithms to convert.
+ * @return std::vector<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm>
+ */
+std::vector<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm>
+ToDot11AuthenticationAlgorithms(const std::vector<Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm>& ieee80211AuthenticationAlgorithms) noexcept;
 
 /**
  * @brief Obtain a vector of Dot11AuthenticationAlgorithms from the specified Dot11AccessPointConfiguration.

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -20,215 +20,215 @@ namespace Microsoft::Net::Wifi
  * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode
  */
 Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode
-ToDot11AccessPointOperationStatusCode(Microsoft::Net::Wifi::AccessPointOperationStatusCode& accessPointOperationStatusCode) noexcept;
+ToDot11AccessPointOperationStatusCode(AccessPointOperationStatusCode& accessPointOperationStatusCode) noexcept;
 
 /**
  * @brief Convert the specified AccessPointOperationStatus to the equivalent WifiAccessPointOperationStatusCode.
  *
  * @param wifiAccessPointOperationStatusCode The AccessPointOperationStatus to convert.
- * @return Microsoft::Net::Wifi::AccessPointOperationStatusCode
+ * @return AccessPointOperationStatusCode
  */
-Microsoft::Net::Wifi::AccessPointOperationStatusCode
+AccessPointOperationStatusCode
 FromDot11AccessPointOperationStatusCode(Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatusCode wifiAccessPointOperationStatusCode) noexcept;
 
 /**
  * @brief Convert the specified Ieee80211SecurityProtocol to the equivalent Dot11SecurityProtocol.
  *
  * @param ieee80211SecurityProtocol The IEEE 802.11 security protocol to convert.
- * @return Microsoft::Net::Wifi::Dot11SecurityProtocol
+ * @return Dot11SecurityProtocol
  */
-Microsoft::Net::Wifi::Dot11SecurityProtocol
-ToDot11SecurityProtocol(Microsoft::Net::Wifi::Ieee80211SecurityProtocol ieee80211SecurityProtocol) noexcept;
+Dot11SecurityProtocol
+ToDot11SecurityProtocol(Ieee80211SecurityProtocol ieee80211SecurityProtocol) noexcept;
 
 /**
  * @brief Convert the specified Dot11SecurityProtocol to the equivalent Ieee80211SecurityProtocol.
  *
  * @param dot11SecurityProtocol The Dot11SecurityProtocol to convert.
- * @return Microsoft::Net::Wifi::Ieee80211SecurityProtocol
+ * @return Ieee80211SecurityProtocol
  */
-Microsoft::Net::Wifi::Ieee80211SecurityProtocol
-FromDot11SecurityProtocol(Microsoft::Net::Wifi::Dot11SecurityProtocol dot11SecurityProtocol) noexcept;
+Ieee80211SecurityProtocol
+FromDot11SecurityProtocol(Dot11SecurityProtocol dot11SecurityProtocol) noexcept;
 
 /**
  * @brief Convert the specified Dot11PhyType to the equivalent IEEE 802.11 protocol.
  *
  * @param ieee80211PhyType The IEEE 802.11 PHY type to convert.
- * @return Microsoft::Net::Wifi::Dot11PhyType
+ * @return Dot11PhyType
  */
-Microsoft::Net::Wifi::Dot11PhyType
-ToDot11PhyType(Microsoft::Net::Wifi::Ieee80211PhyType ieee80211PhyType) noexcept;
+Dot11PhyType
+ToDot11PhyType(Ieee80211PhyType ieee80211PhyType) noexcept;
 
 /**
  * @brief Convert the specified Dot11PhyType to the equivalent IEEE 802.11 protocol.
  *
  * @param dot11PhyType The Dot11PhyType to convert.
- * @return Microsoft::Net::Wifi::Ieee80211PhyType
+ * @return Ieee80211PhyType
  */
-Microsoft::Net::Wifi::Ieee80211PhyType
-FromDot11PhyType(Microsoft::Net::Wifi::Dot11PhyType dot11PhyType) noexcept;
+Ieee80211PhyType
+FromDot11PhyType(Dot11PhyType dot11PhyType) noexcept;
 
 /**
  * @brief Convert the specified Dot11FrequencyBand to the equivalent IEEE 802.11 frequency band.
  *
  * @param ieee80211FrequencyBand The IEEE 802.11 frequency band to convert.
- * @return Microsoft::Net::Wifi::Dot11FrequencyBand
+ * @return Dot11FrequencyBand
  */
-Microsoft::Net::Wifi::Dot11FrequencyBand
-ToDot11FrequencyBand(Microsoft::Net::Wifi::Ieee80211FrequencyBand ieee80211FrequencyBand) noexcept;
+Dot11FrequencyBand
+ToDot11FrequencyBand(Ieee80211FrequencyBand ieee80211FrequencyBand) noexcept;
 
 /**
  * @brief Convert the specified IEEE 802.11 frequency bands to the equivalent Dot11FrequencyBands.
  *
  * @param ieee80211FrequencyBands The IEEE 802.11 frequency bands to convert.
- * @return std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>
+ * @return std::vector<Dot11FrequencyBand>
  */
-std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>
-ToDot11FrequencyBands(const std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand>& ieee80211FrequencyBands) noexcept;
+std::vector<Dot11FrequencyBand>
+ToDot11FrequencyBands(const std::vector<Ieee80211FrequencyBand>& ieee80211FrequencyBands) noexcept;
 
 /**
  * @brief Obtain a vector of Dot11FrequencyBands from the specified WifiAccessPointSetFrequencyBandsRequest.
  *
  * @param request The request to extract the Dot11FrequencyBands from.
- * @return std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>
+ * @return std::vector<Dot11FrequencyBand>
  */
-std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>
+std::vector<Dot11FrequencyBand>
 ToDot11FrequencyBands(const Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest& request) noexcept;
 
 /**
  * @brief Obtain a vector of Dot11FrequencyBands from the specified Dot11AccessPointConfiguration.
  *
  * @param dot11AccessPointConfiguration The Dot11AccessPointConfiguration to extract the Dot11FrequencyBands from.
- * @return std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>
+ * @return std::vector<Dot11FrequencyBand>
  */
-std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>
-ToDot11FrequencyBands(const Microsoft::Net::Wifi::Dot11AccessPointConfiguration& dot11AccessPointConfiguration) noexcept;
+std::vector<Dot11FrequencyBand>
+ToDot11FrequencyBands(const Dot11AccessPointConfiguration& dot11AccessPointConfiguration) noexcept;
 
 /**
  * @brief Convert the specified Dot11FrequencyBand to the equivalent IEEE 802.11 frequency band.
  *
  * @param dot11FrequencyBand The Dot11FrequencyBand to convert.
- * @return Microsoft::Net::Wifi::Ieee80211FrequencyBand
+ * @return Ieee80211FrequencyBand
  */
-Microsoft::Net::Wifi::Ieee80211FrequencyBand
-FromDot11FrequencyBand(Microsoft::Net::Wifi::Dot11FrequencyBand dot11FrequencyBand) noexcept;
+Ieee80211FrequencyBand
+FromDot11FrequencyBand(Dot11FrequencyBand dot11FrequencyBand) noexcept;
 
 /**
  * @brief Obtain the equivalent IEEE 802.11 frequency band from the Dot11FrequencyBands in the
  * WifiAccessPointSetFrequencyBandsRequest.
  *
  * @param request
- * @return std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand>
+ * @return std::vector<Ieee80211FrequencyBand>
  */
-std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand>
+std::vector<Ieee80211FrequencyBand>
 FromDot11SetFrequencyBandsRequest(const Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest& request);
 
 /**
  * @brief Convert the specified IEEE 802.11 authentication algorithm to the equivalent Dot11AuthenticationAlgorithm.
  *
  * @param ieee80211AuthenticationAlgorithm The IEEE 802.11 authentication algorithm to convert.
- * @return Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm
+ * @return Dot11AuthenticationAlgorithm
  */
-Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm
-ToDot11AuthenticationAlgorithm(Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm ieee80211AuthenticationAlgorithm) noexcept;
+Dot11AuthenticationAlgorithm
+ToDot11AuthenticationAlgorithm(Ieee80211AuthenticationAlgorithm ieee80211AuthenticationAlgorithm) noexcept;
 
 /**
  * @brief Convert the specified IEEE 802.11 authentication algorithms to the equivalent Dot11AuthenticationAlgorithms.
  *
  * @param ieee80211AuthenticationAlgorithms The IEEE 802.11 authentication algorithms to convert.
- * @return std::vector<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm>
+ * @return std::vector<Dot11AuthenticationAlgorithm>
  */
-std::vector<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm>
-ToDot11AuthenticationAlgorithms(const std::vector<Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm>& ieee80211AuthenticationAlgorithms) noexcept;
+std::vector<Dot11AuthenticationAlgorithm>
+ToDot11AuthenticationAlgorithms(const std::vector<Ieee80211AuthenticationAlgorithm>& ieee80211AuthenticationAlgorithms) noexcept;
 
 /**
  * @brief Obtain a vector of Dot11AuthenticationAlgorithms from the specified Dot11AccessPointConfiguration.
  *
  * @param dot11AccessPointConfiguration The Dot11AccessPointConfiguration to extract the Dot11AuthenticationAlgorithms from.
- * @return std::vector<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm>
+ * @return std::vector<Dot11AuthenticationAlgorithm>
  */
-std::vector<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm>
-ToDot11AuthenticationAlgorithms(const Microsoft::Net::Wifi::Dot11AccessPointConfiguration& dot11AccessPointConfiguration) noexcept;
+std::vector<Dot11AuthenticationAlgorithm>
+ToDot11AuthenticationAlgorithms(const Dot11AccessPointConfiguration& dot11AccessPointConfiguration) noexcept;
 
 /**
  * @brief Convert the specified Dot11AuthenticationAlgorithm to the equivalent IEEE 802.11 authentication algorithm.
  *
  * @param dot11AuthenticationAlgorithm The Dot11AuthenticationAlgorithm to convert.
- * @return Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm
+ * @return Ieee80211AuthenticationAlgorithm
  */
-Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm
-FromDot11AuthenticationAlgorithm(Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm dot11AuthenticationAlgorithm) noexcept;
+Ieee80211AuthenticationAlgorithm
+FromDot11AuthenticationAlgorithm(Dot11AuthenticationAlgorithm dot11AuthenticationAlgorithm) noexcept;
 
 /**
  * @brief Convert the specified IEEE 802.11 AKM suite algorithm to the equivalent Dot11CipherAlgorithm.
  *
  * @param ieee80211AkmSuite The IEEE 802.11 AKM suite algorithm to convert.
- * @return Microsoft::Net::Wifi::Dot11AkmSuite
+ * @return Dot11AkmSuite
  */
-Microsoft::Net::Wifi::Dot11AkmSuite
-ToDot11AkmSuite(Microsoft::Net::Wifi::Ieee80211AkmSuite ieee80211AkmSuite) noexcept;
+Dot11AkmSuite
+ToDot11AkmSuite(Ieee80211AkmSuite ieee80211AkmSuite) noexcept;
 
 /**
  * @brief Convert the specified Dot11AkmSuite to the equivalent IEEE 802.11 AKM suite algorithm.
  *
  * @param dot11AkmSuite The Dot11AkmSuite to convert.
- * @return Microsoft::Net::Wifi::Ieee80211AkmSuite
+ * @return Ieee80211AkmSuite
  */
-Microsoft::Net::Wifi::Ieee80211AkmSuite
-FromDot11AkmSuite(Microsoft::Net::Wifi::Dot11AkmSuite dot11AkmSuite) noexcept;
+Ieee80211AkmSuite
+FromDot11AkmSuite(Dot11AkmSuite dot11AkmSuite) noexcept;
 
 /**
  * @brief Convert the specified IEEE 802.11 cipher suite algorithm to the equivalent Dot11CipherSuite.
  *
  * @param ieee80211CipherSuite The IEEE 802.11 cipher suite algorithm to convert.
- * @return Microsoft::Net::Wifi::Dot11CipherSuite
+ * @return Dot11CipherSuite
  */
-Microsoft::Net::Wifi::Dot11CipherSuite
-ToDot11CipherSuite(Microsoft::Net::Wifi::Ieee80211CipherSuite ieee80211CipherSuite) noexcept;
+Dot11CipherSuite
+ToDot11CipherSuite(Ieee80211CipherSuite ieee80211CipherSuite) noexcept;
 
 /**
  * @brief Convert the specified Dot11CipherSuite to the equivalent IEEE 802.11 cipher suite algorithm.
  *
  * @param dot11CipherSuite The Dot11CipherSuite to convert.
- * @return Microsoft::Net::Wifi::Ieee80211CipherSuite
+ * @return Ieee80211CipherSuite
  */
-Microsoft::Net::Wifi::Ieee80211CipherSuite
-FromDot11CipherSuite(Microsoft::Net::Wifi::Dot11CipherSuite dot11CipherSuite) noexcept;
+Ieee80211CipherSuite
+FromDot11CipherSuite(Dot11CipherSuite dot11CipherSuite) noexcept;
 
 /**
  * @brief Convert the specified repeated field of Dot11CipherSuiteConfigurations to the equivalent map of Dot11SecurityProtocol to Dot11CipherSuite.
  *
  * @param dot11CipherSuiteConfigurations The repeated field of Dot11CipherSuiteConfigurations to convert.
- * @return std::unordered_map<Microsoft::Net::Wifi::Dot11SecurityProtocol, std::vector<Microsoft::Net::Wifi::Dot11CipherSuite>>
+ * @return std::unordered_map<Dot11SecurityProtocol, std::vector<Dot11CipherSuite>>
  */
-std::unordered_map<Microsoft::Net::Wifi::Dot11SecurityProtocol, std::vector<Microsoft::Net::Wifi::Dot11CipherSuite>>
-ToDot11CipherSuiteConfigurations(const google::protobuf::RepeatedPtrField<Microsoft::Net::Wifi::Dot11CipherSuiteConfiguration>& dot11CipherSuiteConfigurations) noexcept;
+std::unordered_map<Dot11SecurityProtocol, std::vector<Dot11CipherSuite>>
+ToDot11CipherSuiteConfigurations(const google::protobuf::RepeatedPtrField<Dot11CipherSuiteConfiguration>& dot11CipherSuiteConfigurations) noexcept;
 
 /**
  * @brief Convert the specified map of Ieee80211SecurityProtocol to Ieee80211CipherSuite to the equivalent vector of Dot11CipherSuiteConfiguratios.
  *
  * @param ieee80211CipherSuiteConfigurations The map of Ieee80211SecurityProtocol to Ieee80211CipherSuite to convert.
- * @return std::vector<Microsoft::Net::Wifi::Dot11CipherSuiteConfiguration>
+ * @return std::vector<Dot11CipherSuiteConfiguration>
  */
-std::vector<Microsoft::Net::Wifi::Dot11CipherSuiteConfiguration>
+std::vector<Dot11CipherSuiteConfiguration>
 ToDot11CipherSuiteConfigurations(const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuiteConfigurations) noexcept;
 
 /**
  * @brief Convert the specified map of Dot11SecurityProtocol to Dot11CipherSuite to the equivalent map of IEEE 802.11 security protocol to cipher suite.
  *
  * @param dot11CipherSuiteConfigurations The map of Dot11SecurityProtocol to Dot11CipherSuite to convert.
- * @return std::unordered_map<Microsoft::Net::Wifi::Ieee80211SecurityProtocol, std::vector<Microsoft::Net::Wifi::Ieee80211CipherSuite>>
+ * @return std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>
  */
-std::unordered_map<Microsoft::Net::Wifi::Ieee80211SecurityProtocol, std::vector<Microsoft::Net::Wifi::Ieee80211CipherSuite>>
-FromDot11CipherSuiteConfigurations(const std::unordered_map<Microsoft::Net::Wifi::Dot11SecurityProtocol, std::vector<Microsoft::Net::Wifi::Dot11CipherSuite>>& dot11CipherSuiteConfigurations) noexcept;
+std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>
+FromDot11CipherSuiteConfigurations(const std::unordered_map<Dot11SecurityProtocol, std::vector<Dot11CipherSuite>>& dot11CipherSuiteConfigurations) noexcept;
 
 /**
  * @brief Convert the specified IEEE 802.11 access point capabilities to the equivalent Dot11AccessPointCapabilities.
  *
  * @param ieee80211AccessPointCapabilities The IEEE 802.11 access point capabilities to convert.
- * @return Microsoft::Net::Wifi::Dot11AccessPointCapabilities
+ * @return Dot11AccessPointCapabilities
  */
-Microsoft::Net::Wifi::Dot11AccessPointCapabilities
-ToDot11AccessPointCapabilities(const Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) noexcept;
+Dot11AccessPointCapabilities
+ToDot11AccessPointCapabilities(const Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) noexcept;
 
 } // namespace Microsoft::Net::Wifi
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow access points to be enabled and disabled from the command line tool.
* Allow end-to-end functionality to be incorporated into functional tests.

### Technical Details

* Add commands `ap-enable` and `ap-disable` to the `netremote-cli` tool.
* Add `Ieee80211AccessPointConfiguration` structure corresponding to dot11 equivalent, use for CLI input to the API.
* Add helper adaption functions for converting between `Ieee80211*` types in `Ieee80211AccessPointConfiguration` to those in `Dot11AccessPointConfiguration`.
* Link `wifi-core` and `wifi-core-adapter-dot11` libraries to `netremote-cli` library.
* Implement access point configuration enforcement in `WifiAccessPointEnable` API using above implementation bits.

### Test Results

* All unit tests pass.
* As-hoc testing still in progress.

### Reviewer Focus

* None

### Future Work

* 

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
