### PR TITLE
Complete work to expose security protocols

### DIFF
--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -57,7 +57,8 @@ NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::Dot11Access
     }
 
     constexpr auto PhyTypePrefixLength = std::size(std::string_view("Dot11PhyType"));
-    ss << indent0
+    ss << '\n'
+       << indent0
        << "Phy Types: ";
     for (const auto& phyType : accessPointCapabilities.phytypes()) {
         std::string_view phyTypeName(magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11PhyType>(phyType)));

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -52,8 +52,10 @@ NetRemoteAccessPointCapabilitiesToString(const Microsoft::Net::Wifi::Dot11Access
     for (const auto& securityProtocol : accessPointCapabilities.securityprotocols()) {
         std::string_view securityProtocolName(magic_enum::enum_name(static_cast<Microsoft::Net::Wifi::Dot11SecurityProtocol>(securityProtocol)));
         securityProtocolName.remove_prefix(SecurityProtocolPrefixLength);
-        ss << '\n'
-           << indent1 << securityProtocolName;
+        if (securityProtocol != accessPointCapabilities.securityprotocols()[0]) {
+            ss << ' ';
+        }
+        ss << securityProtocolName;
     }
 
     constexpr auto PhyTypePrefixLength = std::size(std::string_view("Dot11PhyType"));

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -238,6 +238,56 @@ constexpr std::initializer_list<uint32_t> AllIeee80211Akms{
 };
 
 /**
+ * @brief List of AKM suites that are supported by WPA v1.
+ */
+constexpr std::initializer_list<Ieee80211AkmSuite> Wpa1AkmSuites{
+    Ieee80211AkmSuite::Ieee8021x,
+    Ieee80211AkmSuite::Psk,
+};
+
+/**
+ * @brief List of AKM suites that are supported by WPA v2.
+ */
+constexpr std::initializer_list<Ieee80211AkmSuite> Wpa2AkmSuites{
+    Ieee80211AkmSuite::Ieee8021x,
+    Ieee80211AkmSuite::Psk,
+};
+
+/**
+ * @brief List of AKM suites that are supported by WPA v3.
+ */
+constexpr std::initializer_list<Ieee80211AkmSuite> Wpa3AkmSuites{
+    Ieee80211AkmSuite::Ieee8021x,
+    Ieee80211AkmSuite::Ft8021x,
+    Ieee80211AkmSuite::FtSae,
+    Ieee80211AkmSuite::Ieee8021xSuiteB,
+    Ieee80211AkmSuite::Ieee8011xSuiteB192,
+    Ieee80211AkmSuite::Sae,
+    Ieee80211AkmSuite::Owe,
+};
+
+/**
+ * @brief Obtain a list of supported AKM suites for a given security protocol.
+ *
+ * @param securityProtocol The security protocol to obtain AKM suites for.
+ * @return constexpr std::initializer_list<Ieee80211AkmSuite>
+ */
+constexpr std::initializer_list<Ieee80211AkmSuite>
+WpaAkmSuites(const Ieee80211SecurityProtocol& securityProtocol)
+{
+    switch (securityProtocol) {
+    case Ieee80211SecurityProtocol::Wpa:
+        return Wpa1AkmSuites;
+    case Ieee80211SecurityProtocol::Wpa2:
+        return Wpa2AkmSuites;
+    case Ieee80211SecurityProtocol::Wpa3:
+        return Wpa3AkmSuites;
+    default:
+        return {};
+    }
+}
+
+/**
  * @brief Cipher suite identifiers or "selectors".
  *
  * Defined in IEEE 802.11-2020, Section 9.4.2.24.2, Table 9-149.
@@ -278,6 +328,53 @@ enum class Ieee80211CipherSuite : uint32_t {
     Wep104 = MakeIeee80211Suite(Ieee80211CipherSuiteIdWep104),
     Wep40 = MakeIeee80211Suite(Ieee80211CipherSuiteIdWep40),
 };
+
+/**
+ * @brief List of cipher suites supported by WPA v1.
+ */
+constexpr std::initializer_list<Ieee80211CipherSuite> Wpa1CipherSuites{
+    Ieee80211CipherSuite::Tkip,
+};
+
+/**
+ * @brief List of cipher suites supported by WPA v2.
+ */
+constexpr std::initializer_list<Ieee80211CipherSuite> Wpa2CipherSuites{
+    Ieee80211CipherSuite::Tkip,
+    Ieee80211CipherSuite::Ccmp128,
+};
+
+/**
+ * @brief List of cipher suites supported by WPA v3.
+ */
+constexpr std::initializer_list<Ieee80211CipherSuite> Wpa3CipherSuites{
+    Ieee80211CipherSuite::Tkip,
+    Ieee80211CipherSuite::Ccmp128,
+    Ieee80211CipherSuite::Ccmp256,
+    Ieee80211CipherSuite::Gcmp128,
+    Ieee80211CipherSuite::Gcmp256,
+};
+
+/**
+ * @brief Obtain a list of supported cipher suites for a given security protocol.
+ *
+ * @param securityProtocol The security protocol to obtain cipher suites for.
+ * @return constexpr std::initializer_list<Ieee80211CipherSuite>
+ */
+constexpr std::initializer_list<Ieee80211CipherSuite>
+WpaCipherSuites(const Ieee80211SecurityProtocol& securityProtocol)
+{
+    switch (securityProtocol) {
+    case Ieee80211SecurityProtocol::Wpa:
+        return Wpa1CipherSuites;
+    case Ieee80211SecurityProtocol::Wpa2:
+        return Wpa2CipherSuites;
+    case Ieee80211SecurityProtocol::Wpa3:
+        return Wpa3CipherSuites;
+    default:
+        return {};
+    }
+}
 
 /**
  * @brief IEEE 802.11 BSS Types.

--- a/src/linux/libnl-helpers/CMakeLists.txt
+++ b/src/linux/libnl-helpers/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX ${LIBNL_HELPERS_PUBLIC_INCLUDE}/${LIBNL_
 
 target_sources(libnl-helpers
     PRIVATE
+        Ieee80211Nl80211Adapters.cxx
         Netlink80211.cxx
         Netlink80211Interface.cxx
         NetlinkException.cxx
@@ -22,9 +23,10 @@ target_sources(libnl-helpers
     BASE_DIRS ${LIBNL_HELPERS_PUBLIC_INCLUDE}
     FILES
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkErrorCategory.hxx
+        ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkException.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkMessage.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkSocket.hxx
-        ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkException.hxx
+        ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Ieee80211Nl80211Adapters.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211Interface.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211ProtocolState.hxx

--- a/src/linux/libnl-helpers/Ieee80211Nl80211Adapters.cxx
+++ b/src/linux/libnl-helpers/Ieee80211Nl80211Adapters.cxx
@@ -7,20 +7,34 @@
 #include <string_view>
 #include <vector>
 
-#include <Wpa/ProtocolHostapd.hxx>
 #include <linux/nl80211.h>
 #include <magic_enum.hpp>
+#include <microsoft/net/netlink/nl80211/Ieee80211Nl80211Adapters.hxx>
 #include <microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx>
 #include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
-#include <plog/Log.h>
 
-#include "Ieee80211Nl80211Adapters.hxx"
+#include <plog/Log.h>
 
 using Microsoft::Net::Netlink::Nl80211::Nl80211Wiphy;
 
 namespace Microsoft::Net::Wifi
 {
+Ieee80211SecurityProtocol
+Nl80211WpaVersionToIeee80211SecurityProtocol(nl80211_wpa_versions nl80211WpaVersion) noexcept
+{
+    switch (nl80211WpaVersion) {
+    case NL80211_WPA_VERSION_1:
+        return Ieee80211SecurityProtocol::Wpa;
+    case NL80211_WPA_VERSION_2:
+        return Ieee80211SecurityProtocol::Wpa2;
+    case NL80211_WPA_VERSION_3:
+        return Ieee80211SecurityProtocol::Wpa3;
+    default:
+        return Ieee80211SecurityProtocol::Unknown;
+    }
+}
+
 Ieee80211CipherSuite
 Nl80211CipherSuiteToIeee80211CipherSuite(uint32_t nl80211CipherSuite) noexcept
 {

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Ieee80211Nl80211Adapters.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Ieee80211Nl80211Adapters.hxx
@@ -7,13 +7,21 @@
 #include <string_view>
 #include <vector>
 
-#include <Wpa/ProtocolHostapd.hxx>
 #include <linux/nl80211.h>
 #include <microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 
 namespace Microsoft::Net::Wifi
 {
+/**
+ * @brief Convert the specific nl80211 wpa version to the equivalent Ieee80211SecurityProtocol.
+ *
+ * @param nl80211WpaVersion The nl80211 wpa version to convert.
+ * @return Ieee80211SecurityProtocol
+ */
+Ieee80211SecurityProtocol
+Nl80211WpaVersionToIeee80211SecurityProtocol(nl80211_wpa_versions nl80211WpaVersion) noexcept;
+
 /**
  * @brief Convert the specified nl80211 cipher suite value to the equivalent Ieee80211CipherSuite.
  *

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx
@@ -32,6 +32,7 @@ struct Nl80211Wiphy
     std::vector<uint32_t> CipherSuites;
     std::unordered_map<nl80211_band, Nl80211WiphyBand> Bands;
     std::vector<nl80211_iftype> SupportedInterfaceTypes;
+    std::vector<nl80211_wpa_versions> WpaVersions;
     bool SupportsRoaming;
 
     /**
@@ -76,9 +77,15 @@ private:
      * @brief Construct a new Nl80211Wiphy object.
      *
      * @param index The wiphy index.
-     * @param name The wiphy name.
+     * @param name The wiphy (interface) name.
+     * @param akmSuites The supported AKM suites.
+     * @param cipherSuites The supported cipher suites.
+     * @param bands The supported frequency bands.
+     * @param supportedInterfaceTypes The supported interface types.
+     * @param wpaVersions The supported WPA versions (security protocols).
+     * @param supportsRoaming Whether roaming is supported.
      */
-    Nl80211Wiphy(uint32_t index, std::string_view name, std::vector<uint32_t> akmSuites, std::vector<uint32_t> cipherSuites, std::unordered_map<nl80211_band, Nl80211WiphyBand> bands, std::vector<nl80211_iftype> supportedInterfaceTypes, bool supportsRoaming) noexcept;
+    Nl80211Wiphy(uint32_t index, std::string_view name, std::vector<uint32_t> akmSuites, std::vector<uint32_t> cipherSuites, std::unordered_map<nl80211_band, Nl80211WiphyBand> bands, std::vector<nl80211_iftype> supportedInterfaceTypes, std::vector<nl80211_wpa_versions> wpaVersions, bool supportsRoaming) noexcept;
 
     /**
      * @brief Creates a new Nl80211Wiphy object, using the specified function to add an identifier to the message,

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -70,6 +70,10 @@ AccessPointControllerLinux::GetCapabilities(Ieee80211AccessPointCapabilities& ie
     capabilities.CipherSuites = std::vector<Ieee80211CipherSuite>(std::size(wiphy->CipherSuites));
     std::ranges::transform(wiphy->CipherSuites, std::begin(capabilities.CipherSuites), Nl80211CipherSuiteToIeee80211CipherSuite);
 
+    // Convert security types.
+    capabilities.SecurityProtocols = std::vector<Ieee80211SecurityProtocol>(std::size(wiphy->WpaVersions));
+    std::ranges::transform(wiphy->WpaVersions, std::begin(capabilities.SecurityProtocols), Nl80211WpaVersionToIeee80211SecurityProtocol);
+
     ieee80211AccessPointCapabilities = std::move(capabilities);
 
     status.Code = AccessPointOperationStatusCode::Succeeded;

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -16,6 +16,7 @@
 #include <Wpa/IHostapd.hxx>
 #include <Wpa/ProtocolHostapd.hxx>
 #include <magic_enum.hpp>
+#include <microsoft/net/netlink/nl80211/Ieee80211Nl80211Adapters.hxx>
 #include <microsoft/net/netlink/nl80211/Netlink80211Wiphy.hxx>
 #include <microsoft/net/wifi/AccessPointController.hxx>
 #include <microsoft/net/wifi/AccessPointControllerLinux.hxx>
@@ -26,7 +27,6 @@
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
 #include <plog/Severity.h>
 
-#include "Ieee80211Nl80211Adapters.hxx"
 #include "Ieee80211WpaAdapters.hxx"
 
 using namespace Microsoft::Net::Wifi;

--- a/src/linux/wifi/core/CMakeLists.txt
+++ b/src/linux/wifi/core/CMakeLists.txt
@@ -9,8 +9,6 @@ target_sources(wifi-core-linux
     PRIVATE
         AccessPointControllerLinux.cxx
         AccessPointLinux.cxx
-        Ieee80211Nl80211Adapters.cxx
-        Ieee80211Nl80211Adapters.hxx
         Ieee80211WpaAdapters.cxx
         Ieee80211WpaAdapters.hxx
     PUBLIC

--- a/src/linux/wpa-controller/include/Wpa/WpaController.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaController.hxx
@@ -114,8 +114,8 @@ struct WpaController
          */
         static constexpr auto MessageSizeMax = 4096;
 
-        static constexpr auto DefaultPathHostapd = "/var/run/hostapd";
-        static constexpr auto DefaultPathWpaSupplicant = "/var/run/wpa_supplicant";
+        static constexpr auto DefaultPathHostapd = "/usr/local/var/run/hostapd";
+        static constexpr auto DefaultPathWpaSupplicant = "/usr/local/var/run/wpa_supplicant";
 
         /**
          * @brief Get the default path for the control socket of the specified daemon.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure security protocols are provided in capability information.
* Ensure security protocols are provided in cli output for `wifi enumaps` command.

### Technical Details

* Combine all security protocols to a single line for `ToString()` output.
* Define constants for cipher suites and akms assoicated with each security protocol.
* Move Ieee80211 <-> wiphy adapters to `libnl-helpers` library where they belong.
* Add list of supported `nl80211_wpa_versions` 
* Update default wpa/hostapd control socket search directory.

### Test Results

* All unit tests pass.
* `wifi enumap` command now shows security protocols:
<img width="811" alt="image" src="https://github.com/microsoft/netremote/assets/2082148/f190f49b-e15b-4beb-9dca-5f9427cffd55">

### Reviewer Focus

* None

### Future Work

* Determine if WPA versions can be indirectly obtained without using the `NL80211_ATTR_WPA_VERSIONS` attribute selector.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
