### PR TITLE
Allow settings AKMs from WifiAccessPointEnable API

### DIFF
--- a/protocol/include/microsoft/net/remote/protocol/NetRemoteProtocol.hxx
+++ b/protocol/include/microsoft/net/remote/protocol/NetRemoteProtocol.hxx
@@ -8,9 +8,6 @@
 
 namespace Microsoft::Net::Remote::Protocol
 {
-static constexpr uint32_t NetRemotePortDefault = 5047;
-static constexpr std::string_view NetRemoteAddressHttpDefault = "localhost:5047";
-
 /**
  * @brief Static NetRemote protocol information.
  */
@@ -18,13 +15,13 @@ struct NetRemoteProtocol
 {
 #define IP_DEFAULT     "localhost"
 #define PORT_DEFAULT   5047
-#define PORT_SEPARATOR ""
+#define PORT_SEPARATOR ":"
 #define xstr(s)        str(s)
 #define str(s)         #s
 
-    static constexpr uint32_t PortDefault{ 5047 };
-    static constexpr std::string_view PortSeparator{ ":" };
-    static constexpr std::string_view IpDefault{ "localhost" };
+    static constexpr uint32_t PortDefault{ PORT_DEFAULT };
+    static constexpr std::string_view PortSeparator{ PORT_SEPARATOR };
+    static constexpr std::string_view IpDefault{ IP_DEFAULT };
     static constexpr std::string_view AddressDefault{ IP_DEFAULT PORT_SEPARATOR xstr(PORT_DEFAULT) };
 
 #undef IP_DEFAULT

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -164,8 +164,9 @@ message Dot11AccessPointConfiguration
     Dot11MacAddress Bssid = 2;
     Dot11PhyType PhyType = 3;
     repeated Dot11CipherSuiteConfiguration PairwiseCipherSuites = 4;
-    repeated Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 5;
-    repeated Dot11FrequencyBand FrequencyBands = 6;
+    repeated Dot11AkmSuite AkmSuites = 5;
+    repeated Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 6;
+    repeated Dot11FrequencyBand FrequencyBands = 7;
 }
 
 message Dot11AccessPointCapabilities

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -105,6 +105,7 @@ enum Dot11AkmSuite
     Dot11AkmSuiteOwe = 19;
     Dot11AkmSuiteFtPskSha384 = 20;
     Dot11AkmSuitePskSha384 = 21;
+    Dot11AkmSuitePasn = 22;
 }
 
 // 802.11 Cipher suites.

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -186,6 +186,18 @@ protected:
     WifiAccessPointSetAuthenticationAlgorithsmImpl(std::string_view accessPointId, std::vector<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm>& dot11AuthenticationAlgorithms, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
     /**
+     * @brief Set the active AKM suites of the access point. If the access point is online, this will cause it to
+     * temporarily go offline while the change is being applied.
+     *
+     * @param accessPointId The access point identifier.
+     * @param dot11AkmSuites The new AKM suites to set.
+     * @param accessPointController The access point controller for the specified access point (optional).
+     * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+     */
+    Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+    WifiAccessPointSetAkmSuitesImpl(std::string_view accessPointId, std::vector<Microsoft::Net::Wifi::Dot11AkmSuite>& dot11AkmSuites, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
+
+    /**
      * @brief Set the active cipher suites of the access point. If the access point is online, this will cause it to
      * temporarily go offline while the change is being applied.
      *

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -74,10 +74,13 @@ NetRemoteCli::CreateParser() noexcept
 
     app->require_subcommand();
 
+    const std::string serverAddressDefault{ Protocol::NetRemoteProtocol::AddressDefault };
     auto* optionServer = app->add_option_function<std::string>("-s,--server", [this](const std::string& serverAddress) {
         OnServerAddressChanged(serverAddress);
     });
     optionServer->description("The address of the netremote server to connect to, with format '<hostname>[:port]'");
+    optionServer->default_val(serverAddressDefault)->run_callback_for_default()->force_callback();
+    optionServer->default_str(serverAddressDefault);
 
     m_cliAppServerAddress = optionServer;
     m_cliAppWifi = AddSubcommandWifi(app.get());
@@ -279,6 +282,7 @@ NetRemoteCli::OnServerAddressChanged(const std::string& serverAddressArg)
         serverAddress += std::format("{}{}", NetRemoteProtocol::PortSeparator, NetRemoteProtocol::PortDefault);
     }
 
+    LOGI << std::format("Connecting to server {}", serverAddress);
     m_cliData->ServerAddress = std::move(serverAddress);
 
     auto connection = NetRemoteServerConnection::TryEstablishConnection(m_cliData->ServerAddress);

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -185,6 +185,39 @@ Ieee80211AuthenticationAlgorithmNames()
         throw std::runtime_error{ "Failed to create authentication algorithm names" };
     }
 }
+
+const std::map<std::string, Ieee80211AkmSuite>&
+Ieee80211AkmSuiteNames()
+{
+    try {
+        static const std::map<std::string, Ieee80211AkmSuite> ieee80211AkmSuiteNames{
+            { "8021x", Ieee80211AkmSuite::Ieee8021x },
+            { "psk" , Ieee80211AkmSuite::Psk },
+            { "ft8021x" , Ieee80211AkmSuite::Ft8021x },
+            { "ftpsk", Ieee80211AkmSuite::FtPsk },
+            { "8021xsha256", Ieee80211AkmSuite::Ieee8021xSha256 },
+            { "psksha256", Ieee80211AkmSuite::PskSha256 },
+            { "tdls", Ieee80211AkmSuite::Tdls },
+            { "sae", Ieee80211AkmSuite::Sae },
+            { "ftsae", Ieee80211AkmSuite::FtSae },
+            { "appeerkey", Ieee80211AkmSuite::ApPeerKey },
+            { "8021xsuiteb", Ieee80211AkmSuite::Ieee8021xSuiteB },
+            { "8021xsuiteb192", Ieee80211AkmSuite::Ieee8011xSuiteB192 },
+            { "ft8021xsha384", Ieee80211AkmSuite::Ft8021xSha384 },
+            { "filssha256", Ieee80211AkmSuite::FilsSha256 },
+            { "filssha384", Ieee80211AkmSuite::FilsSha384 },
+            { "ftfilssha256", Ieee80211AkmSuite::FtFilsSha256 },
+            { "ftfilssha384", Ieee80211AkmSuite::FtFilsSha384 },
+            { "owe", Ieee80211AkmSuite::Owe },
+            { "ftpsksha384", Ieee80211AkmSuite::FtPskSha384 },
+            { "psksha384" , Ieee80211AkmSuite::PskSha384 },
+            { "pasn", Ieee80211AkmSuite::Pasn },
+        };
+        return ieee80211AkmSuiteNames;
+    } catch (...) {
+        throw std::runtime_error{ "Failed to create AKM suite names" };
+    }
+}
 } // namespace detail
 
 CLI::App*
@@ -200,6 +233,8 @@ NetRemoteCli::AddSubcommandWifiAccessPointEnable(CLI::App* parent)
         ->transform(CLI::CheckedTransformer(detail::Ieee80211FrequencyBandNames()));
     cliAppWifiAccessPointEnable->add_option("--auth,--auths,--authAlg,--authAlgs,--authentication,--authenticationAlgorithm,--authenticationAlgorithms", m_cliData->WifiAccessPointAuthenticationAlgorithms, "The authentication algorithms of the access point to enable")
         ->transform(CLI::CheckedTransformer(detail::Ieee80211AuthenticationAlgorithmNames(), CLI::ignore_case));
+    cliAppWifiAccessPointEnable->add_option("--akm,--akms,--akmSuite,--akmSuites,--keyManagement,--keyManagements", m_cliData->WifiAccessPointAkmSuites, "The AKM suites of the access point to enable")
+        ->transform(CLI::CheckedTransformer(detail::Ieee80211AkmSuiteNames(), CLI::ignore_case));
     cliAppWifiAccessPointEnable->callback([this] {
         WifiAccessPointEnableCallback();
     });

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -77,7 +77,7 @@ NetRemoteCli::CreateParser() noexcept
     auto* optionServer = app->add_option_function<std::string>("-s,--server", [this](const std::string& serverAddress) {
         OnServerAddressChanged(serverAddress);
     });
-    optionServer->description("The address of the netremote server to connect to, with format '<hostname>[:port]");
+    optionServer->description("The address of the netremote server to connect to, with format '<hostname>[:port]'");
 
     m_cliAppServerAddress = optionServer;
     m_cliAppWifi = AddSubcommandWifi(app.get());
@@ -174,8 +174,10 @@ Ieee80211AuthenticationAlgorithmNames()
 {
     try {
         static const std::map<std::string, Ieee80211AuthenticationAlgorithm> ieee80211AuthenticationAlgorithmNames{
+            { "o", Ieee80211AuthenticationAlgorithm::OpenSystem },
             { "open", Ieee80211AuthenticationAlgorithm::OpenSystem },
             { "open-system", Ieee80211AuthenticationAlgorithm::OpenSystem },
+            { "s", Ieee80211AuthenticationAlgorithm::SharedKey },
             { "shared", Ieee80211AuthenticationAlgorithm::SharedKey },
             { "shared-key", Ieee80211AuthenticationAlgorithm::SharedKey },
             { "skey", Ieee80211AuthenticationAlgorithm::SharedKey },
@@ -192,10 +194,13 @@ Ieee80211AkmSuiteNames()
     try {
         static const std::map<std::string, Ieee80211AkmSuite> ieee80211AkmSuiteNames{
             { "8021x", Ieee80211AkmSuite::Ieee8021x },
-            { "psk" , Ieee80211AkmSuite::Psk },
-            { "ft8021x" , Ieee80211AkmSuite::Ft8021x },
+            { "dot1x", Ieee80211AkmSuite::Ieee8021x },
+            { "psk", Ieee80211AkmSuite::Psk },
+            { "ft8021x", Ieee80211AkmSuite::Ft8021x },
+            { "ftdot1x", Ieee80211AkmSuite::Ft8021x },
             { "ftpsk", Ieee80211AkmSuite::FtPsk },
             { "8021xsha256", Ieee80211AkmSuite::Ieee8021xSha256 },
+            { "dot1xsha256", Ieee80211AkmSuite::Ieee8021xSha256 },
             { "psksha256", Ieee80211AkmSuite::PskSha256 },
             { "tdls", Ieee80211AkmSuite::Tdls },
             { "sae", Ieee80211AkmSuite::Sae },
@@ -203,14 +208,21 @@ Ieee80211AkmSuiteNames()
             { "appeerkey", Ieee80211AkmSuite::ApPeerKey },
             { "8021xsuiteb", Ieee80211AkmSuite::Ieee8021xSuiteB },
             { "8021xsuiteb192", Ieee80211AkmSuite::Ieee8011xSuiteB192 },
+            { "dot1xsuiteb", Ieee80211AkmSuite::Ieee8021xSuiteB },
+            { "dot1xsuiteb192", Ieee80211AkmSuite::Ieee8011xSuiteB192 },
+            { "8021xb", Ieee80211AkmSuite::Ieee8021xSuiteB },
+            { "8021xb192", Ieee80211AkmSuite::Ieee8011xSuiteB192 },
+            { "dot11b", Ieee80211AkmSuite::Ieee8021xSuiteB },
+            { "dot11b192", Ieee80211AkmSuite::Ieee8011xSuiteB192 },
             { "ft8021xsha384", Ieee80211AkmSuite::Ft8021xSha384 },
+            { "ftdot1xsha384", Ieee80211AkmSuite::Ft8021xSha384 },
             { "filssha256", Ieee80211AkmSuite::FilsSha256 },
             { "filssha384", Ieee80211AkmSuite::FilsSha384 },
             { "ftfilssha256", Ieee80211AkmSuite::FtFilsSha256 },
             { "ftfilssha384", Ieee80211AkmSuite::FtFilsSha384 },
             { "owe", Ieee80211AkmSuite::Owe },
             { "ftpsksha384", Ieee80211AkmSuite::FtPskSha384 },
-            { "psksha384" , Ieee80211AkmSuite::PskSha384 },
+            { "psksha384", Ieee80211AkmSuite::PskSha384 },
             { "pasn", Ieee80211AkmSuite::Pasn },
         };
         return ieee80211AkmSuiteNames;

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -310,6 +310,15 @@ NetRemoteCliHandlerOperations::WifiAccessPointEnable(std::string_view accessPoin
             dot11AccessPointConfiguration.set_phytype(dot11PhyType);
         }
 
+        // Populate AKM suites if present.
+        if (!std::empty(ieee80211AccessPointConfiguration->AkmSuites)) {
+            auto dot11AkmSuites = ToDot11AkmSuites(ieee80211AccessPointConfiguration->AkmSuites);
+            *dot11AccessPointConfiguration.mutable_akmsuites() = {
+                std::make_move_iterator(std::begin(dot11AkmSuites)),
+                std::make_move_iterator(std::end(dot11AkmSuites))
+            };
+        }
+
         // Populate pairwise cipher suites if present.
         if (!std::empty(ieee80211AccessPointConfiguration->PairwiseCipherSuites)) {
             auto dot11PairwiseCipherSuites = ToDot11CipherSuiteConfigurations(ieee80211AccessPointConfiguration->PairwiseCipherSuites);

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
@@ -27,6 +27,7 @@ struct NetRemoteCliData
     Microsoft::Net::Wifi::Ieee80211PhyType WifiAccessPointPhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> WifiAccessPointFrequencyBands{};
     std::vector<Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm> WifiAccessPointAuthenticationAlgorithms{};
+    std::vector<Microsoft::Net::Wifi::Ieee80211AkmSuite> WifiAccessPointAkmSuites{};
 };
 } // namespace Microsoft::Net::Remote
 

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx
@@ -19,6 +19,7 @@ struct Ieee80211AccessPointConfiguration
     std::optional<std::string> Ssid;
     std::optional<Ieee80211Bssid> Bssid;
     std::optional<Ieee80211PhyType> PhyType;
+    std::vector<Ieee80211AkmSuite> AkmSuites;
     std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> PairwiseCipherSuites;
     std::vector<Ieee80211AuthenticationAlgorithm> AuthenticationAlgorithms;
     std::vector<Ieee80211FrequencyBand> FrequencyBands;

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -386,6 +386,15 @@ ToDot11AkmSuites(const Dot11AccessPointConfiguration& dot11AccessPointConfigurat
     return dot11AkmSuites;
 }
 
+std::vector<Dot11AkmSuite>
+ToDot11AkmSuites(const std::vector<Ieee80211AkmSuite>& ieee80211AkmSuites) noexcept
+{
+    std::vector<Dot11AkmSuite> dot11AkmSuites(static_cast<std::size_t>(std::size(ieee80211AkmSuites)));
+    std::ranges::transform(ieee80211AkmSuites, std::begin(dot11AkmSuites), ToDot11AkmSuite);
+
+    return dot11AkmSuites;
+}
+
 Ieee80211AkmSuite
 FromDot11AkmSuite(const Dot11AkmSuite dot11AkmSuite) noexcept
 {

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -363,6 +363,8 @@ ToDot11AkmSuite(const Ieee80211AkmSuite ieee80211AkmSuite) noexcept
         return Dot11AkmSuite::Dot11AkmSuiteFtPskSha384;
     case Ieee80211AkmSuite::PskSha384:
         return Dot11AkmSuite::Dot11AkmSuitePskSha384;
+    case Ieee80211AkmSuite::Pasn:
+        return Dot11AkmSuite::Dot11AkmSuitePasn;
     default:
         return Dot11AkmSuite::Dot11AkmSuiteUnknown;
     }
@@ -414,8 +416,10 @@ FromDot11AkmSuite(const Dot11AkmSuite dot11AkmSuite) noexcept
         return Ieee80211AkmSuite::FtPskSha384;
     case Dot11AkmSuite::Dot11AkmSuitePskSha384:
         return Ieee80211AkmSuite::PskSha384;
+    case Dot11AkmSuite::Dot11AkmSuitePasn:
+        return Ieee80211AkmSuite::Pasn;
     default:
-        return Ieee80211AkmSuite::Reserved0; // FIXME: this needs to be an invalid value instead
+        return Ieee80211AkmSuite::Unknown;
     }
 }
 

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -216,6 +216,13 @@ constexpr auto toDot11FrequencyBand = [](const auto& frequencyBand) {
 constexpr auto toDot11CipherSuite = [](const auto& cipherSuite) {
     return static_cast<Dot11CipherSuite>(cipherSuite);
 };
+
+/**
+ * @brief Convert an int-typed Dot11AkmSuite to its proper enum type.
+ */
+constexpr auto toDot11AkmSuite = [](const auto& akmSuite) {
+    return static_cast<Dot11AkmSuite>(akmSuite);
+};
 } // namespace detail
 
 std::vector<Dot11AuthenticationAlgorithm>
@@ -368,6 +375,15 @@ ToDot11AkmSuite(const Ieee80211AkmSuite ieee80211AkmSuite) noexcept
     default:
         return Dot11AkmSuite::Dot11AkmSuiteUnknown;
     }
