### PR TITLE
Ensure 6GHz bands can be configured

### DIFF
--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -229,10 +229,33 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
 
     // Set the hostapd "setband" property.
     try {
-        m_hostapd.SetProperty(propertyKeyToSet, propertyValueToSet, EnforceConfigurationChange::Now);
+        m_hostapd.SetProperty(propertyKeyToSet, propertyValueToSet, EnforceConfigurationChange::Defer);
     } catch (const Wpa::HostapdException& ex) {
         status.Code = AccessPointOperationStatusCode::InternalError;
         status.Details = std::format("failed to set hostapd property '{}' to '{}' - {}", propertyKeyToSet, propertyValueToSet, ex.what());
+        return status;
+    }
+
+    // If 6GHz is included, enable protected management frames, which are required.
+    if (std::ranges::contains(frequencyBands, Ieee80211FrequencyBand::SixGHz)) {
+        propertyKeyToSet = Wpa::ProtocolHostapd::PropertyNameIeee80211W;
+        propertyValueToSet = Wpa::ManagementFrameProtectionToPropertyValue(Wpa::ManagementFrameProtection::Required);
+
+        try {
+            m_hostapd.SetProperty(propertyKeyToSet, propertyValueToSet, EnforceConfigurationChange::Defer);
+        } catch (const Wpa::HostapdException& ex) {
+            status.Code = AccessPointOperationStatusCode::InternalError;
+            status.Details = std::format("failed to enable protected management frames for 6GHz - {}", ex.what());
+            return status;
+        }
+    }
+
+    // Reload the hostapd configuration to pick up the changes.
+    try {
+        m_hostapd.Reload();
+    } catch (const HostapdException& ex) {
+        status.Code = AccessPointOperationStatusCode::InternalError;
+        status.Details = std::format("failed to reload hostapd configuration for frequency band change - {}", ex.what());
         return status;
     }
 

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -150,7 +150,7 @@ AccessPointControllerLinux::SetPhyType(Ieee80211PhyType ieeePhyType) noexcept
 
     // Add the hw_mode property.
     const auto hwMode = IeeePhyTypeToHostapdHwMode(ieeePhyType);
-    const auto hwModeValue = HostapdHwModeToPropertyValue(hwMode);
+    const auto hwModeValue = HostapdHwModePropertyValue(hwMode);
     propertiesToSet.emplace_back(Wpa::ProtocolHostapd::PropertyNameHwMode, hwModeValue);
 
     // Additively set other hostapd properties based on the protocol.

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
@@ -1,7 +1,6 @@
 
 #include <cstdint>
 #include <format>
-#include <string>
 #include <string_view>
 #include <vector>
 
@@ -39,26 +38,6 @@ IeeePhyTypeToHostapdHwMode(Ieee80211PhyType ieeePhyType) noexcept
         return HostapdHwMode::Ieee80211a; // TODO: Assuming a, although hostapd docs don't mention it
     default:
         return HostapdHwMode::Unknown;
-    }
-}
-
-std::string
-HostapdHwModeToPropertyValue(HostapdHwMode hwMode) noexcept
-{
-    switch (hwMode) {
-    case HostapdHwMode::Ieee80211b:
-        return ProtocolHostapd::PropertyHwModeValueB;
-    case HostapdHwMode::Ieee80211g:
-        return ProtocolHostapd::PropertyHwModeValueG;
-    case HostapdHwMode::Ieee80211a:
-        return ProtocolHostapd::PropertyHwModeValueA;
-    case HostapdHwMode::Ieee80211ad:
-        return ProtocolHostapd::PropertyHwModeValueAD;
-    case HostapdHwMode::Ieee80211any:
-        return ProtocolHostapd::PropertyHwModeValueAny;
-    default: // case HostapdHwMode::Unknown
-        LOGE << std::format("Invalid hostapd hw_mode value {}", magic_enum::enum_name(hwMode));
-        return "invalid";
     }
 }
 

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
@@ -3,7 +3,6 @@
 #define IEEE_80211_WPA_ADAPTERS_HXX
 
 #include <cstdint>
-#include <string>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
@@ -22,15 +21,6 @@ namespace Microsoft::Net::Wifi
  */
 Wpa::HostapdHwMode
 IeeePhyTypeToHostapdHwMode(Ieee80211PhyType ieeePhyType) noexcept;
