### PR TITLE
Wi-Fi AccessPoint[Enable|Disable] Improvements

### DIFF
--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -123,10 +123,16 @@ NetRemoteCli::AddSubcommandWifiAccessPointEnable(CLI::App* parent)
     auto* cliAppWifiAccessPointEnable = parent->add_subcommand("access-point-enable", "Enable a Wi-Fi access point");
     cliAppWifiAccessPointEnable->alias("ap-enable");
     cliAppWifiAccessPointEnable->callback([this] {
-        OnWifiAccessPointEnable();
+        Ieee80211AccessPointConfiguration ieee80211AccessPointConfiguration{};
+        if (!std::empty(m_cliData->WifiAccessPointSsid)) {
+            ieee80211AccessPointConfiguration.Ssid = m_cliData->WifiAccessPointSsid;
+        }
+
+        OnWifiAccessPointEnable(m_cliData->WifiAccessPointId, &ieee80211AccessPointConfiguration);
     });
 
     cliAppWifiAccessPointEnable->add_option("id", m_cliData->WifiAccessPointId, "The identifier of the access point to enable")->required();
+    cliAppWifiAccessPointEnable->add_option("ssid,--ssid", m_cliData->WifiAccessPointSsid, "The SSID of the access point to enable");
 
     return cliAppWifiAccessPointEnable;
 }
@@ -137,7 +143,7 @@ NetRemoteCli::AddSubcommandWifiAccessPointDisable(CLI::App* parent)
     auto* cliAppWifiAccessPointDisable = parent->add_subcommand("access-point-disable", "Disable a Wi-Fi access point");
     cliAppWifiAccessPointDisable->alias("ap-disable");
     cliAppWifiAccessPointDisable->callback([this] {
-        OnWifiAccessPointEnable();
+        OnWifiAccessPointDisable(m_cliData->WifiAccessPointId);
     });
 
     cliAppWifiAccessPointDisable->add_option("id", m_cliData->WifiAccessPointId, "The identifier of the access point to disable")->required();
@@ -174,13 +180,13 @@ NetRemoteCli::OnWifiAccessPointsEnumerate(bool detailedOutput)
 }
 
 void
-NetRemoteCli::OnWifiAccessPointEnable(const Ieee80211AccessPointConfiguration* ieee80211AccessPointConfiguration)
+NetRemoteCli::OnWifiAccessPointEnable(std::string_view accessPointId, const Ieee80211AccessPointConfiguration* ieee80211AccessPointConfiguration)
 {
-    m_cliHandler->HandleCommandWifiAccessPointEnable(m_cliData->WifiAccessPointId, ieee80211AccessPointConfiguration);
+    m_cliHandler->HandleCommandWifiAccessPointEnable(accessPointId, ieee80211AccessPointConfiguration);
 }
 
 void
-NetRemoteCli::OnWifiAccessPointDisable()
+NetRemoteCli::OnWifiAccessPointDisable(std::string_view accessPointId)
 {
-    m_cliHandler->HandleCommandWifiAccessPointDisable(m_cliData->WifiAccessPointId);
+    m_cliHandler->HandleCommandWifiAccessPointDisable(accessPointId);
 }

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -1,11 +1,13 @@
 
 #include <format>
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
 
 #include <CLI/App.hpp>
 #include <CLI/Error.hpp>
+#include <CLI/Validators.hpp>
 #include <microsoft/net/remote/NetRemoteCli.hxx>
 #include <microsoft/net/remote/NetRemoteCliData.hxx>
 #include <microsoft/net/remote/NetRemoteCliHandler.hxx>
