### PR TITLE
Nlaparsefixes

### DIFF
--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -113,6 +113,8 @@ NetRemoteCli::AddSubcommandWifiAccessPointEnable(CLI::App* parent)
         OnWifiAccessPointEnable();
     });
 
+    cliAppWifiAccessPointEnable->add_option("id", m_cliData->WifiAccessPointId, "The identifier of the access point to enable")->required();
+
     return cliAppWifiAccessPointEnable;
 }
 

--- a/src/linux/libnl-helpers/Netlink80211Wiphy.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Wiphy.cxx
@@ -168,7 +168,7 @@ Nl80211Wiphy::Parse(struct nl_msg *nl80211Message) noexcept
 
     // Parse the message.
     std::array<struct nlattr *, NL80211_ATTR_MAX + 1> wiphyAttributes{};
-    int ret = nla_parse(std::data(wiphyAttributes), std::size(wiphyAttributes), genlmsg_attrdata(genl80211MessageHeader, 0), genlmsg_attrlen(genl80211MessageHeader, 0), nullptr);
+    int ret = nla_parse(std::data(wiphyAttributes), std::size(wiphyAttributes) - 1, genlmsg_attrdata(genl80211MessageHeader, 0), genlmsg_attrlen(genl80211MessageHeader, 0), nullptr);
     if (ret < 0) {
         LOGE << std::format("Failed to parse netlink message attributes with error {} ({})", ret, strerror(-ret)); // NOLINT(concurrency-mt-unsafe)
         return std::nullopt;

--- a/src/linux/libnl-helpers/Netlink80211WiphyBand.cxx
+++ b/src/linux/libnl-helpers/Netlink80211WiphyBand.cxx
@@ -34,7 +34,7 @@ Nl80211WiphyBand::Parse(struct nlattr *wiphyBand) noexcept
 {
     // Parse the attribute message.
     std::array<struct nlattr *, NL80211_BAND_ATTR_MAX + 1> wiphyBandAttributes{};
-    int ret = nla_parse(std::data(wiphyBandAttributes), std::size(wiphyBandAttributes), static_cast<struct nlattr *>(nla_data(wiphyBand)), nla_len(wiphyBand), nullptr);
+    int ret = nla_parse(std::data(wiphyBandAttributes), std::size(wiphyBandAttributes) - 1, static_cast<struct nlattr *>(nla_data(wiphyBand)), nla_len(wiphyBand), nullptr);
     if (ret < 0) {
         LOGE << std::format("Failed to parse wiphy band attributes with error {} ({})", ret, nl_geterror(ret));
         return std::nullopt;
@@ -76,7 +76,7 @@ Nl80211WiphyBand::Parse(struct nlattr *wiphyBand) noexcept
         nla_for_each_nested(bitRate, wiphyBandAttributes[NL80211_BAND_ATTR_RATES], remainingBitRates)
         {
             std::array<struct nlattr *, NL80211_BITRATE_ATTR_MAX + 1> bitRateAttributes{};
-            ret = nla_parse(std::data(bitRateAttributes), std::size(bitRateAttributes), static_cast<struct nlattr *>(nla_data(bitRate)), nla_len(bitRate), nullptr);
+            ret = nla_parse(std::data(bitRateAttributes), std::size(bitRateAttributes) - 1, static_cast<struct nlattr *>(nla_data(bitRate)), nla_len(bitRate), nullptr);
             if (ret < 0) {
                 LOGW << std::format("Failed to parse wiphy band bit rate attributes with error {} ({})", ret, nl_geterror(ret));
                 return std::nullopt;

--- a/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -194,7 +194,7 @@ AccessPointDiscoveryAgentOperationsNetlink::ProcessNetlinkMessage(struct nl_msg 
 
     // Parse the message attributes.
     std::array<struct nlattr *, NL80211_ATTR_MAX + 1> netlinkMessageAttributes{};
-    int ret = nla_parse(std::data(netlinkMessageAttributes), std::size(netlinkMessageAttributes), genlmsg_attrdata(genlMessageHeader, 0), genlmsg_attrlen(genlMessageHeader, 0), nullptr);
+    int ret = nla_parse(std::data(netlinkMessageAttributes), std::size(netlinkMessageAttributes) - 1, genlmsg_attrdata(genlMessageHeader, 0), genlmsg_attrlen(genlMessageHeader, 0), nullptr);
     if (ret < 0) {
         LOGE << std::format("Failed to parse netlink message attributes with error {} ({})", ret, strerror(-ret));
         return NL_SKIP;


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure no stack overflows occur.

### Technical Details

* Some uses of `nla_parse` were not updated when originally fixed in #221. Fix those off-by-1 instances here.
* Add missing `--id` option for `netremote-cli` command `ap-enable`.

### Test Results

* Ran `netremote-server` locally and then `netremote-cli wifi enumaps` and verified an ASAN-induced crash no longer occurs.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
