### PR TITLE
Complete debian packaging interactive network configuration

### DIFF
--- a/packaging/deb/config-netplan/scripts/confnetplan
+++ b/packaging/deb/config-netplan/scripts/confnetplan
@@ -13,6 +13,8 @@ readonly NETPLAN_TRY_TIMEOUT_SECONDS_DEFAULT=10
 readonly NETPLAN_KEY_NETWORK=network
 readonly NETPLAN_KEY_INTERFACE_TYPE_ETHERNET=ethernets
 readonly NETPLAN_KEY_INTERFACE_TYPE_BRIDGE=bridges
+readonly NETPLAN_KEY_INTERFACE_DHCP4=dhcp4
+readonly NETPLAN_KEY_BRIDGE_INTERFACE_SEGMENTS=interfaces
 readonly NETPLAN_KEY_RENDERER=renderer
 readonly NETPLAN_RENDERER=networkd
 readonly NETPLAN_VALUE_EMPTY_OBJECT="{}"
@@ -140,26 +142,33 @@ function netplan_configuration_set_interface_key_value() {
     netplan_configuration_set_key_value "${key_composed}" "${value}"
 }
 
-# Set an key-value pair on an ethernet interface in the netplan configuration file. The specified interface is assumed
-# to describe an ethernet interface.
+# Set a boolean property on an interface in the netplan configuration file. The specified interface must already be
+# described in a top-level entry in the netplan configuration file.
 # 
-# Arguments:
+# Arguments
 #   1: Interface name.
-#   2: Key to set.
-#   3: Value to set.
+#   2: Interface type.
+#   3: Boolean key to set.
+#   4: Boolean value to set. Must either be true or false (boolean type, not strings).
 #