+}
+
+std::vector<Dot11AkmSuite>
+ToDot11AkmSuites(const Dot11AccessPointConfiguration& dot11AccessPointConfiguration) noexcept
+{
+    std::vector<Dot11AkmSuite> dot11AkmSuites(static_cast<std::size_t>(std::size(dot11AccessPointConfiguration.akmsuites())));
+    std::ranges::transform(dot11AccessPointConfiguration.akmsuites(), std::begin(dot11AkmSuites), detail::toDot11AkmSuite);
+
+    return dot11AkmSuites;
 }
 
 Ieee80211AkmSuite

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -177,6 +177,15 @@ std::vector<Dot11AkmSuite>
 ToDot11AkmSuites(const Dot11AccessPointConfiguration& dot11AccessPointConfiguration) noexcept;
 
 /**
+ * @brief Convert the specified IEEE 802.11 AKM suite algorithms to the equivalent Dot11AkmSuites.
+ *
+ * @param ieee80211AkmSuites The IEEE 802.11 AKM suite algorithms to convert.
+ * @return std::vector<Dot11AkmSuite>
+ */
+std::vector<Dot11AkmSuite>
+ToDot11AkmSuites(const std::vector<Ieee80211AkmSuite>& ieee80211AkmSuites) noexcept;
+
+/**
  * @brief Convert the specified Dot11AkmSuite to the equivalent IEEE 802.11 AKM suite algorithm.
  *
  * @param dot11AkmSuite The Dot11AkmSuite to convert.

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -168,6 +168,15 @@ Dot11AkmSuite
 ToDot11AkmSuite(Ieee80211AkmSuite ieee80211AkmSuite) noexcept;
 
 /**
+ * @brief Obtain a vector of Dot11AkmSuites from the specified Dot11AccessPointConfiguration.
+ *
+ * @param dot11AccessPointConfiguration The Dot11AccessPointConfiguration to extract the Dot11AkmSuites from.
+ * @return std::vector<Dot11AkmSuite>
+ */
+std::vector<Dot11AkmSuite>
+ToDot11AkmSuites(const Dot11AccessPointConfiguration& dot11AccessPointConfiguration) noexcept;
+
+/**
  * @brief Convert the specified Dot11AkmSuite to the equivalent IEEE 802.11 AKM suite algorithm.
  *
  * @param dot11AkmSuite The Dot11AkmSuite to convert.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure AKMs can be set when enabling an access point.

### Technical Details

* Add `Pasn` AKM type, per 802.11 spec.
* Add AKM suites to `Dot11AccessPointConfiguration`.
* Add `WifiAccessPointSetAkmSuitesImpl` to service implementation, and invoke it from `WifiAccessPointEnable` top-level API.
* Enable use of default server address+port Make `-s, --server` cli option.
* Add single-letter cli aliases for authentication algorithms (o-> open system, s-> shared).
* Add Ieee80211 <-> Dot11 adaption helpers.

### Test Results

* All unit tests pass.
* Manual invocation of cli tool shows success and out-of-band validation with `hostapd_cli` indicates the requested changes were made.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
