### PR TITLE
Enable setting access point AKMs

### DIFF
--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -103,6 +103,15 @@ struct IAccessPointController
     SetAuthenticationAlgorithms(std::vector<Ieee80211AuthenticationAlgorithm> authenticationAlgorithms) noexcept = 0;
 
     /**
+     * @brief Set the authentication and key management (akm) suites the access point should enable.
+     *
+     * @param akmSuites The akm suites to be allowed.
+     * @return AccessPointOperationStatus
+     */
+    virtual AccessPointOperationStatus
+    SetAkmSuites(std::vector<Ieee80211AkmSuite> akmSuites) noexcept = 0;
+
+    /**
      * @brief Set the pairwise cipher suites the access point should enable. These are used to encrypt unicast packets.
      *
      * @param pairwiseCipherSuites The pairwise cipher suites to enable.

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -179,6 +179,7 @@ static constexpr uint8_t Ieee80211AkmSuiteIdFtFilsSha384 = 17;
 static constexpr uint8_t Ieee80211AkmSuiteIdOwe = 18;
 static constexpr uint8_t Ieee80211AkmSuiteIdFtPskSha384 = 19;
 static constexpr uint8_t Ieee80211AkmSuiteIdPskSha384 = 20;
+static constexpr uint8_t Ieee80211AkmSuiteIdPasn = 21;
 
 /**
  * @brief IEEE 802.11 Authentication and Key Management (AKM) Suites.
@@ -186,6 +187,7 @@ static constexpr uint8_t Ieee80211AkmSuiteIdPskSha384 = 20;
  * Defined in IEEE 802.11-2020, Section 9.4.2.24.3, Table 9-151.
  */
 enum class Ieee80211AkmSuite : uint32_t {
+    Unknown = MakeIeeeSuite(OuiInvalid, 0),
     Reserved0 = MakeIeee80211Suite(Ieee80211AkmSuiteIdReserved0),
     Ieee8021x = MakeIeee80211Suite(Ieee80211AkmSuiteId8021x),
     Psk = MakeIeee80211Suite(Ieee80211AkmSuiteIdPsk),
@@ -207,6 +209,7 @@ enum class Ieee80211AkmSuite : uint32_t {
     Owe = MakeIeee80211Suite(Ieee80211AkmSuiteIdOwe),
     FtPskSha384 = MakeIeee80211Suite(Ieee80211AkmSuiteIdFtPskSha384),
     PskSha384 = MakeIeee80211Suite(Ieee80211AkmSuiteIdPskSha384),
+    Pasn = MakeIeee80211Suite(Ieee80211AkmSuiteIdPasn),
 };
 
 /**
@@ -214,6 +217,7 @@ enum class Ieee80211AkmSuite : uint32_t {
  * only supports enums with values up to UINT16_MAX-1, and the AKM suite underlying type is uint32_t, so cannot be used.
  */
 constexpr std::initializer_list<uint32_t> AllIeee80211Akms{
+    std::to_underlying(Ieee80211AkmSuite::Unknown),
     std::to_underlying(Ieee80211AkmSuite::Reserved0),
     std::to_underlying(Ieee80211AkmSuite::Ieee8021x),
     std::to_underlying(Ieee80211AkmSuite::Psk),
@@ -235,6 +239,7 @@ constexpr std::initializer_list<uint32_t> AllIeee80211Akms{
     std::to_underlying(Ieee80211AkmSuite::Owe),
     std::to_underlying(Ieee80211AkmSuite::FtPskSha384),
     std::to_underlying(Ieee80211AkmSuite::PskSha384),
+    std::to_underlying(Ieee80211AkmSuite::Pasn),
 };
 
 /**

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
@@ -119,6 +119,57 @@ Ieee80211SecurityProtocolToWpaSecurityProtocol(Ieee80211SecurityProtocol ieee802
     }
 }
 
+Wpa::WpaKeyManagement
+Ieee80211AkmSuiteToWpaKeyManagement(Ieee80211AkmSuite ieee80211AkmSuite) noexcept
+{
+    switch (ieee80211AkmSuite) {
+    case Ieee80211AkmSuite::Ieee8021x:
+        return WpaKeyManagement::Ieee80211x;
+    case Ieee80211AkmSuite::Psk:
+        return WpaKeyManagement::Psk;
+    case Ieee80211AkmSuite::Ft8021x:
+        return WpaKeyManagement::FtIeee8021x;
+    case Ieee80211AkmSuite::FtPsk:
+        return WpaKeyManagement::FtPsk;
+    case Ieee80211AkmSuite::Ieee8021xSha256:
+        return WpaKeyManagement::Ieee8021xSha256;
+    case Ieee80211AkmSuite::PskSha256:
+        return WpaKeyManagement::PskSha256;
+    case Ieee80211AkmSuite::Sae:
+        return WpaKeyManagement::Sae;
+    case Ieee80211AkmSuite::FtSae:
+        return WpaKeyManagement::FtSae;
+    case Ieee80211AkmSuite::Ieee8021xSuiteB:
+        return WpaKeyManagement::Ieee80211xSuiteB;
+    case Ieee80211AkmSuite::Ieee8011xSuiteB192:
+        return WpaKeyManagement::Ieee80211xSuiteB192;
+    case Ieee80211AkmSuite::Ft8021xSha384:
+        return WpaKeyManagement::FtIeee8021xSha384;
+    case Ieee80211AkmSuite::FilsSha256:
+        return WpaKeyManagement::FilsSha256;
+    case Ieee80211AkmSuite::FilsSha384:
+        return WpaKeyManagement::FilsSha384;
+    case Ieee80211AkmSuite::FtFilsSha256:
+        return WpaKeyManagement::FtFilsSha256;
+    case Ieee80211AkmSuite::FtFilsSha384:
+        return WpaKeyManagement::FilsSha384;
+    case Ieee80211AkmSuite::Owe:
+        return WpaKeyManagement::Owe;
+    case Ieee80211AkmSuite::Reserved0:
+        [[fallthrough]];
+    case Ieee80211AkmSuite::Tdls:
+        [[fallthrough]];
+    case Ieee80211AkmSuite::ApPeerKey:
+        [[fallthrough]];
+    case Ieee80211AkmSuite::FtPskSha384:
+        [[fallthrough]];
+    case Ieee80211AkmSuite::PskSha384:
+        [[fallthrough]];
+    default:
+        return WpaKeyManagement::Unknown;
+    }
+}
+
 WpaCipher
 Ieee80211CipherSuiteToWpaCipher(Ieee80211CipherSuite ieee80211CipherSuite) noexcept
 {

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
@@ -49,27 +49,36 @@ Ieee80211AuthenticationAlgorithmToWpaAuthenticationAlgorithm(Ieee80211Authentica
 
 /**
  * @brief Convert a Ieee80211SecurityProtocol to a WpaSecurityProtocol.
- * 
+ *
  * @param ieee80211SecurityProtocol The Ieee80211SecurityProtocol to convert.
- * @return Wpa::WpaSecurityProtocol 
+ * @return Wpa::WpaSecurityProtocol
  */
 Wpa::WpaSecurityProtocol
 Ieee80211SecurityProtocolToWpaSecurityProtocol(Ieee80211SecurityProtocol ieee80211SecurityProtocol) noexcept;
 
 /**
+ * @brief Convert a Ieee80211AkmSuite to a WpaKeyManagement.
+ *
+ * @param ieee80211AkmSuite The Ieee80211AkmSuite to convert.
+ * @return Wpa::WpaKeyManagement
+ */
+Wpa::WpaKeyManagement
+Ieee80211AkmSuiteToWpaKeyManagement(Ieee80211AkmSuite ieee80211AkmSuite) noexcept;
+
+/**
  * @brief Convert a Ieee80211CipherSuite to a WpaCipher.
- * 
+ *
  * @param ieee80211CipherSuite The Ieee80211CipherSuite to convert.
- * @return Wpa::WpaCipher 
+ * @return Wpa::WpaCipher
  */
 Wpa::WpaCipher
 Ieee80211CipherSuiteToWpaCipher(Ieee80211CipherSuite ieee80211CipherSuite) noexcept;
 
 /**
  * @brief Convert a map of Ieee80211SecurityProtocol to list of Ieee80211CipherSuite to a map of WpaSecurityProtocol to list of WpaCipher.
- * 
+ *
  * @param ieee80211CipherSuiteConfigurations The map of Ieee80211SecurityProtocol to list of Ieee80211CipherSuite to convert.
- * @return std::unordered_map<Wpa::WpaSecurityProtocol, std::vector<Wpa::WpaCipher>> 
+ * @return std::unordered_map<Wpa::WpaSecurityProtocol, std::vector<Wpa::WpaCipher>>
  */
 std::unordered_map<Wpa::WpaSecurityProtocol, std::vector<Wpa::WpaCipher>>
 Ieee80211CipherSuitesToWpaCipherSuites(const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuiteConfigurations) noexcept;

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -101,6 +101,15 @@ struct AccessPointControllerLinux :
     SetAuthenticationAlgorithms(std::vector<Ieee80211AuthenticationAlgorithm> authenticationAlgorithms) noexcept override;
 
     /**
+     * @brief Set the authentication and key management (akm) suites the access point should enable.
+     *
+     * @param akmSuites The akm suites to be allowed.
+     * @return AccessPointOperationStatus
+     */
+    AccessPointOperationStatus
+    SetAkmSuites(std::vector<Ieee80211AkmSuite> akmSuites) noexcept override;
+
+    /**
      * @brief Set the pairwise cipher suites the access point should enable. These are used to encrypt unicast packets.
      *
      * @param pairwiseCipherSuites The pairwise cipher suites to enable.

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -233,6 +233,7 @@ enum class WpaAlgorithm : uint32_t {
  * Values obtained from hostap/src/common/defs.h.
  */
 enum class WpaKeyManagement : uint32_t {
+    Unknown = 0U,
     Ieee80211x = (1U << 0U),
     Psk = (1U << 1U),
     None = (1U << 2U),
@@ -266,7 +267,8 @@ enum class WpaKeyManagement : uint32_t {
  *
  * magic_enum::enum_values() cannot be used since the enum values exceed [MAGIC_ENUM_RANGE_MIN, MAGIC_ENUM_RANGE_MAX].
  */
-inline constexpr std::array<WpaKeyManagement, 26> AllWpaKeyManagements = {
+inline constexpr std::array<WpaKeyManagement, 27> AllWpaKeyManagements = {
+    WpaKeyManagement::Unknown,
     WpaKeyManagement::Ieee80211x,
     WpaKeyManagement::Psk,
     WpaKeyManagement::None,
@@ -670,7 +672,7 @@ WpaCipherPropertyName(WpaSecurityProtocol WpaSecurityProtocol) noexcept
     case WpaSecurityProtocol::Wpa:
         return ProtocolHostapd::PropertyNameWpaPairwise;
     case WpaSecurityProtocol::Wpa2:
-    // case WpaSecurityProtocol::Wpa3: // duplicate case value not allowed
+        // case WpaSecurityProtocol::Wpa3: // duplicate case value not allowed
         return ProtocolHostapd::PropertyNameRsnPairwise;
     default:
         return ProtocolHostapd::PropertyNameInvalid;

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -110,7 +110,7 @@ AccessPointControllerTest::SetFrequencyBands(std::vector<Ieee80211FrequencyBand>
 }
 
 AccessPointOperationStatus
-AccessPointControllerTest::SetAuthenticationAlgorithms([[maybe_unused]] std::vector<Ieee80211AuthenticationAlgorithm> authenticationAlgorithms) noexcept
+AccessPointControllerTest::SetAuthenticationAlgorithms(std::vector<Ieee80211AuthenticationAlgorithm> authenticationAlgorithms) noexcept
 {
     assert(AccessPoint != nullptr);
 
@@ -122,6 +122,19 @@ AccessPointControllerTest::SetAuthenticationAlgorithms([[maybe_unused]] std::vec
     // If so, ensure authenticationAlgorithms is subset of those in AccessPointCapabilities.AuthenticationAlgorithms.
 
     AccessPoint->AuthenticationAlgorithms = std::move(authenticationAlgorithms);
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
+}
+
+AccessPointOperationStatus
+AccessPointControllerTest::SetAkmSuites(std::vector<Ieee80211AkmSuite> akmSuites) noexcept
+{
+    assert(AccessPoint != nullptr);
+
+    if (AccessPoint == nullptr) {
+        return AccessPointOperationStatus::InvalidAccessPoint("null AccessPoint");
+    }
+
+    AccessPoint->AkmSuites = std::move(akmSuites);
     return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -113,6 +113,15 @@ struct AccessPointControllerTest final :
     SetAuthenticationAlgorithms(std::vector<Ieee80211AuthenticationAlgorithm> authenticationAlgorithms) noexcept override;
 
     /**
+     * @brief Set the authentication and key management (akm) suites the access point should enable.
+     *
+     * @param akmSuites The akm suites to be allowed.
+     * @return AccessPointOperationStatus
+     */
+    AccessPointOperationStatus
+    SetAkmSuites(std::vector<Ieee80211AkmSuite> akmSuites) noexcept override;
+
+    /**
      * @brief Set the pairwise cipher suites the access point should enable. These are used to encrypt unicast packets.
      *
      * @param pairwiseCipherSuites The pairwise cipher suites to enable.

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -30,6 +30,7 @@ struct AccessPointTest final :
     Microsoft::Net::Wifi::Ieee80211PhyType PhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> FrequencyBands;
     std::vector<Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm> AuthenticationAlgorithms;
+    std::vector<Microsoft::Net::Wifi::Ieee80211AkmSuite> AkmSuites;
     std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> CipherSuites;
     AccessPointOperationalState OperationalState{ AccessPointOperationalState::Disabled };
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure AKMs can be set from the API layer.

### Technical Details

* Add `IAccessPointController::SetAkms` function to set the AKMs for the access point.
* Add functionality to adapt between `WpaKeyManagement` and `Ieee80211AkmSuite` types.
* Add `Unknown` sentinel and `PASN` akm types.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* The new functionality must be called from the `WifiAccessPointEnableImpl` function in the API layer.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