-
-/**
- * @brief Get a string representation of a HostapdHwMode.
- *
- * @param hwMode The HostapdHwMode value to convert.
- * @return std::string
- */
-std::string
-HostapdHwModeToPropertyValue(Wpa::HostapdHwMode hwMode) noexcept;
 
 /**
  * @brief Get a string representation of a Ieee80211FrequencyBand.

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -309,6 +309,16 @@ static constexpr std::underlying_type_t<WpaKeyManagement> WpaKeyManagementFt =
     std::to_underlying(WpaKeyManagement::FtFilsSha256) |
     std::to_underlying(WpaKeyManagement::FtFilsSha384);
 
+/**
+ * @brief Management frame protection levels.
+ */
+enum class ManagementFrameProtection : uint8_t {
+    Unknown,
+    None,
+    Optional,
+    Required,
+};
+
 struct MulticastListenerDiscoveryProtocolInfo
 {
     int Id;
@@ -490,6 +500,11 @@ struct ProtocolHostapd :
     static constexpr auto PropertyNameWmmEnabled = "wmm_enabled";
     static constexpr auto PropertyNameState = "state";
 
+    static constexpr auto PropertyNameIeee80211W = "ieee80211w";
+    static constexpr auto PropertyValueIeee80211WNone = "0";
+    static constexpr auto PropertyValueIeee80211WOptional = "1";
+    static constexpr auto PropertyValueIeee80211WRequired = "2";
+
     // Indexed property names for BSS entries in the "STATUS" response.
     static constexpr auto PropertyNameBss = "bss";
     static constexpr auto PropertyNameBssBssid = "bssid";
@@ -519,6 +534,58 @@ struct ProtocolHostapd :
     static constexpr auto ResponseStatusPropertyKeyIeee80211AX = PropertyNameIeee80211AX;
     static constexpr auto ResponseStatusPropertyKeyDisableAX = PropertyNameDisable11AX;
 };
+
+/**
+ * @brief Convert a ManagementFrameProtection value to the corresponding property value string expected by hostapd. The
+ * return value may be used for the hostapd property 'ieee80211w'.
+ * 
+ * @param managementFrameProtection The ManagementFrameProtection value to convert.
+ * @return constexpr std::string_view 
+ */
+constexpr std::string_view
+ManagementFrameProtectionToPropertyValue(ManagementFrameProtection managementFrameProtection) noexcept
+{
+    switch (managementFrameProtection) {
+    case ManagementFrameProtection::None:
+        return ProtocolHostapd::PropertyValueIeee80211WNone;
+    case ManagementFrameProtection::Optional:
+        return ProtocolHostapd::PropertyValueIeee80211WOptional;
+    case ManagementFrameProtection::Required:
+        return ProtocolHostapd::PropertyValueIeee80211WRequired;
+    case ManagementFrameProtection::Unknown:
+        [[fallthrough]];
+    default:
+        return "UNKNOWN";
+    }
+}
+
+/**
+ * @brief Convert a HostapdHwMode value to the corresponding property value string expected by hostapd. The
+ * return value may be used for the hostapd property 'hw_mode'.
+ * 
+ * @param hwMode The HostapdHwMode value to convert.
+ * @return constexpr std::string_view 
+ */
+constexpr std::string_view
+HostapdHwModePropertyValue(HostapdHwMode hwMode) noexcept
+{
+    switch (hwMode) {
+    case HostapdHwMode::Ieee80211b:
+        return ProtocolHostapd::PropertyHwModeValueB;
+    case HostapdHwMode::Ieee80211g:
+        return ProtocolHostapd::PropertyHwModeValueG;
+    case HostapdHwMode::Ieee80211a:
+        return ProtocolHostapd::PropertyHwModeValueA;
+    case HostapdHwMode::Ieee80211ad:
+        return ProtocolHostapd::PropertyHwModeValueAD;
+    case HostapdHwMode::Ieee80211any:
+        return ProtocolHostapd::PropertyHwModeValueAny;
+    case HostapdHwMode::Unknown:
+        [[fallthrough]];
+    default:
+        return "UNKNOWN";
+    }
+}
 
 /**
  * @brief Converts a string to a HostapdInterfaceState.

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -313,7 +313,7 @@ static constexpr std::underlying_type_t<WpaKeyManagement> WpaKeyManagementFt =
  * @brief Management frame protection levels.
  */
 enum class ManagementFrameProtection : uint8_t {
-    Unknown = 0xFFU,
+    Unknown = 0x80U,
     None = 0x00U,
     Optional = 0x01U,
     Required = 0x02U,

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -313,10 +313,10 @@ static constexpr std::underlying_type_t<WpaKeyManagement> WpaKeyManagementFt =
  * @brief Management frame protection levels.
  */
 enum class ManagementFrameProtection : uint8_t {
-    Unknown,
-    None,
-    Optional,
-    Required,
+    Unknown = 0xFFU,
+    None = 0x00U,
+    Optional = 0x01U,
+    Required = 0x02U,
 };
 
 struct MulticastListenerDiscoveryProtocolInfo


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure 6GHz bands are enabled when requested. This band requires protected management frames (PMF) and this was not being set in the lower hostapd layer.

### Technical Details

* Add `ManagementFrameProtection` enumeration for hostapd.
* Extend `AccessPointControllerLinux::SetFrequencyBands` to set the `ieee80211w` management frames property to `ManagementFrameProtection::Required`.
* Move `hw_mode` property value helper to `ProtocolHostapd` with other related ones.

### Test Results

* All unit tests pass.
* Verified out-of-band with `hostapd_cli` that 6GHz band is enabled following enabling it using the cli.

### Reviewer Focus

* None

### Future Work

* Additional 6GHz related features may need additional changes. These will be determined as needed. 

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