@@ -109,6 +111,15 @@ NetRemoteCli::AddSubcommandWifiAccessPointsEnumerate(CLI::App* parent)
 CLI::App*
 NetRemoteCli::AddSubcommandWifiAccessPointEnable(CLI::App* parent)
 {
+    const std::map<std::string, Ieee80211PhyType> Ieee80211PhyTypeNames{
+        { "a", Ieee80211PhyType::A },
+        { "b", Ieee80211PhyType::B },
+        { "g", Ieee80211PhyType::G },
+        { "n", Ieee80211PhyType::N },
+        { "ac", Ieee80211PhyType::AC },
+        { "ax", Ieee80211PhyType::AX },
+    };
+
     auto* cliAppWifiAccessPointEnable = parent->add_subcommand("access-point-enable", "Enable a Wi-Fi access point");
     cliAppWifiAccessPointEnable->alias("ap-enable");
     cliAppWifiAccessPointEnable->callback([this] {

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -127,12 +127,17 @@ NetRemoteCli::AddSubcommandWifiAccessPointEnable(CLI::App* parent)
         if (!std::empty(m_cliData->WifiAccessPointSsid)) {
             ieee80211AccessPointConfiguration.Ssid = m_cliData->WifiAccessPointSsid;
         }
+        if (m_cliData->WifiAccessPointPhyType != Ieee80211PhyType::Unknown) {
+            ieee80211AccessPointConfiguration.PhyType = m_cliData->WifiAccessPointPhyType;
+        }
 
         OnWifiAccessPointEnable(m_cliData->WifiAccessPointId, &ieee80211AccessPointConfiguration);
     });
 
     cliAppWifiAccessPointEnable->add_option("id", m_cliData->WifiAccessPointId, "The identifier of the access point to enable")->required();
-    cliAppWifiAccessPointEnable->add_option("ssid,--ssid", m_cliData->WifiAccessPointSsid, "The SSID of the access point to enable");
+    cliAppWifiAccessPointEnable->add_option("--ssid", m_cliData->WifiAccessPointSsid, "The SSID of the access point to enable");
+    cliAppWifiAccessPointEnable->add_option("--phy,--phyType,", m_cliData->WifiAccessPointPhyType, "The PHY type of the access point to enable")
+        ->transform(CLI::CheckedTransformer(Ieee80211PhyTypeNames, CLI::ignore_case));
 
     return cliAppWifiAccessPointEnable;
 }

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -100,7 +100,7 @@ NetRemoteCli::AddSubcommandWifiAccessPointsEnumerate(CLI::App* parent)
 {
     auto* cliAppWifiAccessPointsEnumerate = parent->add_subcommand("enumerate-access-points", "Enumerate available Wi-Fi access points");
     cliAppWifiAccessPointsEnumerate->add_flag("--detailed", m_cliData->DetailedOutput, "Show detailed information about each access point");
-    cliAppWifiAccessPointsEnumerate->alias("enumaps");
+    cliAppWifiAccessPointsEnumerate->alias("enumaps")->alias("enum")->alias("aps");
     cliAppWifiAccessPointsEnumerate->callback([this] {
         OnWifiAccessPointsEnumerate(m_cliData->DetailedOutput.value_or(false));
     });
@@ -121,7 +121,7 @@ NetRemoteCli::AddSubcommandWifiAccessPointEnable(CLI::App* parent)
     };
 
     auto* cliAppWifiAccessPointEnable = parent->add_subcommand("access-point-enable", "Enable a Wi-Fi access point");
