### PR TITLE
Refer to PSK authentication data consistently, and pass the data to bottom of the stack

### DIFF
--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -143,18 +143,22 @@ message Dot11MacAddress
     bytes Value = 1;
 }
 
-message Dot11RsnaPsk
+message Dot11RsnaPskDataValue
 {
-    oneof Value
+    oneof Data
     {
-        string Passphrase = 1;
-        bytes Data = 2;
+        string Hex = 1;
+        bytes Raw = 2;
     }
 }
 
-message Dot11AuthenticationDataPsk
+message Dot11RsnaPsk
 {
-    Dot11RsnaPsk Psk = 1;
+    oneof Data
+    {
+        string Passphrase = 1;
+        Dot11RsnaPskDataValue Value = 2;
+    }
 }
 
 // 802.11 Authentication Password.
@@ -166,6 +170,11 @@ message Dot11RsnaPassword
     string Credential = 1;
     string PasswordId = 2;
     Dot11MacAddress PeerMacAddress = 3;
+}
+
+message Dot11AuthenticationDataPsk
+{
+    Dot11RsnaPsk Psk = 1;
 }
 
 message Dot11AuthenticationDataSae

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -175,11 +175,8 @@ message Dot11AuthenticationDataSae
 
 message Dot11AuthenticationData
 {
-    oneof Value
-    {
-        Dot11AuthenticationDataPsk Psk = 1;
-        Dot11AuthenticationDataSae Sae = 2;
-    }
+    Dot11AuthenticationDataPsk Psk = 1;
+    Dot11AuthenticationDataSae Sae = 2;
 }
 
 message Dot11CipherSuiteConfiguration

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -748,7 +748,8 @@ NetRemoteService::WifiAccessPointSetAuthenticationDataImpl(std::string_view acce
             wifiOperationStatus.set_message("No PSK key data or passphrase provided");
             return wifiOperationStatus;
         }
