### PR TITLE
Add DataStreamPing unary RPC for checking server availability

### DIFF
--- a/protocol/protos/NetRemoteDataStreamingService.proto
+++ b/protocol/protos/NetRemoteDataStreamingService.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 
 package Microsoft.Net.Remote.Service;
 
+import "google/protobuf/empty.proto";
+
 import "NetRemote.proto";
 import "NetRemoteDataStream.proto";
 
@@ -11,4 +13,5 @@ service NetRemoteDataStreaming
     rpc DataStreamUpload (stream Microsoft.Net.Remote.DataStream.DataStreamUploadData) returns (Microsoft.Net.Remote.DataStream.DataStreamUploadResult);
     rpc DataStreamDownload (Microsoft.Net.Remote.DataStream.DataStreamDownloadRequest) returns (stream Microsoft.Net.Remote.DataStream.DataStreamDownloadData);
     rpc DataStreamBidirectional (stream Microsoft.Net.Remote.DataStream.DataStreamUploadData) returns (stream Microsoft.Net.Remote.DataStream.DataStreamDownloadData);
+    rpc DataStreamPing (google.protobuf.Empty) returns (google.protobuf.Empty);
 }

--- a/src/common/service/NetRemoteDataStreamingService.cxx
+++ b/src/common/service/NetRemoteDataStreamingService.cxx
@@ -36,3 +36,14 @@ NetRemoteDataStreamingService::DataStreamBidirectional([[maybe_unused]] grpc::Ca
 
     return std::make_unique<Reactors::DataStreamReaderWriter>().release();
 }
+
+grpc::ServerUnaryReactor*
+NetRemoteDataStreamingService::DataStreamPing(grpc::CallbackServerContext* context, [[maybe_unused]] const google::protobuf::Empty* request, [[maybe_unused]] google::protobuf::Empty* response)
+{
+    const NetRemoteApiTrace traceMe{};
+
+    auto* reactor = context->DefaultReactor();
+    reactor->Finish(grpc::Status::OK);
+
+    return reactor;
+}

--- a/src/common/service/NetRemoteDataStreamingService.cxx
+++ b/src/common/service/NetRemoteDataStreamingService.cxx
@@ -1,6 +1,7 @@
 
 #include <memory>
 
+#include <google/protobuf/empty.pb.h>
 #include <grpcpp/server_context.h>
 #include <grpcpp/support/server_callback.h>
 #include <microsoft/net/remote/NetRemoteDataStreamingService.hxx>

--- a/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
@@ -50,6 +50,15 @@ private:
      */
     grpc::ServerBidiReactor<Microsoft::Net::Remote::DataStream::DataStreamUploadData, Microsoft::Net::Remote::DataStream::DataStreamDownloadData>*
     DataStreamBidirectional(grpc::CallbackServerContext* context) override;
+
+    /**
+     * @brief Allows the client to ping the server for availability.
+     *
+     * @param context
+     * @return grpc::ServerUnaryReactor*
+     */
+    grpc::ServerUnaryReactor*
+    DataStreamPing(grpc::CallbackServerContext* context, const google::protobuf::Empty* request, google::protobuf::Empty* response) override;
 };
 } // namespace Microsoft::Net::Remote::Service
 

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -9,6 +9,8 @@
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
+#include <google/protobuf/empty.pb.h>
+#include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/impl/codegen/status.h>
 #include <grpcpp/impl/codegen/status_code_enum.h>
@@ -245,10 +247,10 @@ TEST_CASE("DataStreamPing API", "[basic][rpc][client][remote][stream]")
     SECTION("Can be called")
     {
         grpc::ClientContext clientContext{};
-        google::protobuf::Empty request{};
+        const google::protobuf::Empty request{};
         google::protobuf::Empty response{};
 
-        grpc::Status status = client->DataStreamPing(&clientContext, request, &response);
+        const grpc::Status status = client->DataStreamPing(&clientContext, request, &response);
         REQUIRE(status.ok());
     }
 }

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -222,3 +222,33 @@ TEST_CASE("DataStreamBidirectional API", "[basic][rpc][client][remote][stream]")
         REQUIRE(lostDataBlockSequenceNumbers.empty());
     }
 }
+
+TEST_CASE("DataStreamPing API", "[basic][rpc][client][remote][stream]")
+{
+    using namespace Microsoft::Net::Remote;
+    using namespace Microsoft::Net::Remote::DataStream;
+    using namespace Microsoft::Net::Remote::Service;
+
+    using Microsoft::Net::Remote::Test::DataStreamReaderWriter;
+    using Microsoft::Net::Remote::Test::RemoteServiceAddressHttp;
+
+    const NetRemoteServerConfiguration Configuration{
+        .ServerAddress = RemoteServiceAddressHttp,
+    };
+
+    NetRemoteServer server{ Configuration };
+    server.Run();
+
+    auto channel = grpc::CreateChannel(RemoteServiceAddressHttp, grpc::InsecureChannelCredentials());
+    auto client = NetRemoteDataStreaming::NewStub(channel);
+
+    SECTION("Can be called")
+    {
+        grpc::ClientContext clientContext{};
+        google::protobuf::Empty request{};
+        google::protobuf::Empty response{};
+
+        grpc::Status status = client->DataStreamPing(&clientContext, request, &response);
+        REQUIRE(status.ok());
+    }
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

Due to the nature of RPCs in gRPC, the only way to see if the remote server is unavailable is to try an RPC and check the status of the failure for status code 14 (UNAVAILABLE). Because the data streaming service uses streaming RPCs, this status code is not returned until operations are complete.

With this behavior, clients cannot check the availability of the server without trying the RPC and waiting for all operations to complete, which may be immediate if the server is unavailable or indefinite in successful streams. This is undesirable in cases where a disconnect occurs during a previous RPC call (server is unavailable) and the client wants to know exactly when the server is ready to successfully handle the next RPC.

Therefore, this PR adds a simple unary RPC called `DataStreamPing` that allows clients to quickly get a status from the server without request/response objects.

### Technical Details

* Added `DataStreamPing` unary RPC to `NetRemoteDataStreamingService`.
* Added a unit test for `DataStreamPing`.

### Test Results

All tests pass

### Reviewer Focus

None.

### Future Work

None.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
