### PR TITLE
Enable setting authentication data in WifiAccessPointEnable API

### DIFF
--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -152,6 +152,36 @@ message Dot11SharedKey
     }
 }
 
+message Dot11AuthenticationDataPsk
+{
+    Dot11SharedKey Psk = 1;
+}
+
+// 802.11 Authentication Password.
+//
+// Maps to that defined in IEEE 802.11-2020, Section 12.4, 'Authentication using a password' and 12.4.3, 'Representation
+// of a password' (specifically, Dot11RSNAConfigPasswordValueEntry).
+message Dot11RsnaPassword
+{
+    Dot11SharedKey Credential = 1;
+    Dot11MacAddress PeerMacAddress = 2;
+    string PasswordId = 3;
+}
+
+message Dot11AuthenticationDataSae
+{
+    repeated Dot11RsnaPassword Passwords = 1;
+}
+
+message Dot11AuthenticationData
+{
+    oneof Value
+    {
+        Dot11AuthenticationDataPsk Psk = 1;
+        Dot11AuthenticationDataSae Sae = 2;
+    }
+}
+
 message Dot11CipherSuiteConfiguration
 {
     Dot11SecurityProtocol SecurityProtocol = 1;
@@ -163,10 +193,11 @@ message Dot11AccessPointConfiguration
     Dot11Ssid Ssid = 1;
     Dot11MacAddress Bssid = 2;
     Dot11PhyType PhyType = 3;
-    repeated Dot11CipherSuiteConfiguration PairwiseCipherSuites = 4;
-    repeated Dot11AkmSuite AkmSuites = 5;
-    repeated Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 6;
-    repeated Dot11FrequencyBand FrequencyBands = 7;
+    Dot11AuthenticationData AuthenticationData = 4;
+    repeated Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 5;
+    repeated Dot11CipherSuiteConfiguration PairwiseCipherSuites = 6;
+    repeated Dot11AkmSuite AkmSuites = 7;
+    repeated Dot11FrequencyBand FrequencyBands = 8;
 }
 
 message Dot11AccessPointCapabilities

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -154,7 +154,7 @@ message Dot11SharedKey
 
 message Dot11AuthenticationDataPsk
 {
-    Dot11SharedKey Psk = 1;
+    Dot11SharedKey Key = 1;
 }
 
 // 802.11 Authentication Password.

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -186,6 +186,18 @@ protected:
     WifiAccessPointSetAuthenticationAlgorithsmImpl(std::string_view accessPointId, std::vector<Microsoft::Net::Wifi::Dot11AuthenticationAlgorithm>& dot11AuthenticationAlgorithms, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
     /**
+     * @brief Set the active authentication data of the access point. If the access point is online, this will cause it to
+     * temporarily go offline while the change is being applied.
+     * 
+     * @param accessPointId The access point identifier.
+     * @param dot11AuthenticationData The new authentication data to set.
+     * @param accessPointController The access point controller for the specified access point (optional).
+     * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus 
+     */
+    Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+    WifiAccessPointSetAuthenticationDataImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11AuthenticationData& dot11AuthenticationData, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
+
+    /**
      * @brief Set the active AKM suites of the access point. If the access point is online, this will cause it to
      * temporarily go offline while the change is being applied.
      *

--- a/src/common/wifi/core/CMakeLists.txt
+++ b/src/common/wifi/core/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(wifi-core
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/Ieee80211.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/Ieee80211AccessPointCapabilities.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/Ieee80211AccessPointConfiguration.hxx
+        ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/Ieee80211Authentication.hxx
 )
 
 target_link_libraries(wifi-core

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -12,6 +12,7 @@
 #include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
+#include <microsoft/net/wifi/Ieee80211Authentication.hxx>
 
 namespace Microsoft::Net::Wifi
 {
@@ -101,6 +102,15 @@ struct IAccessPointController
      */
     virtual AccessPointOperationStatus
     SetAuthenticationAlgorithms(std::vector<Ieee80211AuthenticationAlgorithm> authenticationAlgorithms) noexcept = 0;
+
+    /**
+     * @brief Set the authentication data the access point should use.
+     *
+     * @param authenticationData The authentication data to be set.
+     * @return AccessPointOperationStatus
+     */
+    virtual AccessPointOperationStatus
+    SetAuthenticationData(Ieee80211AuthenticationData authenticationData) noexcept = 0;
 
     /**
      * @brief Set the authentication and key management (akm) suites the access point should enable.

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -405,6 +405,16 @@ static constexpr auto BssidNumOctets = 6;
 using Ieee80211Bssid = std::array<uint8_t, BssidNumOctets>;
 
 /**
+ * @brief Number of octets per MAC address.
+ */
+static constexpr auto MacAddressNumOctets = 6;
+
+/**
+ * @brief MAC address type.
+ */
+using Ieee80211MacAddress = std::array<uint8_t, MacAddressNumOctets>;
+
+/**
  * @brief Information about a BSS.
  */
 struct Ieee80211Bss

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <microsoft/net/wifi/Ieee80211.hxx>
+#include <microsoft/net/wifi/Ieee80211Authentication.hxx>
 
 namespace Microsoft::Net::Wifi
 {
@@ -23,6 +24,7 @@ struct Ieee80211AccessPointConfiguration
     std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> PairwiseCipherSuites;
     std::vector<Ieee80211AuthenticationAlgorithm> AuthenticationAlgorithms;
     std::vector<Ieee80211FrequencyBand> FrequencyBands;
+    Ieee80211AuthenticationData AuthenticationData;
 };
 } // namespace Microsoft::Net::Wifi
 

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211Authentication.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211Authentication.hxx
@@ -1,0 +1,44 @@
+
+#ifndef IEEE_80211_AUTHENTICATION_HXX
+#define IEEE_80211_AUTHENTICATION_HXX
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <microsoft/net/wifi/Ieee80211.hxx>
+
+namespace Microsoft::Net::Wifi
+{
+struct Ieee80211SharedKey
+{
+    std::vector<std::uint8_t> Data;
+};
+
+struct Ieee80211RsnaPassword
+{
+    Ieee80211SharedKey Credential;
+    std::optional<std::string> PasswordId;
+    std::optional<Ieee80211MacAddress> PeerMacAddress;
+};
+
+struct Ieee80211AuthenticationDataPsk
+{
+    Ieee80211SharedKey Psk;
+};
+
+struct Ieee80211AuthenticationDataSae
+{
+    std::vector<Ieee80211RsnaPassword> Passwords;
+};
+
+struct Ieee80211AuthenticationData
+{
+    std::optional<Ieee80211AuthenticationDataPsk> Psk;
+    std::optional<Ieee80211AuthenticationDataSae> Sae;
+};
+
+} // namespace Microsoft::Net::Wifi
+
+#endif // IEEE_80211_AUTHENTICATION_HXX

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211Authentication.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211Authentication.hxx
@@ -2,6 +2,7 @@
 #ifndef IEEE_80211_AUTHENTICATION_HXX
 #define IEEE_80211_AUTHENTICATION_HXX
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -11,6 +12,9 @@
 
 namespace Microsoft::Net::Wifi
 {
+constexpr std::size_t Ieee80211PskLengthMinimum{ 8 };
+constexpr std::size_t Ieee80211PskLengthMaximum{ 63 };
+
 struct Ieee80211SharedKey
 {
     std::vector<std::uint8_t> Data;
@@ -25,7 +29,7 @@ struct Ieee80211RsnaPassword
 
 struct Ieee80211AuthenticationDataPsk
 {
-    Ieee80211SharedKey Psk;
+    Ieee80211SharedKey Key;
 };
 
 struct Ieee80211AuthenticationDataSae

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -10,6 +10,7 @@
 #include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
+#include <microsoft/net/wifi/Ieee80211Authentication.hxx>
 
 namespace Microsoft::Net::Wifi
 {
@@ -247,6 +248,15 @@ FromDot11CipherSuiteConfigurations(const std::unordered_map<Dot11SecurityProtoco
  */
 Dot11AccessPointCapabilities
 ToDot11AccessPointCapabilities(const Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) noexcept;
+
+/**
+ * @brief Convert the specified Dot11AuthenticationData to the equivalent IEEE 802.11 authentication data.
+ *
+ * @param dot11AuthenticationData The Dot11AuthenticationData to convert.
+ * @return Ieee80211AuthenticationData
+ */
+Ieee80211AuthenticationData
+FromDot11AuthenticationData(const Dot11AuthenticationData& dot11AuthenticationData) noexcept;
 
 } // namespace Microsoft::Net::Wifi
 

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -250,6 +250,51 @@ Dot11AccessPointCapabilities
 ToDot11AccessPointCapabilities(const Ieee80211AccessPointCapabilities& ieee80211AccessPointCapabilities) noexcept;
 
 /**
+ * @brief Convert the specified Dot11MacAddress to the equivalent IEEE 802.11 mac address.
+ * 
+ * @param dot11MacAddress The Dot11MacAddress to convert.
+ * @return Ieee80211MacAddress 
+ */
+Ieee80211MacAddress
+FromDot11MacAddress(const Dot11MacAddress& dot11MacAddress) noexcept;
+
+/**
+ * @brief Convert the specified Dot11SharedKey to the equivalent IEEE 802.11 shared key.
+ * 
+ * @param dot11SharedKey The Dot11SharedKey to convert.
+ * @return Ieee80211SharedKey 
+ */
+Ieee80211SharedKey
+FromDot11SharedKey(const Dot11SharedKey& dot11SharedKey) noexcept;
+
+/**
+ * @brief Convert the specified Dot11RsnaPassword to the equivalent IEEE 802.11 RSNA password.
+ * 
+ * @param dot11RsnaPassword The Dot11RsnaPassword to convert.
+ * @return Ieee80211RsnaPassword 
+ */
+Ieee80211RsnaPassword
+FromDot11RsnaPassword(const Dot11RsnaPassword& dot11RsnaPassword) noexcept;
+
+/**
+ * @brief Convert the specified Dot11AuthenticationDataPsk to the equivalent IEEE 802.11 authentication data.
+ * 
+ * @param dot11AuthenticationDataPsk The Dot11AuthenticationDataPsk to convert.
+ * @return Ieee80211AuthenticationDataPsk 
+ */
+Ieee80211AuthenticationDataPsk
+FromDot11AuthenticationDataPsk(const Dot11AuthenticationDataPsk& dot11AuthenticationDataPsk) noexcept;
+
+/**
+ * @brief Convert the specified Dot11AuthenticationDataSae to the equivalent IEEE 802.11 authentication data.
+ * 
+ * @param dot11AuthenticationDataSae The Dot11AuthenticationDataSae to convert.
+ * @return Ieee80211AuthenticationDataSae 
+ */
+Ieee80211AuthenticationDataSae
+FromDot11AuthenticationDataSae(const Dot11AuthenticationDataSae& dot11AuthenticationDataSae) noexcept;
+
+/**
  * @brief Convert the specified Dot11AuthenticationData to the equivalent IEEE 802.11 authentication data.
  *
  * @param dot11AuthenticationData The Dot11AuthenticationData to convert.

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -251,48 +251,93 @@ ToDot11AccessPointCapabilities(const Ieee80211AccessPointCapabilities& ieee80211
 
 /**
  * @brief Convert the specified Dot11MacAddress to the equivalent IEEE 802.11 mac address.
- * 
+ *
  * @param dot11MacAddress The Dot11MacAddress to convert.
- * @return Ieee80211MacAddress 
+ * @return Ieee80211MacAddress
  */
 Ieee80211MacAddress
 FromDot11MacAddress(const Dot11MacAddress& dot11MacAddress) noexcept;
 
 /**
+ * @brief Convert the specified IEEE 802.11 mac address to the equivalent Dot11MacAddress.
+ *
+ * @param ieee80211MacAddress The IEEE 802.11 mac address to convert.
+ * @return Dot11MacAddress
+ */
+Dot11MacAddress
+ToDot11MacAddress(const Ieee80211MacAddress& ieee80211MacAddress) noexcept;
+
+/**
  * @brief Convert the specified Dot11SharedKey to the equivalent IEEE 802.11 shared key.
- * 
+ *
  * @param dot11SharedKey The Dot11SharedKey to convert.
- * @return Ieee80211SharedKey 
+ * @return Ieee80211SharedKey
  */
 Ieee80211SharedKey
 FromDot11SharedKey(const Dot11SharedKey& dot11SharedKey) noexcept;
 
 /**
+ * @brief Convert the specified IEEE 802.11 shared key to the equivalent Dot11SharedKey.
+ *
+ * @param ieee80211SharedKey The IEEE 802.11 shared key to convert.
+ * @return Dot11SharedKey
+ */
+Dot11SharedKey
+ToDot11SharedKey(const Ieee80211SharedKey& ieee80211SharedKey) noexcept;
+
+/**
  * @brief Convert the specified Dot11RsnaPassword to the equivalent IEEE 802.11 RSNA password.
- * 
+ *
  * @param dot11RsnaPassword The Dot11RsnaPassword to convert.
- * @return Ieee80211RsnaPassword 
+ * @return Ieee80211RsnaPassword
  */
 Ieee80211RsnaPassword
 FromDot11RsnaPassword(const Dot11RsnaPassword& dot11RsnaPassword) noexcept;
 
 /**
+ * @brief Convert the specified IEEE 802.11 RSNA password to the equivalent Dot11RsnaPassword.
+ *
+ * @param ieee80211RsnaPassword The IEEE 802.11 RSNA password to convert.
+ * @return Dot11RsnaPassword
+ */
+Dot11RsnaPassword
+ToDot11RsnaPassword(const Ieee80211RsnaPassword& ieee80211RsnaPassword) noexcept;
+
+/**
  * @brief Convert the specified Dot11AuthenticationDataPsk to the equivalent IEEE 802.11 authentication data.
- * 
+ *
  * @param dot11AuthenticationDataPsk The Dot11AuthenticationDataPsk to convert.
- * @return Ieee80211AuthenticationDataPsk 
+ * @return Ieee80211AuthenticationDataPsk
  */
 Ieee80211AuthenticationDataPsk
 FromDot11AuthenticationDataPsk(const Dot11AuthenticationDataPsk& dot11AuthenticationDataPsk) noexcept;
 
 /**
+ * @brief Convert the specified IEEE 802.11 authentication data to the equivalent Dot11AuthenticationDataPsk.
+ *
+ * @param ieee80211AuthenticationDataPsk The IEEE 802.11 authentication data to convert.
+ * @return Dot11AuthenticationDataPsk
+ */
+Dot11AuthenticationDataPsk
+ToDot11AuthenticationDataPsk(const Ieee80211AuthenticationDataPsk& ieee80211AuthenticationDataPsk) noexcept;
+
+/**
  * @brief Convert the specified Dot11AuthenticationDataSae to the equivalent IEEE 802.11 authentication data.
- * 
+ *
  * @param dot11AuthenticationDataSae The Dot11AuthenticationDataSae to convert.
- * @return Ieee80211AuthenticationDataSae 
+ * @return Ieee80211AuthenticationDataSae
  */
 Ieee80211AuthenticationDataSae
 FromDot11AuthenticationDataSae(const Dot11AuthenticationDataSae& dot11AuthenticationDataSae) noexcept;
+
+/**
+ * @brief Convert the specified IEEE 802.11 authentication data to the equivalent Dot11AuthenticationDataSae.
+ *
+ * @param ieee80211AuthenticationDataSae The IEEE 802.11 authentication data to convert.
+ * @return Dot11AuthenticationDataSae
+ */
+Dot11AuthenticationDataSae
+ToDot11AuthenticationDataSae(const Ieee80211AuthenticationDataSae& ieee80211AuthenticationDataSae) noexcept;
 
 /**
  * @brief Convert the specified Dot11AuthenticationData to the equivalent IEEE 802.11 authentication data.
@@ -302,6 +347,15 @@ FromDot11AuthenticationDataSae(const Dot11AuthenticationDataSae& dot11Authentica
  */
 Ieee80211AuthenticationData
 FromDot11AuthenticationData(const Dot11AuthenticationData& dot11AuthenticationData) noexcept;
+
+/**
+ * @brief Convert the specified IEEE 802.11 authentication data to the equivalent Dot11AuthenticationData.
+ *
+ * @param ieee80211AuthenticationData The IEEE 802.11 authentication data to convert.
+ * @return Dot11AuthenticationData
+ */
+Dot11AuthenticationData
+ToDot11AuthenticationData(const Ieee80211AuthenticationData& ieee80211AuthenticationData) noexcept;
 
 } // namespace Microsoft::Net::Wifi
 

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -271,6 +271,19 @@ AccessPointControllerLinux::SetAuthenticationAlgorithms(std::vector<Ieee80211Aut
 }
 
 AccessPointOperationStatus
+AccessPointControllerLinux::SetAuthenticationData([[maybe_unused]] Ieee80211AuthenticationData authenticationData) noexcept
+{
+    AccessPointOperationStatus status{ GetInterfaceName() };
+    const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
+
+    // TODO: implement this
+
+    status.Code = AccessPointOperationStatusCode::Succeeded;
+
+    return status;
+}
+
+AccessPointOperationStatus
 AccessPointControllerLinux::SetAkmSuites(std::vector<Ieee80211AkmSuite> akmSuites) noexcept
 {
     AccessPointOperationStatus status{ GetInterfaceName() };

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -13,6 +13,7 @@
 #include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
+#include <microsoft/net/wifi/Ieee80211Authentication.hxx>
 
 namespace Microsoft::Net::Wifi
 {
@@ -99,6 +100,15 @@ struct AccessPointControllerLinux :
      */
     AccessPointOperationStatus
     SetAuthenticationAlgorithms(std::vector<Ieee80211AuthenticationAlgorithm> authenticationAlgorithms) noexcept override;
+
+    /**
+     * @brief Set the authentication data the access point should use.
+     *
+     * @param authenticationData The authentication data to be set.
+     * @return AccessPointOperationStatus
+     */
+    AccessPointOperationStatus
+    SetAuthenticationData(Ieee80211AuthenticationData authenticationData) noexcept override;
 
     /**
      * @brief Set the authentication and key management (akm) suites the access point should enable.

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -126,6 +126,19 @@ AccessPointControllerTest::SetAuthenticationAlgorithms(std::vector<Ieee80211Auth
 }
 
 AccessPointOperationStatus
+AccessPointControllerTest::SetAuthenticationData(Ieee80211AuthenticationData authenticationData) noexcept
+{
+    assert(AccessPoint != nullptr);
+
+    if (AccessPoint == nullptr) {
+        return AccessPointOperationStatus::InvalidAccessPoint("null AccessPoint");
+    }
+
+    AccessPoint->AuthenticationData = std::move(authenticationData);
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
+}
+
+AccessPointOperationStatus
 AccessPointControllerTest::SetAkmSuites(std::vector<Ieee80211AkmSuite> akmSuites) noexcept
 {
     assert(AccessPoint != nullptr);

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -113,6 +113,15 @@ struct AccessPointControllerTest final :
     SetAuthenticationAlgorithms(std::vector<Ieee80211AuthenticationAlgorithm> authenticationAlgorithms) noexcept override;
 
     /**
+     * @brief Set the authentication data the access point should use.
+     *
+     * @param authenticationData The authentication data to be set.
+     * @return AccessPointOperationStatus
+     */
+    AccessPointOperationStatus
+    SetAuthenticationData(Ieee80211AuthenticationData authenticationData) noexcept override;
+
+    /**
      * @brief Set the authentication and key management (akm) suites the access point should enable.
      *
      * @param akmSuites The akm suites to be allowed.

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -12,6 +12,7 @@
 #include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
+#include <microsoft/net/wifi/Ieee80211Authentication.hxx>
 
 namespace Microsoft::Net::Wifi::Test
 {
@@ -28,6 +29,7 @@ struct AccessPointTest final :
     std::string InterfaceName;
     Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities Capabilities;
     Microsoft::Net::Wifi::Ieee80211PhyType PhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
+    Microsoft::Net::Wifi::Ieee80211AuthenticationData AuthenticationData;
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> FrequencyBands;
     std::vector<Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm> AuthenticationAlgorithms;
     std::vector<Microsoft::Net::Wifi::Ieee80211AkmSuite> AkmSuites;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [X] Breaking change
- [ ] Non-functional change

### Goals

* Allow authentication data such as the AP PSK/password to be set when enabled.

### Technical Details

* Add API and neutral type definitions for PSK-based and SAE-based authentication.
* Add definition for IEEE 802.11 mac addresses.
* Add `Ieee80211AuthenticationData*` <-> `Dot11AuthenticationData*` adaptors.
* Add and implement `WifiAccessPointSetAuthenticationDataImpl` and call it from `WifiAccessPointEnable`.
* `IAccessPointController::SetAuthenticationData`

### Test Results

* All unit tests pass.
* Ad-hoc testing to be done once CLI is updated to accept new arguments for authentication data.

### Reviewer Focus

* Consider whether the current API definitions capture the proper options for configuring authentication data.

### Future Work

* Extend `IHostapd` to expose functionality for setting auth data, with implementation in `Hostapd`.
* Implement `AccessPointControllerLinux::SetAuthenticationData` using above implementation.
* Extend `netremote-cli` to accept auth data arguments.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