-function netplan_configuration_set_ethernet_interface_property() {
+function netplan_configuration_set_interface_boolean_property() {
     local interface_name
     local interface_type
     local key
+    local enable
     local value
 
-    interface_type="${NETPLAN_KEY_INTERFACE_TYPE_ETHERNET}"
-    interface_name="${1}"
-    key="${2}"
-    value="${3}"
+    readonly interface_name="${1}"
+    readonly interface_type="${2}"
+    readonly key="${3}"
+    readonly enable="${4}"
 
-    netplan_configuration_set_key_value "${interface_name}" "${interface_type}" "${key}" "${value}"
+    # shellcheck disable=SC2015
+    [[ "${enable}" == true ]] \
+        && readonly value="true" \
+        || readonly value="false"
+
+    netplan_configuration_set_interface_key_value "${interface_name}" "${interface_type}" "${key}" "${value}"
 }
 
 # Add a new interface to the netplan configuration file.
@@ -209,6 +218,158 @@ function netplan_configuration_add_bridge_interface() {
     readonly interface_type="${NETPLAN_KEY_INTERFACE_TYPE_BRIDGE}"
 
     netplan_configuration_add_interface "${interface_name}" "${interface_type}"
+}
+
+# Set an key-value pair on an ethernet interface in the netplan configuration file. The specified interface must
+# describe an ethernet interface.
+# 
+# Arguments:
+#   1: Interface name.
+#   2: Key to set.
+#   3: Value to set.
+#
+function netplan_configuration_set_ethernet_interface_property() {
+    local interface_name
+    local interface_type
+    local key
+    local value
+
+    interface_type="${NETPLAN_KEY_INTERFACE_TYPE_ETHERNET}"
+    interface_name="${1}"
+    key="${2}"
+    value="${3}"
+
+    netplan_configuration_set_key_value "${interface_name}" "${interface_type}" "${key}" "${value}"
+}
+
+# Set a property on a bridge interface in the netplan configuration file. The specified bridge interface must already be
+# described in a top-level entry in the netplan configuration file.
+#
+# Arguments
+#   1: Interface name.
+#   2: Bridge property to set.
+#   3: Bridge property value to set.
+#
+function netplan_configuration_set_bridge_interface_property() {
+    local interface_name
+    local interface_type
+    local key
+    local value
+
+    readonly interface_type="${NETPLAN_KEY_INTERFACE_TYPE_BRIDGE}"
+    readonly interface_name="${1}"
+    readonly key="${2}"
+    readonly value="${3}"
+
+    netplan_configuration_set_interface_key_value "${interface_name}" "${interface_type}" "${key}" "${value}"
+}
+
+# Add a network segment (interface) to a bridge in the netplan configuration file. The specified bridge interface target
+# must already be descripted in a top-level entry in the netplan configuration file, as does the interface of the
+# network segment.
+#
+# Arguments:
+#   1: Bridge interface name.
+#   2: Network segment interface name.
+#
+function netplan_configuration_add_bridge_interface_segment() {
+    local interface_name
+    local interface_segment
+    local key
+    local value
+
+    readonly interface_name="${1}"
+    readonly interface_segment="${2}"
+    readonly key="${NETPLAN_KEY_BRIDGE_INTERFACE_SEGMENTS}"
+    readonly value="[${interface_segment}]"
+
+    netplan_configuration_set_bridge_interface_property "${interface_name}" "${key}" "${value}"
+}
+
+# Enable DHCP (IPv4) on an interface in the netplan configuration file. The specified interface must already be
+# described in a top-level entry in the netplan configuration file.
+#
+# Arguments:
+#   1: Interface name.
+#   2: Interface type.
+#
+function netplan_configuration_set_interface_dhcp4_enable() {
+    local interface_name
+    local interface_type
+    local key
+    local enable
+
+    readonly interface_name="${1}"
+    readonly interface_type="${2}"
+    readonly key="${NETPLAN_KEY_INTERFACE_DHCP4}"
+    readonly enable=true
+
+    netplan_configuration_set_interface_boolean_property "${interface_name}" "${interface_type}" "${key}" "${enable}"
+}
+
+# Disable DHCP (IPv4) on an interface in the netplan configuration file. The specified interface must already be
+# described in a top-level entry in the netplan configuration file.
+#
+# Arguments:
+#   1: Interface name.
+#   2: Interface type.
+#
+function netplan_configuration_set_interface_dhcp4_disable() {
+    local interface_name
+    local interface_type
+    local key
+    local enable
+
+    readonly interface_name="${1}"
+    readonly interface_type="${2}"
+    readonly key="${NETPLAN_KEY_INTERFACE_DHCP4}"
+    readonly enable=false
+
+    netplan_configuration_set_interface_boolean_property "${interface_name}" "${interface_type}" "${key}" "${enable}"
+}
+
+# Enable DHCP (IPv4) on an ethernet interface in the netplan configuration file. The specified interface must already be
+# described in a top-level entry in the netplan configuration file.
+#
+# Arguments:
+#   1: Interface name.
+#   2: Interface type.
+#
+function netplan_configuration_set_ethernet_interface_dhcp4_enable() {
+    netplan_configuration_set_interface_dhcp4_enable "${1}" "${NETPLAN_KEY_INTERFACE_TYPE_ETHERNET}"
+}
+
+# Disable DHCP (IPv4) on an ethernet interface in the netplan configuration file. The specified interface must already be
+# described in a top-level entry in the netplan configuration file.
+#
+# Arguments:
+#   1: Interface name.
+#   2: Interface type.
+#
+function netplan_configuration_set_ethernet_interface_dhcp4_disable() {
+    netplan_configuration_set_interface_dhcp4_disable "${1}" "${NETPLAN_KEY_INTERFACE_TYPE_ETHERNET}"
+}
+
+# Enable DHCP (IPv4) on a bridge  interface in the netplan configuration file. The specified interface must already be
+# described in a top-level entry in the netplan configuration file.
+#
+# Arguments:
+#   1: Interface name.
+#   2: Interface type.
+#
+function netplan_configuration_set_bridge_interface_dhcp4_enable() {
+    netplan_configuration_set_interface_dhcp4_enable "${1}" "${NETPLAN_KEY_INTERFACE_TYPE_BRIDGE}"
+}
+
+# Disable DHCP (IPv4) on a bridge  interface in the netplan configuration file. The specified interface must already be
+# described in a top-level entry in the netplan configuration file.
+#
+# Arguments:
+#   1: Interface name.
+#   2: Interface type.
+#
+function netplan_configuration_set_bridge_interface_dhcp4_enable() {
+    netplan_configuration_set_interface_dhcp4_disable "${1}" "${NETPLAN_KEY_INTERFACE_TYPE_BRIDGE}"
 }
 
 # Set the top-level (global) fields in the netplan configuration file.

--- a/packaging/deb/config-netplan/scripts/confnetplan
+++ b/packaging/deb/config-netplan/scripts/confnetplan
@@ -12,6 +12,7 @@ readonly NETPLAN_TRY_TIMEOUT_SECONDS_DEFAULT=10
 # Netplan key-value constants.
 readonly NETPLAN_KEY_NETWORK=network
 readonly NETPLAN_KEY_INTERFACE_TYPE_ETHERNET=ethernets
+readonly NETPLAN_KEY_INTERFACE_TYPE_BRIDGE=bridges
 readonly NETPLAN_KEY_RENDERER=renderer
 readonly NETPLAN_RENDERER=networkd
 readonly NETPLAN_VALUE_EMPTY_OBJECT="{}"
@@ -192,6 +193,20 @@ function netplan_configuration_add_ethernet_interface() {
 
     interface_name="${1}"
     interface_type="${NETPLAN_KEY_INTERFACE_TYPE_ETHERNET}"
+
+    netplan_configuration_add_interface "${interface_name}" "${interface_type}"
+}
+
+# Add a new bridge interface to the netplan configuration file.
+#
+#   1: Interface name.
+#
+function netplan_configuration_add_bridge_interface() {
+    local interface_name
+    local interface_type
+
+    readonly interface_name="${1}"
+    readonly interface_type="${NETPLAN_KEY_INTERFACE_TYPE_BRIDGE}"
 
     netplan_configuration_add_interface "${interface_name}" "${interface_type}"
 }

--- a/packaging/deb/config-netplan/scripts/confnetplan
+++ b/packaging/deb/config-netplan/scripts/confnetplan
@@ -7,6 +7,7 @@
 readonly NETPLAN_ORIGIN_FILE_NAME=10-network-netremote-all
 readonly NETPLAN_ORIGIN_FILE_PATH=/etc/netplan/${NETPLAN_ORIGIN_FILE_NAME}.yaml
 readonly NETPLAN_ORIGIN_FILE_PERMS=0600
+readonly NETPLAN_TRY_TIMEOUT_SECONDS_DEFAULT=10
 
 # Netplan key-value constants.
 readonly NETPLAN_KEY_NETWORK=network
@@ -32,6 +33,24 @@ readonly QUESTION_NETWORK_BRIDGE_CHOICES_VAR=network-bridge-interfaces-choices
 QUESTION_NETWORK_BRIDGE_CHOICES=
 QUESTION_NETWORK_BRIDGE_CHOICES=$(echo "${ETHERNET_INTERFACES// /, }" | head -c-1)
 readonly QUESTION_NETWORK_BRIDGE_CHOICES
+
+# Execute the `netplan try` cli command with the specified arguments. This will apply the network configuration then
+# wait for the user to press '<Enter>' to accept the configuration prior to the timeout period expiring. Otherwise, the
+# changes will be reverted.
+#
+# Arguments:
+#   1: Configuration file path (full). If unspecified, NETPLAN_ORIGIN_FILE_PATH is used.
+#   2: Timeout value, in seconds. If unspecified, NETPLAN_TRY_TIMEOUT_SECONDS_DEFAULT is used.
+#
+function netplan_configuration_try() {
+    local config_file
+    local timeout
+
+    readonly config_file="${1:-${NETPLAN_ORIGIN_FILE_PATH}}"
+    readonly timeout="${2:-${NETPLAN_TRY_TIMEOUT_SECONDS_DEFAULT}}"
+
+    netplan try --config-file "${config_file}" --timeout "${timeout}"
+}
 
 # Execute the `netplan set` cli command with the specified arguments. This sets a key-value pair in a netplan YAML
 # configuration file.

--- a/packaging/deb/config-netplan/scripts/confnetplan
+++ b/packaging/deb/config-netplan/scripts/confnetplan
@@ -8,6 +8,7 @@ readonly NETPLAN_ORIGIN_FILE_NAME=10-network-netremote-all
 readonly NETPLAN_ORIGIN_FILE_PATH=/etc/netplan/${NETPLAN_ORIGIN_FILE_NAME}.yaml
 readonly NETPLAN_ORIGIN_FILE_PERMS=0600
 readonly NETPLAN_TRY_TIMEOUT_SECONDS_DEFAULT=10
+readonly NETPLAN_BRIDGE_INTERFACE_PREFIX=brgateway
 
 # Netplan key-value constants.
 readonly NETPLAN_KEY_NETWORK=network
@@ -432,6 +433,9 @@ function netplan_configuration_create() {
 #
 function debconf_prompt_netplan_network_bridge_configuration() {
     local ethernet_interfaces_selected_for_bridges
+    local bridge_interface
+    local num_bridges
+    # local bridge_interface
 
     # Clear the question from the debconf database to force the prompt.
     db_clear
@@ -445,11 +449,11 @@ function debconf_prompt_netplan_network_bridge_configuration() {
     db_get "${QUESTION_NETWORK_BRIDGES}" || true
     readonly ethernet_interfaces_selected_for_bridges=${RET//\, / }
 
-    # Ensure the configuration file has been created.
-    netplan_configuration_create
-
+    num_bridges=0
     for ethernet_interface in ${ethernet_interfaces_selected_for_bridges}; do
-        netplan_configuration_add_ethernet_interface "${ethernet_interface}"
+        bridge_interface="${NETPLAN_BRIDGE_INTERFACE_PREFIX}$((num_bridges++))"
+
+        netplan_configuration_create_bridge_with_initial_ethernet_segment "${bridge_interface}" "${ethernet_interface}"
     done
 }
 
@@ -460,6 +464,16 @@ function debconf_prompt_netplan_network_bridge_configuration() {
 #
 function debconf_prompt_netplan_configuration() {
     local network_bridge_configure
+
+    # Ensure the configuration file has been created.
+    netplan_configuration_create
+
+    # Add each ethernet interface. If the ethernet interface is later added to a bridge, DHCPv4 will be disabled on it,
+    # however, it is done here because the user may not configure a bridge for every interface, and so this will ensure
+    # the interface is usable in either case.
+    for ethernet_interface in ${ETHERNET_INTERFACES}; do
+        netplan_configuration_add_ethernet_interface "${ethernet_interface}"
+    done
 
     # Prompt user whether they want to configure network bridges.
     db_input high "${QUESTION_NETWORK_CONFIGURE_BRIDGES}" || true

--- a/packaging/deb/config-netplan/scripts/confnetplan
+++ b/packaging/deb/config-netplan/scripts/confnetplan
@@ -372,6 +372,28 @@ function netplan_configuration_set_bridge_interface_dhcp4_enable() {
     netplan_configuration_set_interface_dhcp4_disable "${1}" "${NETPLAN_KEY_INTERFACE_TYPE_BRIDGE}"
 }
 
+# Create a new virtual network bridge with an ethernet interface segment.
+#
+# This will create a bridge, enable dhpc IPv4 on it, add the specified ethernet interface as a segment, and disable
+# DHCPv4 on it.
+#
+# Arguments:
+#   1: Bridge interface name.
+#   2: Ethernet segment interface name.
+#
+function netplan_configuration_create_bridge_with_initial_ethernet_segment() {
+    local interface_name
+    local interface_segment
+
+    readonly interface_name="${1}"
+    readonly interface_segment="${2}"
+
+    netplan_configuration_add_bridge_interface "${interface_name}"
+    netplan_configuration_add_bridge_interface_segment "${interface_name}" "${interface_segment}"
+    netplan_configuration_set_bridge_interface_dhcp4_enable "${interface_name}"
+    netplan_configuration_set_ethernet_interface_dhcp4_disable "${interface_segment}"
+}
+
 # Set the top-level (global) fields in the netplan configuration file.
 #
 # The netplan configuration file referred to by NETPLAN_ORIGIN_FILE_NAME is used.

--- a/packaging/deb/config-netplan/scripts/confnetplan
+++ b/packaging/deb/config-netplan/scripts/confnetplan
@@ -9,6 +9,8 @@ readonly NETPLAN_ORIGIN_FILE_PATH=/etc/netplan/${NETPLAN_ORIGIN_FILE_NAME}.yaml
 readonly NETPLAN_ORIGIN_FILE_PERMS=0600
 readonly NETPLAN_TRY_TIMEOUT_SECONDS_DEFAULT=10
 readonly NETPLAN_BRIDGE_INTERFACE_PREFIX=brgateway
+readonly NETPLAT_CONFIGURATION_FILE_REVIEW_SECONDS=5
+readonly NETPLAT_CONFIGURATION_FILE_REVIEW_SECONDS_DEBUG=1
 
 # Netplan key-value constants.
 readonly NETPLAN_KEY_NETWORK=network
@@ -28,10 +30,12 @@ readonly NETPLAN_VALUE_EMPTY_OBJECT="{}"
 ETHERNET_INTERFACES=
 ETHERNET_INTERFACES=$(find -L /sys/class/net -mindepth 1 -maxdepth 1 -type d -name "en*" -printf "%f " | xargs -n1 | sort | xargs)
 readonly ETHERNET_INTERFACES
-
+readonly QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION=netremote/network/configure-show-generate-configuration
+readonly QUESTION_NETWORK_CONFIGURE_APPLY_GENERATED_CONFIGURATION=netremote/network/configure-apply-generated-configuration
 readonly QUESTION_NETWORK_CONFIGURE_BRIDGES=netremote/network/configure-bridge-interfaces
 readonly QUESTION_NETWORK_BRIDGES=netremote/network/bridge-interfaces
 readonly QUESTION_NETWORK_BRIDGE_CHOICES_VAR=network-bridge-interfaces-choices
+readonly QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION_VAR=network-netplan-configuration-file
 
 # Populate bridge network interface choices with available ethernet interfaces.
 QUESTION_NETWORK_BRIDGE_CHOICES=
@@ -68,6 +72,7 @@ function netplan_configuration_apply() {
 #   1: Configuration file path (full). If unspecified, NETPLAN_ORIGIN_FILE_PATH is used.
 #   2: Timeout value, in seconds. If unspecified, NETPLAN_TRY_TIMEOUT_SECONDS_DEFAULT is used.
 #
+# shellcheck disable=SC2120
 function netplan_configuration_try() {
     local config_file
     local timeout
@@ -76,6 +81,15 @@ function netplan_configuration_try() {
     readonly timeout="${2:-${NETPLAN_TRY_TIMEOUT_SECONDS_DEFAULT}}"
 
     netplan try --config-file "${config_file}" --timeout "${timeout}"
+}
+
+# Execute the `netplan get` cli command.
+#
+# Arguments:
+#   None
+#
+function netplan_configuration_get() {
+    netplan get
 }
 
 # Execute the `netplan set` cli command with the specified arguments. This sets a key-value pair in a netplan YAML
@@ -369,7 +383,7 @@ function netplan_configuration_set_bridge_interface_dhcp4_enable() {
 #   1: Interface name.
 #   2: Interface type.
 #
-function netplan_configuration_set_bridge_interface_dhcp4_enable() {
+function netplan_configuration_set_bridge_interface_dhcp4_disable() {
     netplan_configuration_set_interface_dhcp4_disable "${1}" "${NETPLAN_KEY_INTERFACE_TYPE_BRIDGE}"
 }
 
@@ -435,7 +449,6 @@ function debconf_prompt_netplan_network_bridge_configuration() {
     local ethernet_interfaces_selected_for_bridges
     local bridge_interface
     local num_bridges
-    # local bridge_interface
 
     # Clear the question from the debconf database to force the prompt.
     db_clear
@@ -464,12 +477,14 @@ function debconf_prompt_netplan_network_bridge_configuration() {
 #
 function debconf_prompt_netplan_configuration() {
     local network_bridge_configure
+    local configuration_file_review_seconds
+    local generated_configuration_action_requested
 
     # Ensure the configuration file has been created.
     netplan_configuration_create
 
     # Add each ethernet interface. If the ethernet interface is later added to a bridge, DHCPv4 will be disabled on it,
-    # however, it is done here because the user may not configure a bridge for every interface, and so this will ensure
+    # however, it is enabled here because the user may not configure a bridge for every interface, and so this will ensure
     # the interface is usable in either case.
     for ethernet_interface in ${ETHERNET_INTERFACES}; do
         netplan_configuration_add_ethernet_interface "${ethernet_interface}"
@@ -486,4 +501,49 @@ function debconf_prompt_netplan_configuration() {
     if [[ "${network_bridge_configure}" == "true" ]]; then
         debconf_prompt_netplan_network_bridge_configuration
     fi
+
+    # shellcheck disable=SC2015
+    [[ -z "${DEBCONF_DEBUG}" ]] \
+        && readonly configuration_file_review_seconds="${NETPLAT_CONFIGURATION_FILE_REVIEW_SECONDS}" \
+        || readonly configuration_file_review_seconds="${NETPLAT_CONFIGURATION_FILE_REVIEW_SECONDS_DEBUG}"
+
+    # Show the user the generated netplan configuration.
+    db_subst "${QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION}" "${QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION_VAR}" "${NETPLAN_ORIGIN_FILE_PATH}"
+    db_input high "${QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION}" || true
+    db_go || true
+    netplan_configuration_get
+    sleep "${configuration_file_review_seconds}"
+
+    # Substitute the generated configuration file into the prompt description.
+    db_subst "${QUESTION_NETWORK_CONFIGURE_APPLY_GENERATED_CONFIGURATION}" "${QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION_VAR}" "${NETPLAN_ORIGIN_FILE_PATH}"
+
+    # Prompt the user to choose an action to take on the generated configuration.
+    # Continue prompting until either 'Apply', 'Continue', or an invalid option is selected.
+    while true; do 
+        db_input high "${QUESTION_NETWORK_CONFIGURE_APPLY_GENERATED_CONFIGURATION}" || true
+        db_go || true
+        db_get "${QUESTION_NETWORK_CONFIGURE_APPLY_GENERATED_CONFIGURATION}" || true
+
+        generated_configuration_action_requested="${RET}"
+
+        # Check which action the user requested and carry it out.
+        case "${generated_configuration_action_requested}" in
+            "Generate Backend Configuration")
+                netplan_configuration_generate
+                ;;
+            "Try")
+                netplan_configuration_try
+                ;;
+            "Apply")
+                netplan_configuration_apply
+                break # Exit while loop
+                ;;
+            "Continue" | *) 
+                break # Exit while loop
+                ;;
+        esac
+
+        # Update default to "None" after first iteration.
+        db_set "${QUESTION_NETWORK_CONFIGURE_APPLY_GENERATED_CONFIGURATION}" "Continue" || true
+    done # while true
 }

--- a/packaging/deb/config-netplan/scripts/confnetplan
+++ b/packaging/deb/config-netplan/scripts/confnetplan
@@ -503,7 +503,7 @@ function debconf_prompt_netplan_configuration() {
     fi
 
     # shellcheck disable=SC2015
-    [[ -z "${DEBCONF_DEBUG}" ]] \
+    [[ -z "${DEBCONF_DEBUG-}" ]] \
         && readonly configuration_file_review_seconds="${NETPLAT_CONFIGURATION_FILE_REVIEW_SECONDS}" \
         || readonly configuration_file_review_seconds="${NETPLAT_CONFIGURATION_FILE_REVIEW_SECONDS_DEBUG}"
 

--- a/packaging/deb/config-netplan/scripts/confnetplan
+++ b/packaging/deb/config-netplan/scripts/confnetplan
@@ -34,7 +34,29 @@ QUESTION_NETWORK_BRIDGE_CHOICES=
 QUESTION_NETWORK_BRIDGE_CHOICES=$(echo "${ETHERNET_INTERFACES// /, }" | head -c-1)
 readonly QUESTION_NETWORK_BRIDGE_CHOICES
 
-# Execute the `netplan try` cli command with the specified arguments. This will apply the network configuration then
+# Execute the `netplan generate` cli command. This generates renderer-specific configuration files from all discovered
+# yaml configuration files in /{lib,etc,run}/netplan directories as described in
+# https://netplan.readthedocs.io/en/stable/netplan-generate/#handling-multiple-files. The location of the generated
+# files is specific to the configured renderer(s).
+# 
+# Arguments:
+#   None
+#
+function netplan_configuration_generate() {
+    netplan generate
+}
+
+# Execute the `netplan apply` cli command. This will apply netplan configuration from all discovered yaml configuration
+# files in /{lib,etc,run} directories as described in https://netplan.readthedocs.io/en/stable/netplan-generate/#handling-multiple-files.
+# 
+# Arguments:
+#   None
+#
+function netplan_configuration_apply() {
+    netplan apply
+}
+
+# Execute the `netplan try` cli command with the specified arguments. This will apply the netplan configuration then
 # wait for the user to press '<Enter>' to accept the configuration prior to the timeout period expiring. Otherwise, the
 # changes will be reverted.
 #

--- a/packaging/deb/config-netplan/scripts/confnetplan
+++ b/packaging/deb/config-netplan/scripts/confnetplan
@@ -511,6 +511,7 @@ function debconf_prompt_netplan_configuration() {
     db_subst "${QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION}" "${QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION_VAR}" "${NETPLAN_ORIGIN_FILE_PATH}"
     db_input high "${QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION}" || true
     db_go || true
+    clear
     netplan_configuration_get
     sleep "${configuration_file_review_seconds}"
 

--- a/packaging/deb/config-netplan/scripts/confnetplan
+++ b/packaging/deb/config-netplan/scripts/confnetplan
@@ -477,6 +477,7 @@ function debconf_prompt_netplan_network_bridge_configuration() {
 #
 function debconf_prompt_netplan_configuration() {
     local network_bridge_configure
+    local configuration_file_show
     local configuration_file_review_seconds
     local generated_configuration_action_requested
 
@@ -511,9 +512,18 @@ function debconf_prompt_netplan_configuration() {
     db_subst "${QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION}" "${QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION_VAR}" "${NETPLAN_ORIGIN_FILE_PATH}"
     db_input high "${QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION}" || true
     db_go || true
-    clear
-    netplan_configuration_get
-    sleep "${configuration_file_review_seconds}"
+    db_get "${QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION}" || true
+
+    readonly configuration_file_show="${RET}"
+
+    # If user requested to show the generated configuration, do so.
+    if [[ "${configuration_file_show}" == "true" ]]; then
+        clear
+        echo "Generated netplan configuration ${NETPLAN_ORIGIN_FILE_PATH}:"
+        echo
+        netplan_configuration_get
+        sleep "${configuration_file_review_seconds}"
+    fi
 
     # Substitute the generated configuration file into the prompt description.
     db_subst "${QUESTION_NETWORK_CONFIGURE_APPLY_GENERATED_CONFIGURATION}" "${QUESTION_NETWORK_CONFIGURE_SHOW_GENERATED_CONFIGURATION_VAR}" "${NETPLAN_ORIGIN_FILE_PATH}"

--- a/packaging/deb/config-netplan/scripts/postinst
+++ b/packaging/deb/config-netplan/scripts/postinst
@@ -20,6 +20,7 @@ set -euo pipefail
 #   Must be those passed to the script (ie. "$@")
 #
 function main() {
+    :;
 }
 
 main "$@"

--- a/packaging/deb/config-netplan/scripts/postinst
+++ b/packaging/deb/config-netplan/scripts/postinst
@@ -20,15 +20,6 @@ set -euo pipefail
 #   Must be those passed to the script (ie. "$@")
 #
 function main() {
-    db_get "${QUESTION_NETWORK_BRIDGES}" || true
-    ETHERNET_INTERFACES_SELECTED_FOR_BRIDGES=${RET//\, / }
-
-    echo "Ethernet interfaces selected: ${ETHERNET_INTERFACES_SELECTED_FOR_BRIDGES}"
-
-    # TODO: modify netplan configuration and add bridge interface description for each interface.
-    # - possibly just generate the configuration file instead.
-    # - invoke `netplan generate`
-    # - invoke `netplan apply`
 }
 
 main "$@"

--- a/packaging/deb/config-netplan/scripts/templates
+++ b/packaging/deb/config-netplan/scripts/templates
@@ -18,10 +18,10 @@ Description: Select the ethernet interfaces for which a virtual network bridge s
  For each ethernet interface selected below, a virtual network bridge interface will be created and the ethernet interface will be added to it as a network segment. One (1) virtual network bridge is typically needed to provide network services such as DHCP, DNS, etc. for each wireless network interface on the system.
 
 Template: netremote/network/configure-show-generate-configuration
-Type: note
-Description: A netplan configuration file was successfully generated at ${network-netplan-configuration-file}. It will be displayed for five (5) seconds so that it can be reviewed for correctness.
- Press OK to show the generated netplan configuration:
-
+Type: boolean
+Default: true
+Description: Show the generated netplan configuration?
+ A netplan configuration file was successfully generated at ${network-netplan-configuration-file}. If shown, it will be displayed for five (5) seconds so that it can be reviewed for correctness.
 
 Template: netremote/network/configure-apply-generated-configuration
 Type: select

--- a/packaging/deb/config-netplan/scripts/templates
+++ b/packaging/deb/config-netplan/scripts/templates
@@ -15,4 +15,24 @@ Template: netremote/network/bridge-interfaces
 Type: multiselect
 Choices: ${network-bridge-interfaces-choices}
 Description: Select the ethernet interfaces for which a virtual network bridge should be created:
- For each ethernet interface selected below, a virtual network bridge interface will be created. The ethernet interface will be added to it as a network segment. One (1) virtual network bridge is typically needed to provide network services such as DHCP, DNS, etc. for each wireless network interface on the system.
+ For each ethernet interface selected below, a virtual network bridge interface will be created and the ethernet interface will be added to it as a network segment. One (1) virtual network bridge is typically needed to provide network services such as DHCP, DNS, etc. for each wireless network interface on the system.
+
+Template: netremote/network/configure-show-generate-configuration
+Type: note
+Description: A netplan configuration file was successfully generated at ${network-netplan-configuration-file}. It will be displayed for five (5) seconds so that it can be reviewed for correctness.
+ Press OK to show the generated netplan configuration:
+
+
+Template: netremote/network/configure-apply-generated-configuration
+Type: select
+Default: Apply
+Choices: Continue, Generate Backend Configuration, Try, Apply
+Description: Select the action to take on the generated configuration:
+ The generated netplan configuration at ${network-netplan-configuration-file} is ready for use. The configuration must be applied to take effect, but you may select any of the following four (4) actions to take on the generated configuration:
+ .
+  Apply: Generate the backend configuration, apply it, and continue package installation.
+  Continue: Leave the generated configuration file in place, don't apply any changes, and continue package installation.
+  Try: Generate the backend configuration, apply it for 10 seconds, then revert it. Use to validate the generated configuration.
+  Generate Backend Configuration: Generate backend configuration files under /run/systemd/network. Use to inspect the backend configuration files in detail. 
+ .
+ For the 'Continue' and 'Generate Backend Configuration' options, the generated configuration in ${network-netplan-configuration-file} must later be applied manually using 'netplan apply'. For the 'Try' and 'Apply' actions, netplan will bring down all network interfaces described in the generated configuration and connectivity will be lost for a short period while the configuration is applied. This menu will be exited when either 'Continue' or 'Apply' is selected.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure complete networking stack is configured using `netremote-config-netplan` package.

### Technical Details

* Add prompt to show generated netplan configuration file.
* Add prompt for action on generated netplan configuration file: Continue, Generate Backend Configuration, Try, Apply.
* Add script helpers for configuring DHCPv4, adding bridge interface with initial ethernet segment, 
* Fix bug in enabling dhcp4 on bridge interfaces.

### Test Results

* Installed package, ran through menu system and verified connectivity per below:

![netremote-config-netplan-install](https://github.com/microsoft/netremote/assets/2082148/a87dfd54-4678-432d-a8a1-b1447506ed83)

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
