### PR TITLE
Accept PSK and SAE authentication data in CLI

### DIFF
--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -130,6 +130,9 @@ NetRemoteCli::WifiAccessPointEnableCallback()
     if (m_cliData->WifiAccessPointPhyType != Ieee80211PhyType::Unknown) {
         ieee80211AccessPointConfiguration.PhyType = m_cliData->WifiAccessPointPhyType;
     }
+    if (m_cliData->WifiAccessPointAuthenticationData.Psk.has_value()) {
+        ieee80211AccessPointConfiguration.AuthenticationData.Psk = m_cliData->WifiAccessPointAuthenticationData.Psk.value();
+    }
     if (m_cliData->WifiAccessPointAuthenticationData.Sae.has_value()) {
         ieee80211AccessPointConfiguration.AuthenticationData.Sae = m_cliData->WifiAccessPointAuthenticationData.Sae.value();
     }

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -275,7 +275,7 @@ NetRemoteCli::AddSubcommandWifiAccessPointEnable(CLI::App* parent)
     cliAppWifiAccessPointEnable->add_option("--akm,--akms,--akmSuite,--akmSuites,--keyManagement,--keyManagements", m_cliData->WifiAccessPointAkmSuites, "The AKM suites of the access point to enable")
         ->transform(CLI::CheckedTransformer(detail::Ieee80211AkmSuiteNames(), CLI::ignore_case));
     cliAppWifiAccessPointEnable->add_option("--passphrase,--pskPassphrase", m_cliData->WifiAccessPointPskPassphrase, "The PSK passphrase of the access point to enable");
-    cliAppWifiAccessPointEnable->add_option("--sae,--password,--saePassword,--saePasswords", m_cliData->WifiAccessPointSaePasswords, "The SAE passwords of the access point to enable");
+    cliAppWifiAccessPointEnable->add_option("--sae,--password,--passwords,--saePassword,--saePasswords", m_cliData->WifiAccessPointSaePasswords, "The SAE passwords of the access point to enable");
     cliAppWifiAccessPointEnable->callback([this] {
         WifiAccessPointEnableCallback();
     });

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -121,6 +121,11 @@ NetRemoteCli::WifiAccessPointEnableCallback()
 {
     Ieee80211AccessPointConfiguration ieee80211AccessPointConfiguration{};
 
+    if (!std::empty(m_cliData->WifiAccessPointPskPassphrase)) {
+        auto& psk = ieee80211AccessPointConfiguration.AuthenticationData.Psk.emplace();
+        psk.Psk = m_cliData->WifiAccessPointPskPassphrase;
+    }
+
     if (!std::empty(m_cliData->WifiAccessPointSsid)) {
         ieee80211AccessPointConfiguration.Ssid = m_cliData->WifiAccessPointSsid;
     }
@@ -256,6 +261,7 @@ NetRemoteCli::AddSubcommandWifiAccessPointEnable(CLI::App* parent)
         ->transform(CLI::CheckedTransformer(detail::Ieee80211AuthenticationAlgorithmNames(), CLI::ignore_case));
     cliAppWifiAccessPointEnable->add_option("--akm,--akms,--akmSuite,--akmSuites,--keyManagement,--keyManagements", m_cliData->WifiAccessPointAkmSuites, "The AKM suites of the access point to enable")
         ->transform(CLI::CheckedTransformer(detail::Ieee80211AkmSuiteNames(), CLI::ignore_case));
+    cliAppWifiAccessPointEnable->add_option("--passphrase,--pskPassphrase", m_cliData->WifiAccessPointPskPassphrase, "The PSK passphrase of the access point to enable");
     cliAppWifiAccessPointEnable->callback([this] {
         WifiAccessPointEnableCallback();
     });

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -130,6 +130,9 @@ NetRemoteCli::WifiAccessPointEnableCallback()
     if (m_cliData->WifiAccessPointPhyType != Ieee80211PhyType::Unknown) {
         ieee80211AccessPointConfiguration.PhyType = m_cliData->WifiAccessPointPhyType;
     }
+    if (m_cliData->WifiAccessPointAuthenticationData.Sae.has_value()) {
+        ieee80211AccessPointConfiguration.AuthenticationData.Sae = m_cliData->WifiAccessPointAuthenticationData.Sae.value();
+    }
 
     OnWifiAccessPointEnable(m_cliData->WifiAccessPointId, &ieee80211AccessPointConfiguration);
 }

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -346,6 +346,14 @@ NetRemoteCliHandlerOperations::WifiAccessPointEnable(std::string_view accessPoin
             };
         }
 
