### PR TITLE
Fix DataStreamDownload bug

### DIFF
--- a/src/common/service/NetRemoteDataStreamingReactors.cxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.cxx
@@ -145,7 +145,11 @@ DataStreamWriter::OnWriteDone(bool isOk)
 
     // Check for a failed status code from HandleWriteFailure since that invoked a final write, thus causing this callback to be invoked.
     if (m_writeStatus.code() == DataStreamOperationStatusCode::DataStreamOperationStatusCodeFailed) {
-        Finish(::grpc::Status::OK);
+        bool isCompletedExpected{ false };
+        if (m_isCompleted.compare_exchange_strong(isCompletedExpected, true, std::memory_order_relaxed, std::memory_order_relaxed)) {
+            Finish(grpc::Status::OK);
+        }
+
         return;
     }
 
@@ -170,7 +174,10 @@ DataStreamWriter::OnCancel()
     // The RPC is canceled by the client, so call Finish to complete it from the server perspective.
     bool isCanceledExpected{ false };
     if (m_isCanceled.compare_exchange_strong(isCanceledExpected, true, std::memory_order_relaxed, std::memory_order_relaxed)) {
-        Finish(grpc::Status::CANCELLED);
+        // It's possible that Finish was already called due to a write failure, so don't call Finish again in that case.
+        if (!m_isCompleted.load(std::memory_order_relaxed)) {
+            Finish(grpc::Status::CANCELLED);
+        }
     }
 }
 

--- a/src/common/service/NetRemoteDataStreamingReactors.hxx
+++ b/src/common/service/NetRemoteDataStreamingReactors.hxx
@@ -148,6 +148,7 @@ private:
     uint32_t m_numberOfDataBlocksWritten{};
     Microsoft::Net::Remote::DataStream::DataStreamOperationStatus m_writeStatus{};
     std::atomic<bool> m_isCanceled{};
+    std::atomic<bool> m_isCompleted{};
     Microsoft::Net::Remote::Service::Reactors::Helpers::DataGenerator m_dataGenerator{};
 };
 

--- a/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteDataStreamingService.hxx
@@ -55,6 +55,8 @@ private:
      * @brief Allows the client to ping the server for availability.
      *
      * @param context
+     * @param request
+     * @param response
      * @return grpc::ServerUnaryReactor*
      */
     grpc::ServerUnaryReactor*

--- a/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
+++ b/tests/unit/TestNetRemoteDataStreamingServiceClient.cxx
@@ -155,7 +155,7 @@ TEST_CASE("DataStreamDownload API", "[basic][rpc][client][remote][stream]")
         if (status.error_code() == grpc::StatusCode::CANCELLED) {
             REQUIRE(operationStatus.code() == DataStreamOperationStatusCodeSucceeded);
             REQUIRE(lostDataBlockSequenceNumbers.empty());
-        // The cancelation may cause a write failure before the server's OnCancel callback is invoked
+            // The cancelation may cause a write failure before the server's OnCancel callback is invoked
         } else if (status.error_code() == grpc::StatusCode::OK) {
             REQUIRE(operationStatus.code() == DataStreamOperationStatusCodeFailed);
         }


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

This PR fixes a race condition bug where after the client canceled the `DataStreamDownload` RPC, a write from the server to the client failed before the server's `OnCancel()` callback could be invoked. The write failure led to the server completing the RPC. Then, once `OnCancel()` was invoked, the server tried to complete the RPC again, causing the crash.

Fixes #233 

### Technical Details

* Added `m_isCompleted` atomic boolean variable and used it to ensure that the server only completes the RPC once.
* Updated unit test for `DataStreamDownload` accordingly.

### Test Results

Ran all tests 20+ times in a row with no failures. Previously, I was able to repro the bug about every 10-15 test runs.

### Reviewer Focus

There may be a more elegant way to handle all the various race conditions in the server with a single sync mechanism rather than 2 atomic booleans, but this approach does seem to work.

### Future Work

None.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
