### PR TITLE
Add basic WpaController unit tests for PSK 

### DIFF
--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -340,9 +340,6 @@ Hostapd::SetPreSharedKey(WpaPreSharedKey preSharedKey, EnforceConfigurationChang
 
     try {
         SetProperty(pskPropertyName, pskPropertyValue, enforceConfigurationChange);
-        if (enforceConfigurationChange == EnforceConfigurationChange::Now) {
-            Reload();
-        }
     } catch (const HostapdException& e) {
         throw HostapdException(std::format("Failed to set pre-shared key ({})", e.what()));
     }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the use of PSK-based authentication data with `Hostapd` is tested.

### Technical Details

* Remove redundant call to `Reload` in `Hostapd::SetPreSharedKey`.
* Add basic unit tests.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Additional high-layer tests need to be added for PSK, including checks for invalid characters.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
