### PR TITLE
CLI: Output when API commands succeed

### DIFF
--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -19,7 +19,8 @@ message WifiAccessPointsEnumerateRequest
 
 message WifiAccessPointsEnumerateResult
 {
-    repeated Microsoft.Net.Remote.Wifi.WifiAccessPointsEnumerateResultItem AccessPoints = 1;
+    WifiAccessPointOperationStatus Status = 1;
+    repeated Microsoft.Net.Remote.Wifi.WifiAccessPointsEnumerateResultItem AccessPoints = 2;
 }
 
 enum WifiAccessPointOperationStatusCode

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -279,10 +279,10 @@ NetRemoteService::WifiAccessPointsEnumerate([[maybe_unused]] grpc::ServerContext
 
     // List all known access points.
     auto accessPoints = m_accessPointManager->GetAllAccessPoints();
+
+    // Convert neutral types to dot11 API types.
     std::vector<WifiAccessPointsEnumerateResultItem> accessPointResultItems(std::size(accessPoints));
-    std::ranges::transform(accessPoints, std::begin(accessPointResultItems), [](auto& accessPointWeak) {
-        return detail::IAccessPointWeakToNetRemoteAccessPointResultItem(accessPointWeak);
-    });
+    std::ranges::transform(accessPoints, std::begin(accessPointResultItems), detail::IAccessPointWeakToNetRemoteAccessPointResultItem);
 
     // Remove any invalid items.
     accessPointResultItems.erase(std::begin(std::ranges::remove_if(accessPointResultItems, detail::NetRemoteAccessPointResultItemIsInvalid)), std::end(accessPointResultItems));
@@ -292,6 +292,8 @@ NetRemoteService::WifiAccessPointsEnumerate([[maybe_unused]] grpc::ServerContext
         std::make_move_iterator(std::begin(accessPointResultItems)),
         std::make_move_iterator(std::end(accessPointResultItems))
     };
+
+    response->mutable_status()->set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
 
     return grpc::Status::OK;
 }

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -316,35 +316,9 @@ NetRemoteService::WifiAccessPointDisable([[maybe_unused]] grpc::ServerContext* c
 {
     const NetRemoteWifiApiTrace traceMe{ request->accesspointid(), result->mutable_status() };
 
-    // Create an AP controller for the requested AP.
-    auto accessPointController = detail::TryGetAccessPointController(request, result, m_accessPointManager);
-    if (accessPointController == nullptr) {
-        return grpc::Status::OK;
-    }
-
-    // Obtain current operational state.
-    AccessPointOperationalState operationalState{};
-    auto operationStatus = accessPointController->GetOperationalState(operationalState);
-    if (!operationStatus) {
-        return HandleFailure(request, result, operationStatus.Code, std::format("Failed to get operational state for access point {}", request->accesspointid()));
-    }
-
-    // Disable the access point if it's not already disabled.
-    if (operationalState != AccessPointOperationalState::Disabled) {
-        // Disable the access point.
-        operationStatus = accessPointController->SetOperationalState(AccessPointOperationalState::Disabled);
-        if (!operationStatus) {
-            return HandleFailure(request, result, operationStatus.Code, std::format("Failed to set operational state to 'disabled' for access point {}", request->accesspointid()));
-        }
-    } else {
-        LOGI << std::format("Access point {} is in 'disabled' operational state", request->accesspointid());
-    }
-
-    WifiAccessPointOperationStatus status{};
-    status.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
-
+    auto wifiOperationStatus = WifiAccessPointDisableImpl(request->accesspointid());
     result->set_accesspointid(request->accesspointid());
-    *result->mutable_status() = std::move(status);
+    *result->mutable_status() = std::move(wifiOperationStatus);
 
     return grpc::Status::OK;
 }
@@ -509,6 +483,49 @@ NetRemoteService::WifiAccessPointEnableImpl(std::string_view accessPointId, cons
         }
     } else {
         LOGI << std::format("Access point {} is already enabled", accessPointId);
+    }
+
+    wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
+
+    return wifiOperationStatus;
+}
+
+Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+NetRemoteService::WifiAccessPointDisableImpl(std::string_view accessPointId, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController)
+{
+    WifiAccessPointOperationStatus wifiOperationStatus{};
+    AccessPointOperationStatus operationStatus{ accessPointId };
+
+    // Create an AP controller for the requested AP if one wasn't specified.
+    if (accessPointController == nullptr) {
+        operationStatus = TryGetAccessPointController(accessPointId, accessPointController);
+        if (!operationStatus.Succeeded() || accessPointController == nullptr) {
+            wifiOperationStatus.set_code(ToDot11AccessPointOperationStatusCode(operationStatus.Code));
+            wifiOperationStatus.set_message(std::format("Failed to create access point controller for access point {} - {}", accessPointId, operationStatus.ToString()));
+            return wifiOperationStatus;
+        }
+    }
+
+    // Obtain current operational state.
+    AccessPointOperationalState operationalState{};
+    operationStatus = accessPointController->GetOperationalState(operationalState);
+    if (!operationStatus) {
+        wifiOperationStatus.set_code(ToDot11AccessPointOperationStatusCode(operationStatus.Code));
+        wifiOperationStatus.set_message(std::format("Failed to get operational state for access point {}", accessPointId));
+        return wifiOperationStatus;
+    }
+
+    // Disable the access point if it's not already disabled.
+    if (operationalState != AccessPointOperationalState::Disabled) {
+        // Disable the access point.
+        operationStatus = accessPointController->SetOperationalState(AccessPointOperationalState::Disabled);
+        if (!operationStatus) {
+            wifiOperationStatus.set_code(ToDot11AccessPointOperationStatusCode(operationStatus.Code));
+            wifiOperationStatus.set_message(std::format("Failed to set operational state to 'disabled' for access point {}", accessPointId));
+            return wifiOperationStatus;
+        }
+    } else {
+        LOGI << std::format("Access point {} is already in 'disabled' operational state", accessPointId);
     }
 
     wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -140,6 +140,16 @@ protected:
     WifiAccessPointEnableImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11AccessPointConfiguration* dot11AccessPointConfiguration, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
     /**
+     * @brief Disable an access point. This will take the access point offline, making it unavailable for use by clients.
+     *
+     * @param accessPointId The access point identifier.
+     * @param accessPointController The access point controller for the specified access point (optional).
+     * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+     */
+    Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+    WifiAccessPointDisableImpl(std::string_view accessPointId, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
+
+    /**
      * @brief Set the active PHY type of the access point. The access point must be enabled. This will cause
      * the access point to temporarily go offline while the change is being applied.
      *


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [X] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the CLI outputs results of the API request.

### Technical Details

* Add helper impl function in API impl for `WifiAccessPointDisable`.
* Add `WifiAccessPointOperationStatus` field to `WifiAccessPointsEnumerateResult` to signal status.
* Output success message when `wifi aps|enable|disable` succeed.
*

### Test Results

* All unit tests pass.
* CLI command failures are output consistently:
```bash
shadowfax@mrstux:~/src/microsoft/netremote-cmake/build/dev-linux$ ./src/linux/tools/cli/Debug/netremote-cli -s 127.0.0.1 wifi enable wls2
Executing command WifiAccessPointEnable
Failed to enable wifi access point 'wls2' (WifiAccessPointOperationStatusCodeAccessPointInvalid)
Failed to create access point controller for access point wls2 - AP 'wls2' operation TryGetAccessPoint failed with code 'AccessPointInvalid' - access point not found [/home/shadowfax/src/microsoft/netremote/src/common/service/NetRemoteService.cxx(354:32) AccessPointOperationStatus Microsoft::Net::Remote::Service::NetRemoteService::TryGetAccessPoint(std::string_view, std::shared_ptr<IAccessPoint> &)]
shadowfax@mrstux:~/src/microsoft/netremote-cmake/build/dev-linux$ ./src/linux/tools/cli/Debug/netremote-cli -s 127.0.0.1 wifi disable wls2
Executing command WifiAccessPointDisable
Failed to disable wifi access point 'wls2' (WifiAccessPointOperationStatusCodeAccessPointInvalid)
Failed to create access point controller for access point wls2 - AP 'wls2' operation TryGetAccessPoint failed with code 'AccessPointInvalid' - access point not found [/home/shadowfax/src/microsoft/netremote/src/common/service/NetRemoteService.cxx(354:32) AccessPointOperationStatus Microsoft::Net::Remote::Service::NetRemoteService::TryGetAccessPoint(std::string_view, std::shared_ptr<IAccessPoint> &)]
```
* CLI command successes are output:
```bash
shadowfax@mrstux:~/src/microsoft/netremote-cmake/build/dev-linux$ ./src/linux/tools/cli/Debug/netremote-cli -s 127.0.0.1 wifi aps
Executing command WifiAccessPointsEnumerate
[1] wlx08beac0696fe: WPA1 WPA2 WPA3 IEEE 802.11 B/G/N 2.4 GHz
[2] wls1: WPA1 WPA2 WPA3 IEEE 802.11 B/G/N/AC 2.4 GHz 5.0 GHz
shadowfax@mrstux:~/src/microsoft/netremote-cmake/build/dev-linux$ ./src/linux/tools/cli/Debug/netremote-cli -s 127.0.0.1 wifi enable wls1
Executing command WifiAccessPointEnable
Successfully enabled wifi access point 'wls1'
shadowfax@mrstux:~/src/microsoft/netremote-cmake/build/dev-linux$ ./src/linux/tools/cli/Debug/netremote-cli -s 127.0.0.1 wifi disable wls1
Executing command WifiAccessPointDisable
Successfully disabled wifi access point 'wls1'
```

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
