### PR TITLE
Complete implementation for setting authentication data via WifiAccessPointEnable API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Testing/
 vcpkg_installed*/
 /vcpkg/
 /packaging/vcpkg/ports/netremote/portfile.cmake
+
+# Debug logs.
+*-LogNetRemote*.txt

--- a/src/common/wifi/core/CMakeLists.txt
+++ b/src/common/wifi/core/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(wifi-core
         AccessPointController.cxx
         AccessPointOperationStatus.cxx
         AccessPointOperationStatusLogOnExit.cxx
+        Ieee80211.cxx
         Ieee80211AccessPointCapabilities.cxx
     PUBLIC
     FILE_SET HEADERS

--- a/src/common/wifi/core/Ieee80211.cxx
+++ b/src/common/wifi/core/Ieee80211.cxx
@@ -1,0 +1,14 @@
+
+#include <format>
+#include <string>
+
+#include <microsoft/net/wifi/Ieee80211.hxx>
+
+namespace Microsoft::Net::Wifi
+{
+std::string
+Ieee80211MacAddressToString(const Ieee80211MacAddress& macAddress)
+{
+    return std::format("{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}", macAddress[0], macAddress[1], macAddress[2], macAddress[3], macAddress[4], macAddress[5]);
+}
+} // namespace Microsoft::Net::Wifi

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -415,6 +415,15 @@ static constexpr auto MacAddressNumOctets = 6;
 using Ieee80211MacAddress = std::array<uint8_t, MacAddressNumOctets>;
 
 /**
+ * @brief Convert a MAC address to a string.
+ *
+ * @param macAddress The MAC address to convert.
+ * @return std::string
+ */
+std::string
+Ieee80211MacAddressToString(const Ieee80211MacAddress& macAddress);
+
+/**
  * @brief Information about a BSS.
  */
 struct Ieee80211Bss

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
@@ -1,11 +1,14 @@
 
+#include <cstdint>
 #include <format>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <Wpa/ProtocolHostapd.hxx>
 #include <magic_enum.hpp>
 #include <microsoft/net/wifi/Ieee80211.hxx>
+#include <microsoft/net/wifi/Ieee80211Authentication.hxx>
 #include <plog/Log.h>
 
 #include "Ieee80211WpaAdapters.hxx"
@@ -222,4 +225,27 @@ Ieee80211CipherSuitesToWpaCipherSuites(const std::unordered_map<Ieee80211Securit
 
     return wpaCipherSuites;
 }
+
+std::vector<uint8_t>
+Ieee80211SharedKeyToWpaCredential(const Ieee80211SharedKey& ieee80211SharedKey) noexcept
+{
+    return ieee80211SharedKey.Data;
+}
+
+SaePassword
+Ieee80211RsnaPasswordToWpaSaePassword(const Ieee80211RsnaPassword& ieee80211RsnaPassword) noexcept
+{
+    SaePassword wpaSaePassword{};
+
+    wpaSaePassword.Credential = Ieee80211SharedKeyToWpaCredential(ieee80211RsnaPassword.Credential);
+    if (ieee80211RsnaPassword.PasswordId.has_value()) {
+        wpaSaePassword.PasswordId = *ieee80211RsnaPassword.PasswordId;
+    }
+    if (ieee80211RsnaPassword.PeerMacAddress.has_value()) {
+        wpaSaePassword.PeerMacAddress = Ieee80211MacAddressToString(ieee80211RsnaPassword.PeerMacAddress.value());
+    }
+
+    return wpaSaePassword;
+}
+
 } // namespace Microsoft::Net::Wifi

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
@@ -2,12 +2,15 @@
 #ifndef IEEE_80211_WPA_ADAPTERS_HXX
 #define IEEE_80211_WPA_ADAPTERS_HXX
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <vector>
 
 #include <Wpa/ProtocolHostapd.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
+#include <microsoft/net/wifi/Ieee80211Authentication.hxx>
 
 namespace Microsoft::Net::Wifi
 {
@@ -82,6 +85,24 @@ Ieee80211CipherSuiteToWpaCipher(Ieee80211CipherSuite ieee80211CipherSuite) noexc
  */
 std::unordered_map<Wpa::WpaSecurityProtocol, std::vector<Wpa::WpaCipher>>
 Ieee80211CipherSuitesToWpaCipherSuites(const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuiteConfigurations) noexcept;
+
+/**
+ * @brief Convert a Ieee80211SharedKey to a wpa credential.
+ *
+ * @param ieee80211SharedKey The Ieee80211SharedKey to convert.
+ * @return std::vector<uint8_t>
+ */
+std::vector<uint8_t>
+Ieee80211SharedKeyToWpaCredential(const Ieee80211SharedKey& ieee80211SharedKey) noexcept;
+
+/**
+ * @brief Convert a Ieee80211RsnaPassword to a WpaSaePassword.
+ *
+ * @param ieee80211RsnaPassword The Ieee80211RsnaPassword to convert.
+ * @return Wpa::SaePassword
+ */
+Wpa::SaePassword
+Ieee80211RsnaPasswordToWpaSaePassword(const Ieee80211RsnaPassword& ieee80211RsnaPassword) noexcept;
 } // namespace Microsoft::Net::Wifi
 
 #endif // IEEE_80211_WPA_ADAPTERS_HXX


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure setting authentication data through the `WifiAccessPointEnable` API works.

### Technical Details

* Implement `IAccessPointController::SetAuthenticationData`.
* Extend `WifiAccessPointEnable` tests to include SAE authentication data.
* Add string conversion function for `Ieee80211MacAddress`.
* Add helpers to adapt between `Ieee802111Auth*` and WPA rsna/password data structures.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