-    } else if (dot11AuthenticationData.has_sae()) {
+    }
+    if (dot11AuthenticationData.has_sae()) {
         const auto& dataSae = dot11AuthenticationData.sae();
         if (std::empty(dataSae.passwords())) {
             wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -762,7 +762,7 @@ NetRemoteService::WifiAccessPointSetAuthenticationDataImpl(std::string_view acce
                 const auto& pskHex = pskValue.hex();
                 if (std::size(pskHex) != Ieee80211RsnaPskLength * 2) {
                     wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
-                    wifiOperationStatus.set_message(std::format("Invalid PSK hex value provided (not {} characters)", Ieee80211RsnaPskLength * 2));
+                    wifiOperationStatus.set_message(std::format("Invalid PSK hex value size '{}' provided (expected {} characters)", std::size(pskHex), Ieee80211RsnaPskLength * 2));
                     return wifiOperationStatus;
                 }
             } else if (pskValue.has_raw()) {

--- a/src/common/wifi/core/CMakeLists.txt
+++ b/src/common/wifi/core/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(wifi-core
         AccessPointOperationStatusLogOnExit.cxx
         Ieee80211.cxx
         Ieee80211AccessPointCapabilities.cxx
+        Ieee80211Authentication.cxx
     PUBLIC
     FILE_SET HEADERS
     BASE_DIRS ${WIFI_CORE_PUBLIC_INCLUDE}

--- a/src/common/wifi/core/Ieee80211Authentication.cxx
+++ b/src/common/wifi/core/Ieee80211Authentication.cxx
@@ -1,0 +1,30 @@
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <format>
+#include <sstream>
+#include <string>
+
+#include <microsoft/net/wifi/Ieee80211Authentication.hxx>
+
+using namespace Microsoft::Net::Wifi;
+
+std::string
+Ieee80211RsnaPsk::ToHexEncodedValue() const
+{
+    assert(Encoding() == Ieee80211RsnaPskEncoding::Value);
+
+    std::string valueHexEncoded;
+    {
+        const auto& value = Value();
+        std::ostringstream valueHexEncodedBuilder;
+        std::ranges::for_each(value, [&](std::uint8_t valueByte) {
+            valueHexEncodedBuilder << std::format("{:02X}", valueByte);
+        });
+
+        valueHexEncoded = valueHexEncodedBuilder.str();
+    }
+
+    return valueHexEncoded;
+}

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211Authentication.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211Authentication.hxx
@@ -15,61 +15,97 @@
 namespace Microsoft::Net::Wifi
 {
 constexpr std::size_t Ieee80211RsnaPskLength{ 32 };
-constexpr std::size_t Ieee80211RsnaPskSecretLength{ Ieee80211RsnaPskLength * 2 }; // 2 hex chars per byte
 constexpr std::size_t Ieee80211RsnaPskPassphraseLengthMinimum{ 8 };
 constexpr std::size_t Ieee80211RsnaPskPassphraseLengthMaximum{ 63 };
 
 using Ieee80211RsnaPskPassphrase = std::string;
 using Ieee80211RsnaPskValue = std::array<std::uint8_t, Ieee80211RsnaPskLength>;
-using Ieee80211RsnaPskSecret = std::array<char, Ieee80211RsnaPskSecretLength>;
-using Ieee80211RsnaPskVariant = std::variant<Ieee80211RsnaPskPassphrase, Ieee80211RsnaPskSecret>;
+using Ieee80211RsnaPskVariant = std::variant<Ieee80211RsnaPskPassphrase, Ieee80211RsnaPskValue>;
 
 /**
  * @brief Encoding of a pre-shared key.
- *
- * The format when the type is 'Secret' is dependent on the context.
  */
 enum class Ieee80211RsnaPskEncoding {
     Passphrase,
-    Secret,
+    Value,
 };
 
+/**
+ * @brief RSN/WPA2 (IEEE 802.11i) pre-shared key. This maps to the 802.11-2020 PSK definitions for
+ * dot11RSNAConfigPSKValue and dot11RSNAConfigPSKPassPhrase.
+ *
+ * This class exists mostly to provide a type-safe way to handle the two possible encodings of a PSK and provide
+ * syntactic sugar over using std::variant<X, Y> directly, which doesn't provid named field access.
+ */
 struct Ieee80211RsnaPsk :
     public Ieee80211RsnaPskVariant
 {
     using Ieee80211RsnaPskVariant::Ieee80211RsnaPskVariant;
 
+    /**
+     * @brief The encoding of the pre-shared key.
+     *
+     * @return constexpr Ieee80211RsnaPskEncoding
+     */
     constexpr Ieee80211RsnaPskEncoding
     Encoding() const noexcept
     {
         return std::holds_alternative<Ieee80211RsnaPskPassphrase>(*this)
             ? Ieee80211RsnaPskEncoding::Passphrase
-            : Ieee80211RsnaPskEncoding::Secret;
+            : Ieee80211RsnaPskEncoding::Value;
     }
 
+    /**
+     * @brief The pre-shared key passphrase. This is only valid when Encoding() == Ieee80211RsnaPskEncoding::Passphrase.
+     *
+     * @return constexpr const Ieee80211RsnaPskPassphrase&
+     */
     constexpr const Ieee80211RsnaPskPassphrase&
     Passphrase() const
     {
         return std::get<Ieee80211RsnaPskPassphrase>(*this);
     }
 
+    /**
+     * @brief The pre-shared key passphrase. This is only valid when Encoding() == Ieee80211RsnaPskEncoding::Passphrase.
+     *
+     * @return constexpr Ieee80211RsnaPskPassphrase&
+     */
     constexpr Ieee80211RsnaPskPassphrase&
     Passphrase()
     {
         return std::get<Ieee80211RsnaPskPassphrase>(*this);
     }
 
-    constexpr const Ieee80211RsnaPskSecret&
-    Secret() const
+    /**
+     * @brief The raw pre-shared key value. This is only valid when Encoding() == Ieee80211RsnaPskEncoding::Value.
+     *
+     * @return constexpr const Ieee80211RsnaPskValue&
+     */
+    constexpr const Ieee80211RsnaPskValue&
+    Value() const
     {
-        return std::get<Ieee80211RsnaPskSecret>(*this);
+        return std::get<Ieee80211RsnaPskValue>(*this);
     }
 
-    constexpr Ieee80211RsnaPskSecret&
-    Secret()
+    /**
+     * @brief The raw pre-shared key value. This is only valid when Encoding() == Ieee80211RsnaPskEncoding::Value.
+     *
+     * @return constexpr Ieee80211RsnaPskValue&
+     */
+    constexpr Ieee80211RsnaPskValue&
+    Value()
     {
-        return std::get<Ieee80211RsnaPskSecret>(*this);
+        return std::get<Ieee80211RsnaPskValue>(*this);
     }
+
+    /**
+     * @brief When the encoding is 'Value', returns the value as a hex-encoded string.
+     *
+     * @return std::string
+     */
+    std::string
+    ToHexEncodedValue() const;
 };
 
 struct Ieee80211RsnaPassword

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -667,7 +667,7 @@ FromDot11RsnaPsk(const Dot11RsnaPsk& dot11RsnaPsk) noexcept
                 std::vector<uint8_t> pskValueRawV(std::size(pskValueRaw));
                 for (std::size_t i = 0; i < std::size(pskValueRaw); i++) {
                     const auto byteAsHex = pskHexView.substr(i * 2, 2); // 2 hex chars
-                    std::from_chars(std::cbegin(byteAsHex), std::cend(byteAsHex), pskValueRaw[i], 16);
+                    std::from_chars(std::data(byteAsHex), std::data(byteAsHex) + std::size(byteAsHex), pskValueRaw[i], 16);
                 }
             }
         } else if (pskValue.has_raw()) {

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -1,5 +1,6 @@
 
 #include <algorithm>
+#include <charconv>
 #include <cstdlib>
 #include <iterator>
 #include <ranges>
@@ -662,8 +663,12 @@ FromDot11RsnaPsk(const Dot11RsnaPsk& dot11RsnaPsk) noexcept
             const auto& pskHex = pskValue.hex();
             // Ensure the hex string is at least twice the length of the value array (2 hex characters per byte).
             if (std::size(pskHex) >= std::size(ieee80211RsnaPsk.Value()) * 2) {
-                ieee80211RsnaPsk.emplace<1>();
-                // TODO: truncate pskHex with range view, then convert from hex string to uint8_t array.
+                std::string_view pskHexView{ pskHex };
+                std::vector<uint8_t> pskValueRawV(std::size(pskValueRaw));
+                for (std::size_t i = 0; i < std::size(pskValueRaw); i++) {
+                    const auto byteAsHex = pskHexView.substr(i * 2, 2); // 2 hex chars
+                    std::from_chars(std::cbegin(byteAsHex), std::cend(byteAsHex), pskValueRaw[i], 16);
+                }
             }
         } else if (pskValue.has_raw()) {
             const auto& pskRaw = pskValue.raw();

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -642,26 +642,36 @@ ToDot11MacAddress(const Ieee80211MacAddress& ieee80211MacAddress) noexcept
 }
 
 Ieee80211RsnaPsk
-FromDot11RsnaPsk(const Dot11RsnaPsk& Dot11RsnaPsk) noexcept
+FromDot11RsnaPsk(const Dot11RsnaPsk& dot11RsnaPsk) noexcept
 {
     Ieee80211RsnaPsk ieee80211RsnaPsk{};
 
-    if (Dot11RsnaPsk.has_data()) {
-        const auto& keyData = Dot11RsnaPsk.data();
-        if (std::size(keyData) >= Ieee80211RsnaPskSecretLength) {
-            // Ensure the variant holds the correct type by calling emplace with the corresponding index. Unfortunately
-            // since the underlying type is a std::array which doesn't have a constructor, it can't be initialized with
-            // a container (e.g. keyData) via emplace args, so the data is explicitly copied with copy_n below, which is
-            // what would happen for "array construction" anyway.
-            auto& pskSecret = ieee80211RsnaPsk.emplace<1>();
-            std::ranges::copy_n(std::cbegin(keyData), Ieee80211RsnaPskSecretLength, std::begin(pskSecret));
-        }
-    } else if (Dot11RsnaPsk.has_passphrase()) {
-        const auto& keyPassphrase = Dot11RsnaPsk.passphrase();
-        const auto keyPassphraseSize = std::size(keyPassphrase);
-        if (keyPassphraseSize >= Ieee80211RsnaPskPassphraseLengthMinimum && keyPassphraseSize <= Ieee80211RsnaPskPassphraseLengthMaximum) {
-            std::string pskPassphrase(std::cbegin(keyPassphrase), std::cend(keyPassphrase));
-            ieee80211RsnaPsk = std::move(pskPassphrase);
+    if (dot11RsnaPsk.has_passphrase()) {
+        const auto& pskPassphrase = dot11RsnaPsk.passphrase();
+        ieee80211RsnaPsk = pskPassphrase;
+    } else if (dot11RsnaPsk.has_value()) {
+        const auto& pskValue = dot11RsnaPsk.value();
+
+        // Ensure the variant holds the correct type by calling emplace with the corresponding index. Unfortunately
+        // since the underlying type is a std::array which doesn't have a constructor, it can't be initialized with
+        // a container via emplace args or variant constructor, so the data is explicitly copied with copy_n below,
+        // which is what would happen for "array construction" anyway.
+        auto& pskValueRaw = ieee80211RsnaPsk.emplace<1>();
+
+        if (pskValue.has_hex()) {
+            const auto& pskHex = pskValue.hex();
+            // Ensure the hex string is at least twice the length of the value array (2 hex characters per byte).
+            if (std::size(pskHex) >= std::size(ieee80211RsnaPsk.Value()) * 2) {
+                ieee80211RsnaPsk.emplace<1>();
+                // TODO: truncate pskHex with range view, then convert from hex string to uint8_t array.
+            }
+        } else if (pskValue.has_raw()) {
+            const auto& pskRaw = pskValue.raw();
+            if (std::size(pskRaw) >= std::size(pskValueRaw)) {
+                std::ranges::copy_n(std::cbegin(pskRaw), static_cast<long>(std::size(pskValueRaw)), std::begin(pskValueRaw));
+            }
+        } else {
+            ieee80211RsnaPsk = {};
         }
     }
 
@@ -671,17 +681,17 @@ FromDot11RsnaPsk(const Dot11RsnaPsk& Dot11RsnaPsk) noexcept
 Dot11RsnaPsk
 ToDot11RsnaPsk(const Ieee80211RsnaPsk& ieee80211RnsaPsk) noexcept
 {
-    Dot11RsnaPsk Dot11RsnaPsk{};
+    Dot11RsnaPsk dot11RsnaPsk{};
 
     switch (ieee80211RnsaPsk.Encoding()) {
     case Ieee80211RsnaPskEncoding::Passphrase: {
         const auto& pskPassphrase = ieee80211RnsaPsk.Passphrase();
-        *Dot11RsnaPsk.mutable_passphrase() = pskPassphrase;
+        *dot11RsnaPsk.mutable_passphrase() = pskPassphrase;
         break;
     }
-    case Ieee80211RsnaPskEncoding::Secret: {
-        const auto& pskSecret = ieee80211RnsaPsk.Secret();
-        Dot11RsnaPsk.mutable_data()->assign(std::cbegin(pskSecret), std::cend(pskSecret));
+    case Ieee80211RsnaPskEncoding::Value: {
+        const auto& pskValue = ieee80211RnsaPsk.Value();
+        dot11RsnaPsk.mutable_value()->mutable_raw()->assign(std::cbegin(pskValue), std::cend(pskValue));
         break;
     }
     default: {
@@ -689,7 +699,7 @@ ToDot11RsnaPsk(const Ieee80211RsnaPsk& ieee80211RnsaPsk) noexcept
     }
     }
 
-    return Dot11RsnaPsk;
+    return dot11RsnaPsk;
 }
 
 Ieee80211RsnaPassword

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -269,9 +269,9 @@ ToDot11MacAddress(const Ieee80211MacAddress& ieee80211MacAddress) noexcept;
 
 /**
  * @brief Convert the specified Dot11RsnaPsk to the equivalent IEEE 802.11 shared key.
- * 
+ *
  * @param Dot11RsnaPsk The Dot11RsnaPsk to convert.
- * @return Ieee80211RsnaPsk 
+ * @return Ieee80211RsnaPsk
  */
 Ieee80211RsnaPsk
 FromDot11RsnaPsk(const Dot11RsnaPsk& Dot11RsnaPsk) noexcept;

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
@@ -1,4 +1,5 @@
 
+#include <cassert>
 #include <cstdint>
 #include <format>
 #include <string_view>
@@ -216,10 +217,16 @@ Ieee80211RsnaPskToWpaSharedKey(const Ieee80211RsnaPsk& ieee80211RsnaPsk) noexcep
         wpaPreSharedKey.emplace<0>(std::move(pskPassphrase));
         break;
     }
-    case Ieee80211RsnaPskEncoding::Secret: {
-        const auto& pskSecret = ieee80211RsnaPsk.Secret();
-        auto& wpaSecret = wpaPreSharedKey.emplace<1>();
-        wpaSecret = pskSecret;
+    case Ieee80211RsnaPskEncoding::Value: {
+        auto pskValueHex = ieee80211RsnaPsk.ToHexEncodedValue();
+        auto& wpaPskValueHex = wpaPreSharedKey.emplace<1>();
+
+        assert(std::size(pskValueHex) == std::size(wpaPskValueHex));
+        if (std::size(pskValueHex) == std::size(wpaPskValueHex)) {
+            std::ranges::copy(wpaPskValueHex, std::begin(pskValueHex));
+        } else {
+            LOGF << std::format("Invalid psk value length '{}'; expected '{}'", std::size(pskValueHex), std::size(wpaPskValueHex));
+        }
         break;
     }
     default:

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -334,7 +334,7 @@ Hostapd::SetPairwiseCipherSuites(std::unordered_map<WpaSecurityProtocol, std::ve
 }
 
 void
-Hostapd::SetPresharedKey(WpaPreSharedKey preSharedKey, EnforceConfigurationChange enforceConfigurationChange)
+Hostapd::SetPreSharedKey(WpaPreSharedKey preSharedKey, EnforceConfigurationChange enforceConfigurationChange)
 {
     auto [pskPropertyName, pskPropertyValue] = WpaPreSharedKeyPropertyKeyAndValue(preSharedKey);
 

--- a/src/linux/wpa-controller/ProtocolHostapd.cxx
+++ b/src/linux/wpa-controller/ProtocolHostapd.cxx
@@ -61,9 +61,9 @@ Wpa::WpaPreSharedKeyPropertyValue(const WpaPreSharedKey& wpaPreSharedKey)
     if (std::holds_alternative<WpaPskPassphraseT>(wpaPreSharedKey)) {
         const auto& pskPassphrase = std::get<WpaPskPassphraseT>(wpaPreSharedKey);
         return std::string(pskPassphrase);
-    } else if (std::holds_alternative<WpaPskSecretT>(wpaPreSharedKey)) {
-        const auto& pskSecret = std::get<WpaPskSecretT>(wpaPreSharedKey);
-        return std::string(std::data(pskSecret), std::size(pskSecret));
+    } else if (std::holds_alternative<WpaPskValueT>(wpaPreSharedKey)) {
+        const auto& pskValue = std::get<WpaPskValueT>(wpaPreSharedKey);
+        return std::string(std::data(pskValue), std::size(pskValue));
     } else {
         return std::string();
     }
@@ -76,7 +76,7 @@ Wpa::WpaPreSharedKeyPropertyKeyAndValue(const WpaPreSharedKey& wpaPreSharedKey)
 
     if (std::holds_alternative<WpaPskPassphraseT>(wpaPreSharedKey)) {
         propertyName = ProtocolHostapd::PropertyNameWpaPassphrase;
-    } else if (std::holds_alternative<WpaPskSecretT>(wpaPreSharedKey)) {
+    } else if (std::holds_alternative<WpaPskValueT>(wpaPreSharedKey)) {
         propertyName = ProtocolHostapd::PropertyNameWpaPsk;
     } else {
         propertyName = ProtocolHostapd::PropertyNameInvalid;

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -154,7 +154,7 @@ struct Hostapd :
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     void
-    SetPresharedKey(WpaPreSharedKey preSharedKey, EnforceConfigurationChange enforceConfigurationChange) override;
+    SetPreSharedKey(WpaPreSharedKey preSharedKey, EnforceConfigurationChange enforceConfigurationChange) override;
 
     /**
      * @brief Set the accepted SAE passwords for the interface.

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -181,7 +181,7 @@ struct IHostapd
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a configuration reload.
      */
     virtual void
-    SetPresharedKey(WpaPreSharedKey preSharedKey, EnforceConfigurationChange enforceConfigurationChange) = 0;
+    SetPreSharedKey(WpaPreSharedKey preSharedKey, EnforceConfigurationChange enforceConfigurationChange) = 0;
 
     /**
      * @brief Set the accepted SAE passwords for the interface.

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -779,17 +779,17 @@ WpaAuthenticationAlgorithmPropertyValue(WpaAuthenticationAlgorithm wpaAuthentica
     return std::to_underlying(wpaAuthenticationAlgorithm);
 }
 
-static constexpr std::size_t WpaPskSecretLength = 64;
+static constexpr std::size_t WpaPskValueLength = 64;
 static constexpr std::size_t WpaPskPassphraseLengthMin = 8;
 static constexpr std::size_t WpaPskPassphraseLengthMax = 63;
 
 using WpaPskPassphraseT = std::string;
-using WpaPskSecretT = std::array<char, WpaPskSecretLength>;
+using WpaPskValueT = std::array<char, WpaPskValueLength>;
 
 /**
  * @brief Pre-shared key (PSK).
  */
-using WpaPreSharedKey = std::variant<WpaPskPassphraseT, WpaPskSecretT>;
+using WpaPreSharedKey = std::variant<WpaPskPassphraseT, WpaPskValueT>;
 
 /**
  * @brief Get the hostapd property value for the specified WpaPreSharedKey. The returned value

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -145,6 +145,7 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
         apConfiguration.mutable_authenticationdata()->mutable_sae()->mutable_passwords()->Add(std::move(dot11RsnaPassword));
+        *apConfiguration.mutable_authenticationdata()->mutable_psk()->mutable_psk()->mutable_passphrase() = AsciiPassword;
 
         WifiAccessPointEnableRequest request{};
         request.set_accesspointid(InterfaceName1);


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure authentication data is referred to consistently throughout the stack.
* Ensure PSK data is passed to the bottom of the stack.
* Allow all supported authentication data to be specified simultaneously.
* Add helper to encode PSK to hex.

### Technical Details

* Rename structures to be consistent with 802.11 naming for PSK (secret -> value, among others).
* Allow specifying both `Psk` and `Sae` in `Dot11AuthenticationData` (remove `oneof` qualifier).
* Mark fields that are expected to be hex-encoded with names that convey this.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* `wpa-controller-unit-test` needs to be updated for PSK scenarios.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
