### PR TITLE
Add package preset display names and descriptions.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -387,26 +387,38 @@
     "packagePresets": [
         {
             "name": "packaging-dev",
+            "displayName": "Development",
+            "description": "Development packaging for inner-loop",
             "configurePreset": "packaging-dev"
         },
         {
             "name": "packaging-release",
+            "displayName": "Release",
+            "description": "Release packaging for inner-loop",
             "configurePreset": "packaging-release"
         },
         {
             "name": "packaging-dev-linux",
+            "displayName": "Development",
+            "description": "Development packaging for inner-loop on Linux",
             "configurePreset": "dev-linux"
         },
         {
             "name": "packaging-release-linux",
+            "displayName": "Release",
+            "description": "Release packaging for inner-loop on Linux",
             "configurePreset": "release-linux"
         },
         {
             "name": "packaging-dev-windows",
+            "displayName": "Development",
+            "description": "Development packaging for inner-loop on Windows",
             "configurePreset": "dev-windows"
         },
         {
             "name": "packaging-release-windows",
+            "displayName": "Release",
+            "description": "Release packaging for inner-loop on Windows",
             "configurePreset": "release-windows"
         }
     ]

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ While not required, it is strongly recommended to configure git with a [GNU Priv
 
 Pre-requisities:
 
-* C++ 20 Compiler
+* C++ 23 Compiler
 * CMake version >= 3.25
 
 ### Compiler
 
-Both a compiler and standard C++ library supporting C++20 are required. The C++ reference pages for [C++20 core language features](https://en.cppreference.com/w/cpp/compiler_support#cpp20) and [C++20 library features](https://en.cppreference.com/w/cpp/compiler_support#C.2B.2B20_library_features) provide complete details about current compiler and library support.
+Both a compiler and standard C++ library supporting C++23 are required. The C++ reference pages for [C++23 core language features](https://en.cppreference.com/w/cpp/compiler_support#C.2B.2B23_features) and [C++23 library features](https://en.cppreference.com/w/cpp/compiler_support#C.2B.2B23_library_features) provide complete details about current compiler and library support.
 
 #### Windows
 

--- a/src/linux/README.md
+++ b/src/linux/README.md
@@ -4,7 +4,7 @@ This project tree is meant to exercise and test the OS-agnostic portions of the 
 
 ## Development Environment Setup
 
-As described in the main project [`README`](/README.md), a C++ 20 compiler and CMake are required. So, any distribution satisfying these requirements may be used. A known working environment is ubuntu 23.10 (mantic) with a few development packages. Instructions for setting up this environment are provided below.
+As described in the main project [`README`](/README.md), a C++ 23 compiler and CMake are required. So, any distribution satisfying these requirements may be used. A known working environment is ubuntu 23.10 (mantic) with a few development packages. Instructions for setting up this environment are provided below.
 
 ### 1. Install Ubuntu 23.10 (mantic)
 

--- a/src/windows/README.md
+++ b/src/windows/README.md
@@ -3,7 +3,7 @@
 
 # Development Environment Setup
 
-As described in the main project [`README`](/README.md), a C++ 20 compiler and CMake are required. A known, minimal working environment is using Visual Studio 2022 Build Tools which provides all of the necessary development requirements. Note that the build tools do not provide the Visual Studio IDE, so if this is desired, the Visual Studio product of choice may be installed instead. Instructions for setting up this environment are provided below.
+As described in the main project [`README`](/README.md), a C++ 23 compiler and CMake are required. A known, minimal working environment is using Visual Studio 2022 Build Tools which provides all of the necessary development requirements. Note that the build tools do not provide the Visual Studio IDE, so if this is desired, the Visual Studio product of choice may be installed instead. Instructions for setting up this environment are provided below.
 
 ## 1. Install the tools
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Provide better metadata for CMake packaging presets now that CPack can be invoked directly from VSCode.

### Technical Details

* Add display name and descriptions for each CMake package presets.

### Test Results

* Verified friendly names and descriptions are shown in VSCode when selecting packaging presets:

<img width="446" alt="image" src="https://github.com/microsoft/netremote/assets/2082148/d26ac9c2-8f3f-49e3-b7b1-91c10bac9de9">

* Verified friendly names are shown in package preset listing:

<img width="422" alt="image" src="https://github.com/microsoft/netremote/assets/2082148/5034c5a9-8f42-4efa-b05c-23a0de23973f">

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