-    cliAppWifiAccessPointEnable->alias("ap-enable");
+    cliAppWifiAccessPointEnable->alias("ap-enable")->alias("enable")->alias("ap-en");
     cliAppWifiAccessPointEnable->callback([this] {
         Ieee80211AccessPointConfiguration ieee80211AccessPointConfiguration{};
         if (!std::empty(m_cliData->WifiAccessPointSsid)) {
@@ -146,7 +146,7 @@ CLI::App*
 NetRemoteCli::AddSubcommandWifiAccessPointDisable(CLI::App* parent)
 {
     auto* cliAppWifiAccessPointDisable = parent->add_subcommand("access-point-disable", "Disable a Wi-Fi access point");
-    cliAppWifiAccessPointDisable->alias("ap-disable");
+    cliAppWifiAccessPointDisable->alias("ap-disable")->alias("disable")->alias("ap-dis");
     cliAppWifiAccessPointDisable->callback([this] {
         OnWifiAccessPointDisable(m_cliData->WifiAccessPointId);
     });

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
@@ -132,16 +132,19 @@ private:
     /**
      * @brief Handle the 'wifi ap-enable' command.
      *
+     * @param accessPointId The identifier of the access point to enable.
      * @param ieee80211AccessPointConfiguration Optional configuration for the access point to enable.
      */
     void
-    OnWifiAccessPointEnable(const Microsoft::Net::Wifi::Ieee80211AccessPointConfiguration* ieee80211AccessPointConfiguration = nullptr);
+    OnWifiAccessPointEnable(std::string_view accessPointId, const Microsoft::Net::Wifi::Ieee80211AccessPointConfiguration* ieee80211AccessPointConfiguration = nullptr);
 
     /**
      * @brief Handle the 'wifi ap-disable' command.
+     *
+     * @param accessPointId The identifier of the access point to disable.
      */
     void
-    OnWifiAccessPointDisable();
+    OnWifiAccessPointDisable(std::string_view accessPointId);
 
 private:
     std::shared_ptr<NetRemoteCliData> m_cliData;

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
@@ -6,6 +6,7 @@
 #include <string>
 
 #include <microsoft/net/remote/protocol/NetRemoteProtocol.hxx>
+#include <microsoft/net/wifi/Ieee80211.hxx>
 
 namespace Microsoft::Net::Remote
 {
@@ -22,6 +23,7 @@ struct NetRemoteCliData
 
     std::string WifiAccessPointId{};
     std::string WifiAccessPointSsid{};
+    Microsoft::Net::Wifi::Ieee80211PhyType WifiAccessPointPhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
 };
 } // namespace Microsoft::Net::Remote
 

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
@@ -21,6 +21,7 @@ struct NetRemoteCliData
     std::optional<bool> DetailedOutput;
 
     std::string WifiAccessPointId{};
+    std::string WifiAccessPointSsid{};
 };
 } // namespace Microsoft::Net::Remote
 

--- a/src/linux/libnl-helpers/Netlink80211.cxx
+++ b/src/linux/libnl-helpers/Netlink80211.cxx
@@ -5,6 +5,7 @@
 #include <system_error>
 
 #include <linux/nl80211.h>
+#include <magic_enum.hpp>
 #include <microsoft/net/netlink/NetlinkErrorCategory.hxx>
 #include <microsoft/net/netlink/NetlinkSocket.hxx>
 #include <microsoft/net/netlink/nl80211/Netlink80211.hxx>
@@ -425,36 +426,12 @@ Nl80211CommandToString(nl80211_commands command) noexcept
 std::string_view
 Nl80211InterfaceTypeToString(nl80211_iftype interfaceType) noexcept
 {
-    switch (interfaceType) {
-    case NL80211_IFTYPE_UNSPECIFIED:
-        return "NL80211_IFTYPE_UNSPECIFIED";
-    case NL80211_IFTYPE_ADHOC:
-        return "NL80211_IFTYPE_ADHOC";
-    case NL80211_IFTYPE_STATION:
-        return "NL80211_IFTYPE_STATION";
-    case NL80211_IFTYPE_AP:
-        return "NL80211_IFTYPE_AP";
-    case NL80211_IFTYPE_AP_VLAN:
-        return "NL80211_IFTYPE_AP_VLAN";
-    case NL80211_IFTYPE_WDS:
-        return "NL80211_IFTYPE_WDS";
-    case NL80211_IFTYPE_MONITOR:
-        return "NL80211_IFTYPE_MONITOR";
-    case NL80211_IFTYPE_MESH_POINT:
-        return "NL80211_IFTYPE_MESH_POINT";
-    case NL80211_IFTYPE_P2P_CLIENT:
-        return "NL80211_IFTYPE_P2P_CLIENT";
-    case NL80211_IFTYPE_P2P_GO:
-        return "NL80211_IFTYPE_P2P_GO";
-    case NL80211_IFTYPE_P2P_DEVICE:
-        return "NL80211_IFTYPE_P2P_DEVICE";
-    case NL80211_IFTYPE_OCB:
-        return "NL80211_IFTYPE_OCB";
-    case NL80211_IFTYPE_NAN:
-        return "NL80211_IFTYPE_NAN";
-    default:
-        return "NL80211_IFTYPE_UNKNOWN";
-    }
+    static constexpr auto InterfaceTypePrefixLength{ std::size(std::string_view("NL80211_IFTYPE_")) };
+
+    auto interfaceTypeName{ magic_enum::enum_name(interfaceType) };
+    interfaceTypeName.remove_prefix(InterfaceTypePrefixLength);
+
+    return interfaceTypeName;
 }
 
 std::string_view

--- a/src/linux/libnl-helpers/Netlink80211Interface.cxx
+++ b/src/linux/libnl-helpers/Netlink80211Interface.cxx
@@ -45,7 +45,12 @@ Nl80211Interface::Nl80211Interface(std::string_view name, nl80211_iftype type, u
 std::string
 Nl80211Interface::ToString() const
 {
-    return std::format("[{}/{}] {} {}", Index, WiphyIndex, Name, magic_enum::enum_name(Type));
+    static constexpr auto InterfaceTypePrefixLength{ std::size(std::string_view("NL80211_IFTYPE_")) };
+
+    auto interfaceType = std::string_view{ magic_enum::enum_name(Type) };
+    interfaceType.remove_prefix(InterfaceTypePrefixLength);
+
+    return std::format("[{}/{}] {} {}", Index, WiphyIndex, Name, interfaceType);
 }
 
 /* static */
@@ -190,7 +195,10 @@ Nl80211Interface::IsAccessPoint() const noexcept
 bool
 Nl80211Interface::SupportsAccessPointMode() const noexcept
 {
-    return std::ranges::find_first_of(SupportedInterfaceTypes, Nl80211AccessPointInterfaceTypes) != std::cend(SupportedInterfaceTypes);
+    auto result = std::ranges::find_first_of(SupportedInterfaceTypes, Nl80211AccessPointInterfaceTypes);
+    auto isSupported = result != std::cend(SupportedInterfaceTypes);
+    return isSupported;
+    // return std::ranges::find_first_of(SupportedInterfaceTypes, Nl80211AccessPointInterfaceTypes) != std::cend(SupportedInterfaceTypes);
 }
 
 // NOLINTEND(concurrency-mt-unsafe)

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211.hxx
@@ -3,6 +3,7 @@
 #define NETLINK_82011_HXX
 
 #include <cstdint>
+#include <initializer_list>
 #include <string_view>
 #include <unordered_map>
 
@@ -31,6 +32,14 @@ static const std::unordered_map<Nl80211MulticastGroup, std::string_view> Nl80211
     { Nl80211MulticastGroup::Nan, NL80211_MULTICAST_GROUP_NAN },
 };
 // NOLINTEND(cert-err58-cpp)
+
+/**
+ * @brief List of interface types that indicate support for access point operation.
+ */
+constexpr std::initializer_list<nl80211_iftype> Nl80211AccessPointInterfaceTypes = {
+    nl80211_iftype::NL80211_IFTYPE_AP,
+    nl80211_iftype::NL80211_IFTYPE_AP_VLAN,
+};
 
 /**
  * @brief Convert an nl80211_commands enum value to a string.

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
@@ -24,8 +24,7 @@ struct Nl80211Interface
     std::string Name;
     nl80211_iftype Type{ nl80211_iftype::NL80211_IFTYPE_UNSPECIFIED };
     uint32_t Index{ 0 };
-    uint32_t WiphyIndex{ 0 };
-    std::vector<nl80211_iftype> SupportedInterfaceTypes{};
+    uint32_t WiphyIndex;
 
     Nl80211Interface() = default;
 
@@ -39,9 +38,8 @@ struct Nl80211Interface
      * @param type The nl80211_iftype of the interface.
      * @param index The interface index in the kernel.
      * @param wiphyIndex The phy interface index in the kernel.
-     * @param supportedInterfaceTypes The supported interface types.
      */
-    Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index, uint32_t wiphyIndex, std::vector<nl80211_iftype> supportedInterfaceTypes) noexcept;
+    Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index, uint32_t wiphyIndex) noexcept;
 
     /**
      * @brief Parse a netlink message into an Nl80211Interface. The netlink message must contain a response to the

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
@@ -25,6 +25,7 @@ struct Nl80211Interface
     nl80211_iftype Type{ nl80211_iftype::NL80211_IFTYPE_UNSPECIFIED };
     uint32_t Index{ 0 };
     uint32_t WiphyIndex{ 0 };
+    std::vector<nl80211_iftype> SupportedInterfaceTypes{};
 
     Nl80211Interface() = default;
 
@@ -38,8 +39,9 @@ struct Nl80211Interface
      * @param type The nl80211_iftype of the interface.
      * @param index The interface index in the kernel.
      * @param wiphyIndex The phy interface index in the kernel.
+     * @param supportedInterfaceTypes The supported interface types.
      */