+        // Populate PSK authentication data if present.
+        if (ieee80211AccessPointConfiguration->AuthenticationData.Psk.has_value()) {
+            const auto& authenticationDataPsk = ieee80211AccessPointConfiguration->AuthenticationData.Psk.value();
+            auto dot11AuthenticationDataPsk = ToDot11AuthenticationDataPsk(authenticationDataPsk);
+
+            *dot11AccessPointConfiguration.mutable_authenticationdata()->mutable_psk() = std::move(dot11AuthenticationDataPsk);
+        }
+
         // Populate SAE authentication data if present.
         if (ieee80211AccessPointConfiguration->AuthenticationData.Sae.has_value()) {
             const auto& authenticationDataSae = ieee80211AccessPointConfiguration->AuthenticationData.Sae.value();

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -345,6 +345,14 @@ NetRemoteCliHandlerOperations::WifiAccessPointEnable(std::string_view accessPoin
                 std::make_move_iterator(std::end(dot11FrequencyBands))
             };
         }
+
+        // Populate SAE authentication data if present.
+        if (ieee80211AccessPointConfiguration->AuthenticationData.Sae.has_value()) {
+            const auto& authenticationDataSae = ieee80211AccessPointConfiguration->AuthenticationData.Sae.value();
+            auto dot11AuthenticationDataSae = ToDot11AuthenticationDataSae(authenticationDataSae);
+
+            *dot11AccessPointConfiguration.mutable_authenticationdata()->mutable_sae() = std::move(dot11AuthenticationDataSae);
+        }
     }
 
     auto status = m_connection->Client->WifiAccessPointEnable(&clientContext, request, &result);

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
@@ -8,6 +8,7 @@
 
 #include <microsoft/net/remote/protocol/NetRemoteProtocol.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
+#include <microsoft/net/wifi/Ieee80211Authentication.hxx>
 
 namespace Microsoft::Net::Remote
 {
@@ -25,6 +26,7 @@ struct NetRemoteCliData
     std::string WifiAccessPointId{};
     std::string WifiAccessPointSsid{};
     Microsoft::Net::Wifi::Ieee80211PhyType WifiAccessPointPhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
+    Microsoft::Net::Wifi::Ieee80211AuthenticationData WifiAccessPointAuthenticationData;
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> WifiAccessPointFrequencyBands{};
     std::vector<Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm> WifiAccessPointAuthenticationAlgorithms{};
     std::vector<Microsoft::Net::Wifi::Ieee80211AkmSuite> WifiAccessPointAkmSuites{};

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
@@ -26,11 +26,11 @@ struct NetRemoteCliData
     std::string WifiAccessPointId{};
     std::string WifiAccessPointSsid{};
     std::string WifiAccessPointPskPassphrase;
-    Microsoft::Net::Wifi::Ieee80211PhyType WifiAccessPointPhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
-    Microsoft::Net::Wifi::Ieee80211AuthenticationData WifiAccessPointAuthenticationData;
+    std::vector<std::string> WifiAccessPointSaePasswords{};
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> WifiAccessPointFrequencyBands{};
     std::vector<Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm> WifiAccessPointAuthenticationAlgorithms{};
     std::vector<Microsoft::Net::Wifi::Ieee80211AkmSuite> WifiAccessPointAkmSuites{};
+    Microsoft::Net::Wifi::Ieee80211PhyType WifiAccessPointPhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
 };
 } // namespace Microsoft::Net::Remote
 

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
@@ -25,6 +25,7 @@ struct NetRemoteCliData
 
     std::string WifiAccessPointId{};
     std::string WifiAccessPointSsid{};
+    std::string WifiAccessPointPskPassphrase;
     Microsoft::Net::Wifi::Ieee80211PhyType WifiAccessPointPhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
     Microsoft::Net::Wifi::Ieee80211AuthenticationData WifiAccessPointAuthenticationData;
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> WifiAccessPointFrequencyBands{};


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow configuration of PSK and SAE authentication data through the CLI for ad-hoc and end-to-end testing.

### Technical Details

* Add switches `--passphrase`, `--pskPassphrase` for accepting the PSK passphrase.
* Add switches `--sae`, `--saePassword`, `saePasswords`, `--password`, `--passwords` for accepting SAE password(s).

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Parsing for SAE password id and peer mac address in CLI.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
