### PR TITLE
Lay groundwork for use of PSK authentication data

### DIFF
--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -143,7 +143,7 @@ message Dot11MacAddress
     bytes Value = 1;
 }
 
-message Dot11SharedKey
+message Dot11RsnaPsk
 {
     oneof Value
     {
@@ -154,7 +154,7 @@ message Dot11SharedKey
 
 message Dot11AuthenticationDataPsk
 {
-    Dot11SharedKey Key = 1;
+    Dot11RsnaPsk Psk = 1;
 }
 
 // 802.11 Authentication Password.
@@ -163,9 +163,9 @@ message Dot11AuthenticationDataPsk
 // of a password' (specifically, Dot11RSNAConfigPasswordValueEntry).
 message Dot11RsnaPassword
 {
-    Dot11SharedKey Credential = 1;
-    Dot11MacAddress PeerMacAddress = 2;
-    string PasswordId = 3;
+    string Credential = 1;
+    string PasswordId = 2;
+    Dot11MacAddress PeerMacAddress = 3;
 }
 
 message Dot11AuthenticationDataSae

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -737,13 +737,13 @@ NetRemoteService::WifiAccessPointSetAuthenticationDataImpl(std::string_view acce
     }
     if (dot11AuthenticationData.has_psk()) {
         const auto& dataPsk = dot11AuthenticationData.psk();
-        if (!dataPsk.has_key()) {
+        if (!dataPsk.has_psk()) {
             wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
             wifiOperationStatus.set_message("No PSK key provided");
             return wifiOperationStatus;
         }
-        const auto& pskKey = dataPsk.key();
-        if (!pskKey.has_data() && !pskKey.has_passphrase()) {
+        const auto& psk = dataPsk.psk();
+        if (!psk.has_data() && !psk.has_passphrase()) {
             wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
             wifiOperationStatus.set_message("No PSK key data or passphrase provided");
             return wifiOperationStatus;

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211Authentication.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211Authentication.hxx
@@ -2,34 +2,86 @@
 #ifndef IEEE_80211_AUTHENTICATION_HXX
 #define IEEE_80211_AUTHENTICATION_HXX
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include <microsoft/net/wifi/Ieee80211.hxx>
 
 namespace Microsoft::Net::Wifi
 {
-constexpr std::size_t Ieee80211PskLengthMinimum{ 8 };
-constexpr std::size_t Ieee80211PskLengthMaximum{ 63 };
+constexpr std::size_t Ieee80211RsnaPskLength{ 32 };
+constexpr std::size_t Ieee80211RsnaPskSecretLength{ Ieee80211RsnaPskLength * 2 }; // 2 hex chars per byte
+constexpr std::size_t Ieee80211RsnaPskPassphraseLengthMinimum{ 8 };
+constexpr std::size_t Ieee80211RsnaPskPassphraseLengthMaximum{ 63 };
 
-struct Ieee80211SharedKey
+using Ieee80211RsnaPskPassphrase = std::string;
+using Ieee80211RsnaPskValue = std::array<std::uint8_t, Ieee80211RsnaPskLength>;
+using Ieee80211RsnaPskSecret = std::array<char, Ieee80211RsnaPskSecretLength>;
+using Ieee80211RsnaPskVariant = std::variant<Ieee80211RsnaPskPassphrase, Ieee80211RsnaPskSecret>;
+
+/**
+ * @brief Encoding of a pre-shared key.
+ *
+ * The format when the type is 'Secret' is dependent on the context.
+ */
+enum class Ieee80211RsnaPskEncoding {
+    Passphrase,
+    Secret,
+};
+
+struct Ieee80211RsnaPsk :
+    public Ieee80211RsnaPskVariant
 {
-    std::vector<std::uint8_t> Data;
+    using Ieee80211RsnaPskVariant::Ieee80211RsnaPskVariant;
+
+    constexpr Ieee80211RsnaPskEncoding
+    Encoding() const noexcept
+    {
+        return std::holds_alternative<Ieee80211RsnaPskPassphrase>(*this)
+            ? Ieee80211RsnaPskEncoding::Passphrase
+            : Ieee80211RsnaPskEncoding::Secret;
+    }
+
+    constexpr const Ieee80211RsnaPskPassphrase&
+    Passphrase() const
+    {
+        return std::get<Ieee80211RsnaPskPassphrase>(*this);
+    }
+
+    constexpr Ieee80211RsnaPskPassphrase&
+    Passphrase()
+    {
+        return std::get<Ieee80211RsnaPskPassphrase>(*this);
+    }
+
+    constexpr const Ieee80211RsnaPskSecret&
+    Secret() const
+    {
+        return std::get<Ieee80211RsnaPskSecret>(*this);
+    }
+
+    constexpr Ieee80211RsnaPskSecret&
+    Secret()
+    {
+        return std::get<Ieee80211RsnaPskSecret>(*this);
+    }
 };
 
 struct Ieee80211RsnaPassword
 {
-    Ieee80211SharedKey Credential;
+    std::string Credential;
     std::optional<std::string> PasswordId;
     std::optional<Ieee80211MacAddress> PeerMacAddress;
 };
 
 struct Ieee80211AuthenticationDataPsk
 {
-    Ieee80211SharedKey Key;
+    Ieee80211RsnaPsk Psk;
 };
 
 struct Ieee80211AuthenticationDataSae

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -268,22 +268,22 @@ Dot11MacAddress
 ToDot11MacAddress(const Ieee80211MacAddress& ieee80211MacAddress) noexcept;
 
 /**
- * @brief Convert the specified Dot11SharedKey to the equivalent IEEE 802.11 shared key.
- *
- * @param dot11SharedKey The Dot11SharedKey to convert.
- * @return Ieee80211SharedKey
+ * @brief Convert the specified Dot11RsnaPsk to the equivalent IEEE 802.11 shared key.
+ * 
+ * @param Dot11RsnaPsk The Dot11RsnaPsk to convert.
+ * @return Ieee80211RsnaPsk 
  */
-Ieee80211SharedKey
-FromDot11SharedKey(const Dot11SharedKey& dot11SharedKey) noexcept;
+Ieee80211RsnaPsk
+FromDot11RsnaPsk(const Dot11RsnaPsk& Dot11RsnaPsk) noexcept;
 
 /**
- * @brief Convert the specified IEEE 802.11 shared key to the equivalent Dot11SharedKey.
+ * @brief Convert the specified IEEE 802.11 shared key to the equivalent Dot11RsnaPsk.
  *
- * @param ieee80211SharedKey The IEEE 802.11 shared key to convert.
- * @return Dot11SharedKey
+ * @param ieee80211RnsaPsk The IEEE 802.11 shared key to convert.
+ * @return Dot11RsnaPsk
  */
-Dot11SharedKey
-ToDot11SharedKey(const Ieee80211SharedKey& ieee80211SharedKey) noexcept;
+Dot11RsnaPsk
+ToDot11RsnaPsk(const Ieee80211RsnaPsk& ieee80211RnsaPsk) noexcept;
 
 /**
  * @brief Convert the specified Dot11RsnaPassword to the equivalent IEEE 802.11 RSNA password.

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.hxx
@@ -77,13 +77,13 @@ std::unordered_map<Wpa::WpaSecurityProtocol, std::vector<Wpa::WpaCipher>>
 Ieee80211CipherSuitesToWpaCipherSuites(const std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>>& ieee80211CipherSuiteConfigurations) noexcept;
 
 /**
- * @brief Convert a Ieee80211SharedKey to a wpa credential.
+ * @brief Convert a Ieee80211RsnaPsk to a WpaPreSharedKey.
  *
- * @param ieee80211SharedKey The Ieee80211SharedKey to convert.
- * @return std::vector<uint8_t>
+ * @param ieee80211RsnaPsk The Ieee80211RsnaPsk to convert.
+ * @return WpaPreSharedKey
  */
-std::vector<uint8_t>
-Ieee80211SharedKeyToWpaCredential(const Ieee80211SharedKey& ieee80211SharedKey) noexcept;
+Wpa::WpaPreSharedKey
+Ieee80211RsnaPskToWpaSharedKey(const Ieee80211RsnaPsk& ieee80211RsnaPsk) noexcept;
 
 /**
  * @brief Convert a Ieee80211RsnaPassword to a WpaSaePassword.

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -336,31 +336,10 @@ Hostapd::SetPairwiseCipherSuites(std::unordered_map<WpaSecurityProtocol, std::ve
 void
 Hostapd::SetPresharedKey(WpaPreSharedKey preSharedKey, EnforceConfigurationChange enforceConfigurationChange)
 {
-    std::string_view pskProperty;
-    std::string pskPropertyValue;
-
-    if (std::holds_alternative<WpaPskPassphraseT>(preSharedKey)) {
-        const auto& pskValue = std::get<WpaPskPassphraseT>(preSharedKey);
-
-        auto pskPassphrase = std::string(std::cbegin(pskValue), std::cend(pskValue));
-        const auto pskPassphraseLength = std::size(pskPassphrase);
-        if (pskPassphraseLength < WpaPskPassphraseLengthMin || pskPassphraseLength > WpaPskPassphraseLengthMax) {
-            throw HostapdException(std::format("Invalid WPA passphrase length {} (must be {}-{} characters)", pskPassphraseLength, WpaPskPassphraseLengthMin, WpaPskPassphraseLengthMax));
-        }
-
-        pskProperty = ProtocolHostapd::PropertyNameWpaPassphrase;
-        pskPropertyValue = std::move(pskPassphrase);
-    } else if (std::holds_alternative<WpaPskSecretT>(preSharedKey)) {
-        const auto& pskValue = std::get<WpaPskSecretT>(preSharedKey);
-        auto pskSecret = std::string(std::cbegin(pskValue), std::cend(pskValue));
-        pskProperty = ProtocolHostapd::PropertyNameWpaPsk;
-        pskPropertyValue = std::move(pskSecret);
-    } else {
-        throw HostapdException("Invalid WPA pre-shared key type");
-    }
+    auto [pskPropertyName, pskPropertyValue] = WpaPreSharedKeyPropertyKeyAndValue(preSharedKey);
 
     try {
-        SetProperty(pskProperty, pskPropertyValue, enforceConfigurationChange);
+        SetProperty(pskPropertyName, pskPropertyValue, enforceConfigurationChange);
         if (enforceConfigurationChange == EnforceConfigurationChange::Now) {
             Reload();
         }

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -146,6 +146,17 @@ struct Hostapd :
     SetPairwiseCipherSuites(std::unordered_map<WpaSecurityProtocol, std::vector<WpaCipher>> protocolPairwiseCipherMap, EnforceConfigurationChange enforceConfigurationChange) override;
 
     /**
+     * @brief Set the pre-shared key for the interface.
+     *
+     * One of either a 8-63 character passphrase, or a 64-character hex string may be specified.
+     *
+     * @param preSharedKey The pre-shared key to set.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     */
+    void
+    SetPresharedKey(WpaPreSharedKey preSharedKey, EnforceConfigurationChange enforceConfigurationChange) override;
+
+    /**
      * @brief Set the accepted SAE passwords for the interface.
      *
      * @param saePasswords The SAE passwords to set.

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -173,6 +173,17 @@ struct IHostapd
     SetPairwiseCipherSuites(std::unordered_map<WpaSecurityProtocol, std::vector<WpaCipher>> protocolCipherMap, EnforceConfigurationChange enforceConfigurationChange) = 0;
 
     /**
+     * @brief Set the pre-shared key for the interface.
+     *
+     * One of either a 8-63 character passphrase, or a 64-character hex string may be specified.
+     *
+     * @param preSharedKey The pre-shared key to set.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
+     */
+    virtual void
+    SetPresharedKey(WpaPreSharedKey preSharedKey, EnforceConfigurationChange enforceConfigurationChange) = 0;
+
+    /**
      * @brief Set the accepted SAE passwords for the interface.
      *
      * @param saePasswords The SAE passwords to set.

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -10,6 +10,7 @@
 #include <string_view>
 #include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <Wpa/ProtocolWpa.hxx>
@@ -538,9 +539,9 @@ struct ProtocolHostapd :
 /**
  * @brief Convert a ManagementFrameProtection value to the corresponding property value string expected by hostapd. The
  * return value may be used for the hostapd property 'ieee80211w'.
- * 
+ *
  * @param managementFrameProtection The ManagementFrameProtection value to convert.
- * @return constexpr std::string_view 
+ * @return constexpr std::string_view
  */
 constexpr std::string_view
 ManagementFrameProtectionToPropertyValue(ManagementFrameProtection managementFrameProtection) noexcept
@@ -562,9 +563,9 @@ ManagementFrameProtectionToPropertyValue(ManagementFrameProtection managementFra
 /**
  * @brief Convert a HostapdHwMode value to the corresponding property value string expected by hostapd. The
  * return value may be used for the hostapd property 'hw_mode'.
- * 
+ *
  * @param hwMode The HostapdHwMode value to convert.
- * @return constexpr std::string_view 
+ * @return constexpr std::string_view
  */
 constexpr std::string_view
 HostapdHwModePropertyValue(HostapdHwMode hwMode) noexcept
@@ -778,6 +779,18 @@ WpaAuthenticationAlgorithmPropertyValue(WpaAuthenticationAlgorithm wpaAuthentica
     return std::to_underlying(wpaAuthenticationAlgorithm);
 }
 
+static constexpr std::size_t WpaPskSecretLength = 64;
+static constexpr std::size_t WpaPskPassphraseLengthMin = 8;
+static constexpr std::size_t WpaPskPassphraseLengthMax = 63;
+
+using WpaPskPassphraseT = std::string;
+using WpaPskSecretT = std::array<char, WpaPskSecretLength>;
+
+/**
+ * @brief Pre-shared key (PSK).
+ */
+using WpaPreSharedKey = std::variant<WpaPskPassphraseT, WpaPskSecretT>;
+
 /**
  * @brief SAE password entry.
  */
@@ -786,7 +799,7 @@ struct SaePassword
     std::vector<uint8_t> Credential;
     std::optional<std::string> PasswordId;
     std::optional<std::string> PeerMacAddress;
-    std::optional<int32_t> VlanId;  
+    std::optional<int32_t> VlanId;
 };
 } // namespace Wpa
 

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -792,11 +792,30 @@ using WpaPskSecretT = std::array<char, WpaPskSecretLength>;
 using WpaPreSharedKey = std::variant<WpaPskPassphraseT, WpaPskSecretT>;
 
 /**
+ * @brief Get the hostapd property value for the specified WpaPreSharedKey. The returned value
+ * may be used for the hostapd property 'wpa_psk' or 'wpa_passphrase'.
+ *
+ * @param wpaPreSharedKey The WpaPreSharedKey to get the property value for.
+ * @return std::string
+ */
+std::string
+WpaPreSharedKeyPropertyValue(const WpaPreSharedKey& wpaPreSharedKey);
+
+/**
+ * @brief Get the hostapd property and corresponding value for the specified WpaPreSharedKey.
+ *
+ * @param wpaPreSharedKey The WpaPreSharedKey to get the property key and value for.
+ * @return std::pair<std::string_view, std::string>
+ */
+std::pair<std::string_view, std::string>
+WpaPreSharedKeyPropertyKeyAndValue(const WpaPreSharedKey& wpaPreSharedKey);
+
+/**
  * @brief SAE password entry.
  */
 struct SaePassword
 {
-    std::vector<uint8_t> Credential;
+    std::string Credential;
     std::optional<std::string> PasswordId;
     std::optional<std::string> PeerMacAddress;
     std::optional<int32_t> VlanId;

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -34,7 +34,7 @@ constexpr auto AllPhyTypes = magic_enum::enum_values<Microsoft::Net::Wifi::Ieee8
 constexpr auto AllBands = magic_enum::enum_values<Microsoft::Net::Wifi::Ieee80211FrequencyBand>();
 
 constexpr auto PasswordIdValid{ "someid" };
-constexpr std::initializer_list<uint8_t> AsciiPasswordData{ 0x70, 0x61, 0x73, 0x73, 0x77, 0x6F, 0x72, 0x64 };
+constexpr auto AsciiPassword{ "password" };
 constexpr std::array<uint8_t, 6> MacAddressDefault{ 0x00, 0x11, 0x22, 0x33, 0x44, 0x55 };
 } // namespace Microsoft::Net::Remote::Test
 
@@ -133,7 +133,7 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
         dot11CipherSuiteConfigurationWpa1.mutable_ciphersuites()->Add(Dot11CipherSuite::Dot11CipherSuiteCcmp256);
 
         Dot11RsnaPassword dot11RsnaPassword{};
-        *dot11RsnaPassword.mutable_credential()->mutable_data() = { std::cbegin(AsciiPasswordData), std::cend(AsciiPasswordData) };
+        *dot11RsnaPassword.mutable_credential() = AsciiPassword;
         *dot11RsnaPassword.mutable_peermacaddress()->mutable_value() = { std::cbegin(MacAddressDefault), std::cend(MacAddressDefault) };
         dot11RsnaPassword.set_passwordid(PasswordIdValid);
 

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -679,7 +679,7 @@ TEST_CASE("Send SetAuthenticationAlgorithms() command (root)", "[wpa][hostapd][c
 
 namespace Wpa::Test
 {
-constexpr std::initializer_list<uint8_t> AsciiPassword{ 0x70, 0x61, 0x73, 0x73, 0x77, 0x6F, 0x72, 0x64 };
+constexpr auto AsciiPassword{ "password" };
 constexpr auto PasswordIdValid{ "someid" };
 constexpr auto PeerMacAddressValid{ "00:11:22:33:44:55" };
 constexpr int32_t VlanIdValid{ 1 };


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure WPA2-PSK authentication data can be specified.

### Technical Details

* Update some credential types to use strings instead od arrays to more closely match the 802.11 spec.
* Replace `Dot11RsnaPassword's use of `DSot11SharedKey` for the credential with a string.
* Rename `Dot11SharedKey` to `Dot11RsnaPsk`.
* Add `Ieee80211RsnaPsk` wrapper around `std::variant<>` for WPA2 PSKs providing some syntactic sugar.
* Add `WpaPreSharedKey` type.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Make the stack consistent regarding encoding of data that can be binary (eg. SSID, PSK, RSNA Password). Some structures accept hex with explicit field names (eg. `Dot11Ssid::Hex`) but the lower layers don't.
* Make the stack consistent with reference to 802.11 data structure fields. For example, the `Ieee80211Authentication` layer refers to the PSK data hex string as `Secret` but the upper layers don't.
* Convert `WpaPreSharedKey` to use a wrapper like `Ieee80211RsnaPsk` with `std::variant`.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
