### PR TITLE
Enable brief and verbose output for 'wifi enumaps' cli command.

### DIFF
--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -96,9 +96,10 @@ CLI::App*
 NetRemoteCli::AddSubcommandWifiEnumerateAccessPoints(CLI::App* parent)
 {
     auto* cliAppWifiEnumerateAccessPoints = parent->add_subcommand("enumerate-access-points", "Enumerate available Wi-Fi access points");
+    cliAppWifiEnumerateAccessPoints->add_flag("--detailed", m_cliData->DetailedOutput, "Show detailed information about each access point");
     cliAppWifiEnumerateAccessPoints->alias("enumaps");
     cliAppWifiEnumerateAccessPoints->callback([this] {
-        OnWifiEnumerateAccessPoints();
+        OnWifiEnumerateAccessPoints(m_cliData->DetailedOutput.value_or(false));
     });
 
     return cliAppWifiEnumerateAccessPoints;
@@ -155,9 +156,9 @@ NetRemoteCli::OnServerAddressChanged(const std::string& serverAddressArg)
 }
 
 void
-NetRemoteCli::OnWifiEnumerateAccessPoints()
+NetRemoteCli::OnWifiEnumerateAccessPoints(bool detailedOutput)
 {
-    m_cliHandler->HandleCommandWifiEnumerateAccessPoints();
+    m_cliHandler->HandleCommandWifiEnumerateAccessPoints(detailedOutput);
 }
 
 void

--- a/src/common/tools/cli/NetRemoteCliHandler.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandler.cxx
@@ -38,7 +38,7 @@ NetRemoteCliHandler::GetParentStrongRef() const
 }
 
 void
-NetRemoteCliHandler::HandleCommandWifiEnumerateAccessPoints()
+NetRemoteCliHandler::HandleCommandWifiEnumerateAccessPoints(bool detailedOutput)
 {
     if (!m_operations) {
         LOGE << "No operations instance available to handle command";
@@ -52,7 +52,7 @@ NetRemoteCliHandler::HandleCommandWifiEnumerateAccessPoints()
     }
 
     LOGD << "Executing command WifiEnumerateAccessPoints";
-    m_operations->WifiEnumerateAccessPoints();
+    m_operations->WifiEnumerateAccessPoints(detailedOutput);
 }
 
 using Microsoft::Net::Wifi::Ieee80211AccessPointConfiguration;

--- a/src/common/tools/cli/include/microsoft/net/remote/INetRemoteCliHandlerOperations.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/INetRemoteCliHandlerOperations.hxx
@@ -35,9 +35,11 @@ struct INetRemoteCliHandlerOperations
 
     /**
      * @brief Enumerate available WiFi access points.
+     *
+     * @param detailedOutput Whether the output should be detailed (false) or brief (true, single line).
      */
     virtual void
-    WifiEnumerateAccessPoints() = 0;
+    WifiEnumerateAccessPoints(bool detailedOutput) = 0;
 
     /**
      * @brief Enable the specified WiFi access point.

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
@@ -96,18 +96,18 @@ private:
 
     /**
      * @brief Add the 'wifi ap-enable' sub-command.
-     * 
+     *
      * @param parent The parent app to add the sub-command to.
-     * @return CLI::App* 
+     * @return CLI::App*
      */
     CLI::App*
     AddSubcommandWifiAccessPointEnable(CLI::App* parent);
 
     /**
      * @brief Add the 'wifi ap-disable' sub-command.
-     * 
+     *
      * @param parent The parent app to add the sub-command to.
-     * @return CLI::App* 
+     * @return CLI::App*
      */
     CLI::App*
     AddSubcommandWifiAccessPointDisable(CLI::App* parent);
@@ -122,9 +122,11 @@ private:
 
     /**
      * @brief Handle the 'wifi enumerate-access-points' command.
+     *
+     * @param detailedOutput Whether the output should be detailed (false) or brief (true, single line).
      */
     void
-    OnWifiEnumerateAccessPoints();
+    OnWifiEnumerateAccessPoints(bool detailedOutput = false);
 
     /**
      * @brief Handle the 'wifi ap-enable' command.

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
@@ -2,6 +2,7 @@
 #ifndef NET_REMOTE_CLI_DATA_HXX
 #define NET_REMOTE_CLI_DATA_HXX
 
+#include <optional>
 #include <string>
 
 #include <microsoft/net/remote/NetRemoteClient.hxx>
@@ -19,6 +20,7 @@ struct NetRemoteCliData
 {
     std::string ServerAddress{ Protocol::NetRemoteProtocol::AddressDefault };
     NetRemoteCommandId Command{ NetRemoteCommandId::None };
+    std::optional<bool> DetailedOutput;
 
     std::string WifiAccessPointId{};
 };

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandler.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandler.hxx
@@ -62,9 +62,11 @@ struct NetRemoteCliHandler
 
     /**
      * @brief Handle a command request to enumerate available Wi-Fi access points.
+     *
+     * @param detailedOutput Whether the output should be detailed (false) or brief (true, single line).
      */
     void
-    HandleCommandWifiEnumerateAccessPoints();
+    HandleCommandWifiEnumerateAccessPoints(bool detailedOutput);
 
     /**
      * @brief Handle a command to enable a Wi-Fi access point.

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandlerOperations.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandlerOperations.hxx
@@ -44,9 +44,11 @@ struct NetRemoteCliHandlerOperations :
 
     /**
      * @brief Enumerate available WiFi access points.
+     *
+     * @param detailedOutput Whether the output should be detailed (false) or brief (true, single line).
      */
     void
-    WifiEnumerateAccessPoints() override;
+    WifiEnumerateAccessPoints(bool detailedOutput) override;
 
     /**
      * @brief Enable the specified WiFi access point.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow to enumerate only essential information about APs from the cli.

### Technical Details

* Add functions to generate brief (new) and detailed (existing) AP capabilities.
* Add `--detailed` cli flag for the `enumaps` command.

### Test Results

* All unit tests pass.
* Brief output:
<img width="812" alt="image" src="https://github.com/microsoft/netremote/assets/2082148/e2486344-b38a-485d-9c0f-2e609c59fb78">

* Verbose output:
<img width="875" alt="image" src="https://github.com/microsoft/netremote/assets/2082148/e50166e0-f379-426e-b67c-f895bce0f03e">

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