-    Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index, uint32_t wiphyIndex) noexcept;
+    Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index, uint32_t wiphyIndex, std::vector<nl80211_iftype> supportedInterfaceTypes) noexcept;
 
     /**
      * @brief Parse a netlink message into an Nl80211Interface. The netlink message must contain a response to the
@@ -85,6 +87,15 @@ struct Nl80211Interface
      */
     bool
     IsAccessPoint() const noexcept;
+
+    /**
+     * @brief Indicates if the interface supports operating as an access point.
+     * 
+     * @return true The interface can be used as an access point.
+     * @return false The interface cannot be used as an access point.
+     */
+    bool
+    SupportsAccessPointMode() const noexcept;
 };
 
 } // namespace Microsoft::Net::Netlink::Nl80211

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
@@ -24,7 +24,7 @@ struct Nl80211Interface
     std::string Name;
     nl80211_iftype Type{ nl80211_iftype::NL80211_IFTYPE_UNSPECIFIED };
     uint32_t Index{ 0 };
-    uint32_t WiphyIndex;
+    uint32_t WiphyIndex{ 0 };
 
     Nl80211Interface() = default;
 
@@ -88,7 +88,7 @@ struct Nl80211Interface
 
     /**
      * @brief Indicates if the interface supports operating as an access point.
-     * 
+     *
      * @return true The interface can be used as an access point.
      * @return false The interface cannot be used as an access point.
      */

