### PR TITLE
Allow specifying authentication algorithm names and frequency bands with WifiAccessPointEnable API

### DIFF
--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -14,6 +15,8 @@
 #include <microsoft/net/remote/NetRemoteCliHandler.hxx>
 #include <microsoft/net/remote/NetRemoteServerConnection.hxx>
 #include <microsoft/net/remote/protocol/NetRemoteProtocol.hxx>
+#include <microsoft/net/wifi/Ieee80211.hxx>
+#include <microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx>
 #include <notstd/Memory.hxx>
 #include <plog/Log.h>
 
@@ -127,34 +130,46 @@ NetRemoteCli::WifiAccessPointEnableCallback()
     OnWifiAccessPointEnable(m_cliData->WifiAccessPointId, &ieee80211AccessPointConfiguration);
 }
 
+namespace detail
+{
+const std::map<std::string, Ieee80211PhyType> Ieee80211PhyTypeNames{
+    { "a", Ieee80211PhyType::A },
+    { "b", Ieee80211PhyType::B },
+    { "g", Ieee80211PhyType::G },
+    { "n", Ieee80211PhyType::N },
+    { "ac", Ieee80211PhyType::AC },
+    { "ax", Ieee80211PhyType::AX },
+};
+const std::map<std::string, Ieee80211FrequencyBand> Ieee80211FrequencyBandNames{
+    { "2", Ieee80211FrequencyBand::TwoPointFourGHz },
+    { "2.4", Ieee80211FrequencyBand::TwoPointFourGHz },
+    { "5", Ieee80211FrequencyBand::FiveGHz },
+    { "5.0", Ieee80211FrequencyBand::FiveGHz },
+    { "6", Ieee80211FrequencyBand::SixGHz },
+    { "6.0", Ieee80211FrequencyBand::SixGHz },
+};
+const std::map<std::string, Ieee80211AuthenticationAlgorithm> Ieee80211AuthenticationAlgorithmNames{
+    { "open", Ieee80211AuthenticationAlgorithm::OpenSystem },
+    { "open-system", Ieee80211AuthenticationAlgorithm::OpenSystem },
+    { "shared", Ieee80211AuthenticationAlgorithm::SharedKey },
+    { "shared-key", Ieee80211AuthenticationAlgorithm::SharedKey },
+    { "skey", Ieee80211AuthenticationAlgorithm::SharedKey },
+};
+} // namespace detail
+
 CLI::App*
 NetRemoteCli::AddSubcommandWifiAccessPointEnable(CLI::App* parent)
 {
-    const std::map<std::string, Ieee80211PhyType> Ieee80211PhyTypeNames{
-        { "a", Ieee80211PhyType::A },
-        { "b", Ieee80211PhyType::B },
-        { "g", Ieee80211PhyType::G },
-        { "n", Ieee80211PhyType::N },
-        { "ac", Ieee80211PhyType::AC },
-        { "ax", Ieee80211PhyType::AX },
-    };
-    const std::map<std::string, Ieee80211FrequencyBand> Ieee80211FrequencyBandNames{
-        { "2", Ieee80211FrequencyBand::TwoPointFourGHz },
-        { "2.4", Ieee80211FrequencyBand::TwoPointFourGHz },
-        { "5", Ieee80211FrequencyBand::FiveGHz },
-        { "5.0", Ieee80211FrequencyBand::FiveGHz },
-        { "6", Ieee80211FrequencyBand::SixGHz },
-        { "6.0", Ieee80211FrequencyBand::SixGHz },
-    };
-
     auto* cliAppWifiAccessPointEnable = parent->add_subcommand("access-point-enable", "Enable a Wi-Fi access point");
     cliAppWifiAccessPointEnable->alias("ap-enable")->alias("enable")->alias("ape");
     cliAppWifiAccessPointEnable->add_option("id", m_cliData->WifiAccessPointId, "The identifier of the access point to enable")->required();
     cliAppWifiAccessPointEnable->add_option("--ssid", m_cliData->WifiAccessPointSsid, "The SSID of the access point to enable");
     cliAppWifiAccessPointEnable->add_option("--phy,--phyType,", m_cliData->WifiAccessPointPhyType, "The PHY type of the access point to enable")
-        ->transform(CLI::CheckedTransformer(Ieee80211PhyTypeNames, CLI::ignore_case));
+        ->transform(CLI::CheckedTransformer(detail::Ieee80211PhyTypeNames, CLI::ignore_case));
     cliAppWifiAccessPointEnable->add_option("--freq,--freqs,--frequencies,--frequencyBand,--frequencyBands,--band,--bands", m_cliData->WifiAccessPointFrequencyBands, "The frequency bands of the access point to enable")
-        ->transform(CLI::CheckedTransformer(Ieee80211FrequencyBandNames));
+        ->transform(CLI::CheckedTransformer(detail::Ieee80211FrequencyBandNames));
+    cliAppWifiAccessPointEnable->add_option("--auth,--auths,--authAlg,--authAlgs,--authentication,--authenticationAlgorithm,--authenticationAlgorithms", m_cliData->WifiAccessPointAuthenticationAlgorithms, "The authentication algorithms of the access point to enable")
+        ->transform(CLI::CheckedTransformer(detail::Ieee80211AuthenticationAlgorithmNames, CLI::ignore_case));
     cliAppWifiAccessPointEnable->callback([this] {
         WifiAccessPointEnableCallback();
     });

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -2,6 +2,7 @@
 #include <format>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -132,29 +133,58 @@ NetRemoteCli::WifiAccessPointEnableCallback()
 
 namespace detail
 {
-const std::map<std::string, Ieee80211PhyType> Ieee80211PhyTypeNames{
-    { "a", Ieee80211PhyType::A },
-    { "b", Ieee80211PhyType::B },
-    { "g", Ieee80211PhyType::G },
-    { "n", Ieee80211PhyType::N },
-    { "ac", Ieee80211PhyType::AC },
-    { "ax", Ieee80211PhyType::AX },
-};
-const std::map<std::string, Ieee80211FrequencyBand> Ieee80211FrequencyBandNames{
-    { "2", Ieee80211FrequencyBand::TwoPointFourGHz },
-    { "2.4", Ieee80211FrequencyBand::TwoPointFourGHz },
-    { "5", Ieee80211FrequencyBand::FiveGHz },
-    { "5.0", Ieee80211FrequencyBand::FiveGHz },
-    { "6", Ieee80211FrequencyBand::SixGHz },
-    { "6.0", Ieee80211FrequencyBand::SixGHz },
-};
-const std::map<std::string, Ieee80211AuthenticationAlgorithm> Ieee80211AuthenticationAlgorithmNames{
-    { "open", Ieee80211AuthenticationAlgorithm::OpenSystem },
-    { "open-system", Ieee80211AuthenticationAlgorithm::OpenSystem },
-    { "shared", Ieee80211AuthenticationAlgorithm::SharedKey },
-    { "shared-key", Ieee80211AuthenticationAlgorithm::SharedKey },
-    { "skey", Ieee80211AuthenticationAlgorithm::SharedKey },
-};
+const std::map<std::string, Ieee80211PhyType>&
+Ieee80211PhyTypeNames()
+{
+    try {
+        static const std::map<std::string, Ieee80211PhyType> ieee80211PhyTypeNames{
+            { "a", Ieee80211PhyType::A },
+            { "b", Ieee80211PhyType::B },
+            { "g", Ieee80211PhyType::G },
+            { "n", Ieee80211PhyType::N },
+            { "ac", Ieee80211PhyType::AC },
+            { "ax", Ieee80211PhyType::AX },
+        };
+        return ieee80211PhyTypeNames;
+    } catch (...) {
+        throw std::runtime_error("Failed to create PHY type names");
+    }
+}
+
+const std::map<std::string, Ieee80211FrequencyBand>&
+Ieee80211FrequencyBandNames()
+{
+    try {
+        static const std::map<std::string, Ieee80211FrequencyBand> ieee80211FrequencyBandNames{
+            { "2", Ieee80211FrequencyBand::TwoPointFourGHz },
+            { "2.4", Ieee80211FrequencyBand::TwoPointFourGHz },
+            { "5", Ieee80211FrequencyBand::FiveGHz },
+            { "5.0", Ieee80211FrequencyBand::FiveGHz },
+            { "6", Ieee80211FrequencyBand::SixGHz },
+            { "6.0", Ieee80211FrequencyBand::SixGHz },
+        };
+        return ieee80211FrequencyBandNames;
+    } catch (...) {
+        throw std::runtime_error("Failed to create frequency band names");
+    }
+}
+
+const std::map<std::string, Ieee80211AuthenticationAlgorithm>&
+Ieee80211AuthenticationAlgorithmNames()
+{
+    try {
+        static const std::map<std::string, Ieee80211AuthenticationAlgorithm> ieee80211AuthenticationAlgorithmNames{
+            { "open", Ieee80211AuthenticationAlgorithm::OpenSystem },
+            { "open-system", Ieee80211AuthenticationAlgorithm::OpenSystem },
+            { "shared", Ieee80211AuthenticationAlgorithm::SharedKey },
+            { "shared-key", Ieee80211AuthenticationAlgorithm::SharedKey },
+            { "skey", Ieee80211AuthenticationAlgorithm::SharedKey },
+        };
+        return ieee80211AuthenticationAlgorithmNames;
+    } catch (...) {
+        throw std::runtime_error{ "Failed to create authentication algorithm names" };
+    }
+}
 } // namespace detail
 
 CLI::App*
@@ -165,11 +195,11 @@ NetRemoteCli::AddSubcommandWifiAccessPointEnable(CLI::App* parent)
     cliAppWifiAccessPointEnable->add_option("id", m_cliData->WifiAccessPointId, "The identifier of the access point to enable")->required();
     cliAppWifiAccessPointEnable->add_option("--ssid", m_cliData->WifiAccessPointSsid, "The SSID of the access point to enable");
     cliAppWifiAccessPointEnable->add_option("--phy,--phyType,", m_cliData->WifiAccessPointPhyType, "The PHY type of the access point to enable")
-        ->transform(CLI::CheckedTransformer(detail::Ieee80211PhyTypeNames, CLI::ignore_case));
+        ->transform(CLI::CheckedTransformer(detail::Ieee80211PhyTypeNames(), CLI::ignore_case));
     cliAppWifiAccessPointEnable->add_option("--freq,--freqs,--frequencies,--frequencyBand,--frequencyBands,--band,--bands", m_cliData->WifiAccessPointFrequencyBands, "The frequency bands of the access point to enable")
-        ->transform(CLI::CheckedTransformer(detail::Ieee80211FrequencyBandNames));
+        ->transform(CLI::CheckedTransformer(detail::Ieee80211FrequencyBandNames()));
     cliAppWifiAccessPointEnable->add_option("--auth,--auths,--authAlg,--authAlgs,--authentication,--authenticationAlgorithm,--authenticationAlgorithms", m_cliData->WifiAccessPointAuthenticationAlgorithms, "The authentication algorithms of the access point to enable")
-        ->transform(CLI::CheckedTransformer(detail::Ieee80211AuthenticationAlgorithmNames, CLI::ignore_case));
+        ->transform(CLI::CheckedTransformer(detail::Ieee80211AuthenticationAlgorithmNames(), CLI::ignore_case));
     cliAppWifiAccessPointEnable->callback([this] {
         WifiAccessPointEnableCallback();
     });

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
@@ -130,6 +130,12 @@ private:
     OnWifiAccessPointsEnumerate(bool detailedOutput = false);
 
     /**
+     * @brief Invoked when all processing for the 'wifi ap-enable' command is complete.
+     */
+    void
+    WifiAccessPointEnableCallback();
+
+    /**
      * @brief Handle the 'wifi ap-enable' command.
      *
      * @param accessPointId The identifier of the access point to enable.

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
@@ -26,6 +26,7 @@ struct NetRemoteCliData
     std::string WifiAccessPointSsid{};
     Microsoft::Net::Wifi::Ieee80211PhyType WifiAccessPointPhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> WifiAccessPointFrequencyBands{};
+    std::vector<Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm> WifiAccessPointAuthenticationAlgorithms{};
 };
 } // namespace Microsoft::Net::Remote
 

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
@@ -4,6 +4,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 #include <microsoft/net/remote/protocol/NetRemoteProtocol.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
@@ -24,6 +25,7 @@ struct NetRemoteCliData
     std::string WifiAccessPointId{};
     std::string WifiAccessPointSsid{};
     Microsoft::Net::Wifi::Ieee80211PhyType WifiAccessPointPhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
+    std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> WifiAccessPointFrequencyBands{};
 };
 } // namespace Microsoft::Net::Remote
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow configuring authentication algorithms via `WifiAccessPointEnable`.
* Allow configuring frequency bands via `WifiAccessPointEnable`.
 
### Technical Details

* Add cli option `--freq` (with aliases) to specify frequency bands with `wifi enable` command.
* Add cli option `--auth` (with aliases) to specify frequency bands with `wifi enable` command.

### Test Results

* All unit tests pass.
* Validated wi-fi access point reflects configured bands and authentication algorithms out-of-band with hostapd following these commands:

```bash
shadowfax@mrstux:~/src/microsoft/netremote-cmake/build/dev-linux$ ./src/linux/tools/cli/Debug/netremote-cli -s 127.0.0.1 wifi enable wls1 --freqs 2.4 5 --auth open shared --phy ac
Executing command WifiAccessPointEnable
```

### Reviewer Focus

* None

### Future Work

Describe any future work that is required as a result of this change. Eg.

* Add AKMs and security protocols to `Dot11AccessPointConfiguration`, and implementation to configure them.
* Add cli options to specify pairwise ciphers.
* Improve cli help text for `wifi enable` arguments.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