--- a/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
+++ b/src/linux/wifi/apmanager/include/microsoft/net/wifi/AccessPointDiscoveryAgentOperationsNetlink.hxx
@@ -7,7 +7,6 @@
 #include <memory>
 #include <stop_token>
 #include <thread>
-#include <unordered_set>
 #include <vector>
 
 #include <microsoft/net/netlink/NetlinkSocket.hxx>
@@ -126,7 +125,6 @@ private:
     int m_eventLoopStopFd{ -1 };
     std::jthread m_netlinkMessageProcessingThread;
 
-    std::unordered_set<Microsoft::Net::Netlink::Nl80211::Nl80211Interface> m_interfacesSeen;
     Microsoft::Net::Netlink::Nl80211::Nl80211ProtocolState &m_netlink80211ProtocolState;
 };
 } // namespace Microsoft::Net::Wifi

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -173,7 +173,6 @@ AccessPointControllerLinux::SetPhyType(Ieee80211PhyType ieeePhyType) noexcept
 
     std::string_view propertyKeyToSet;
     std::string_view propertyValueToSet;
-    bool hostapdOperationSucceeded{ false };
 
     // Attempt to set all required properties.
     try {

--- a/src/linux/wpa-controller/WpaController.cxx
+++ b/src/linux/wpa-controller/WpaController.cxx
@@ -15,6 +15,7 @@
 #include <Wpa/WpaController.hxx>
 #include <Wpa/WpaCore.hxx>
 #include <Wpa/WpaResponse.hxx>
+#include <magic_enum.hpp>
 #include <plog/Log.h>
 
 using namespace Wpa;
@@ -81,6 +82,8 @@ WpaController::GetCommandControlSocket()
         LOGE << std::format("Failed to open control socket for {} interface at {}.", m_interfaceName, controlSocketPath.c_str());
         return nullptr;
     }
+
+    LOGD << std::format("Opened {} control socket for {} interface at {}.", magic_enum::enum_name(m_type), m_interfaceName, controlSocketPath.c_str());
 
     // Update the member and return it.
     m_controlSocketCommand = controlSocket;


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure cycling between enabling and disabling APs works.
* Ensure disabled APs appear in enumeration.

### Technical Details

* Add aliases `enumaps`, `enum`, and `aps` for the `wifi enumerate-access-points` command.
* Add aliases `ap-enable`, `enable, and `ap-en` for the `wifi access-point-enable` command.
* Add aliases `ap-disable`, disable` and `ap-dis` for the `wifi-access-point-disable` command.
* Update `NetRemoteCli::` command handling functions to accept their arguments directly instead of later teasing them out of the `NetRemoteCliData` member.
* Allow specifying a SSID with the `wifi enable` command.
* Allow specifying a PHY type with the `wifi enable` command.
* Improve conversion from `nl80211_iftype` to string conversions and shorten strings.
* Add ability to determine if an `Nl80211Interface` supports AP mode.
* Filter out interfaces that don't support AP mode from access point discovery probes.
* Simplify nl80211 message processing for presence changes.
* Remove "seen" cache of nl80211 interfaces as it's no longer needed.
* Add debug log showing hostapd control socket path.
* Fix some `AccessPointControllerLinux` instances that were not updated to correctly handle `HostapdEexception`s.

### Test Results

* All unit tests pass.
* Cycling between `wifi enable <id>` and `wifi disable <id>` works, and access point with <id> continues to show up in `wifi enum` output.
* hostapd reflects set SSID and PHY type when set through `wifi ap enable <id> --ssid <ssid> --phy <phy>` (validated out-of-band using `hostapd_cli`).

### Reviewer Focus

* Nothing in particular.

### Future Work

* CLI commands `wifi enable` and `wifi disable` need to indicate when they succeed (no message is presently shown).
* Additional AP configuration needs to be accepted for `wifi enable` command (only PHY and SSID accepted so far).

### Checklist

- [X ] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
