### PR TITLE
Add sdbus-cpp as project dependency

### DIFF
--- a/.docker/netremote-dev/Dockerfile
+++ b/.docker/netremote-dev/Dockerfile
@@ -22,7 +22,7 @@ LABEL org.label-schema.schema-version = "1.0"
 # sudo apt -y update && sudo apt -y upgrade
 #
 # 2. Install core build tools and dependencies:
-# sudo apt install -y --no-install-recommends build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip
+# sudo apt install -y --no-install-recommends autoconf build-essential ca-certificates cmake curl dotnet7 git gnupg libmount-dev libtool linux-libc-dev ninja-build pkg-config python3-jinja2 tar unzip zip
 #
 # 3. Install complete LLVM 17  + clang 17 toolchain:
 # sudo apt install -y --no-install-recommends libllvm-17-ocaml-dev libllvm17 llvm-17 llvm-17-dev llvm-17-doc llvm-17-examples llvm-17-runtime clang-17 clang-tools-17 clang-17-doc libclang-common-17-dev libclang-17-dev libclang1-17 clang-format-17 python3-clang-17 clangd-17 clang-tidy-17 libclang-rt-17-dev libpolly-17-dev libfuzzer-17-dev lldb-17 lld-17 libc++-17-dev libc++abi-17-dev libomp-17-dev libclc-17-dev libunwind-17-dev libmlir-17-dev mlir-17-tools libbolt-17-dev bolt-17 flang-17 libclang-rt-17-dev-wasm32 libclang-rt-17-dev-wasm64 libc++-17-dev-wasm32 libc++abi-17-dev-wasm32 libclang-rt-17-dev-wasm32 libclang-rt-17-dev-wasm64
@@ -39,7 +39,8 @@ RUN apt-get $APT_ARGS_COMMON update && \
     apt-get $APT_ARGS_COMMON upgrade && \
     apt-get $APT_ARGS_COMMON install  \
         # Core project build dependencies.
-        # build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip
+        # autoconf build-essential ca-certificates cmake curl dotnet7 git gnupg libmount-dev libtool linux-libc-dev ninja-build pkg-config python3-jinja2 tar unzip zip
+        autoconf \
         build-essential \
         ca-certificates \
         cmake \
@@ -47,9 +48,12 @@ RUN apt-get $APT_ARGS_COMMON update && \
         dotnet7 \
         git \
         gnupg \
+        libmount-dev \
+        libtool \
         linux-libc-dev \
         ninja-build \
         pkg-config \
+        python3-jinja2 \
         tar \
         unzip \
         zip \

--- a/.docker/netremote-dev/Dockerfile
+++ b/.docker/netremote-dev/Dockerfile
@@ -22,9 +22,9 @@ LABEL org.label-schema.schema-version = "1.0"
 # sudo apt -y update && sudo apt -y upgrade
 #
 # 2. Install core build tools and dependencies:
-# sudo apt install -y --no-install-recommends autoconf build-essential ca-certificates cmake curl dotnet7 git gnupg libmount-dev libtool linux-libc-dev ninja-build pkg-config python3-jinja2 tar unzip zip
+# sudo apt install -y --no-install-recommends autoconf automake autopoint build-essential ca-certificates cmake curl dotnet7 git gnupg libltdl-dev libmount-dev libtool linux-libc-dev ninja-build pkg-config python3-jinja2 tar unzip zip 
 #
-# 3. Install complete LLVM 17  + clang 17 toolchain:
+# 3. Install complete LLVM 17 + clang 17 toolchain:
 # sudo apt install -y --no-install-recommends libllvm-17-ocaml-dev libllvm17 llvm-17 llvm-17-dev llvm-17-doc llvm-17-examples llvm-17-runtime clang-17 clang-tools-17 clang-17-doc libclang-common-17-dev libclang-17-dev libclang1-17 clang-format-17 python3-clang-17 clangd-17 clang-tidy-17 libclang-rt-17-dev libpolly-17-dev libfuzzer-17-dev lldb-17 lld-17 libc++-17-dev libc++abi-17-dev libomp-17-dev libclc-17-dev libunwind-17-dev libmlir-17-dev mlir-17-tools libbolt-17-dev bolt-17 flang-17 libclang-rt-17-dev-wasm32 libclang-rt-17-dev-wasm64 libc++-17-dev-wasm32 libc++abi-17-dev-wasm32 libclang-rt-17-dev-wasm32 libclang-rt-17-dev-wasm64
 # 
 # 4. Install other development dependencies and helpful tools:
@@ -39,8 +39,10 @@ RUN apt-get $APT_ARGS_COMMON update && \
     apt-get $APT_ARGS_COMMON upgrade && \
     apt-get $APT_ARGS_COMMON install  \
         # Core project build dependencies.
-        # autoconf build-essential ca-certificates cmake curl dotnet7 git gnupg libmount-dev libtool linux-libc-dev ninja-build pkg-config python3-jinja2 tar unzip zip
+        # autoconf automake autopoint build-essential ca-certificates cmake curl dotnet7 git gnupg libltdl-dev libmount-dev libtool linux-libc-dev ninja-build pkg-config python3-jinja2 tar unzip zip 
         autoconf \
+        automake \
+        autopoint \
         build-essential \
         ca-certificates \
         cmake \
@@ -48,6 +50,7 @@ RUN apt-get $APT_ARGS_COMMON update && \
         dotnet7 \
         git \
         gnupg \
+        libltdl-dev \
         libmount-dev \
         libtool \
         linux-libc-dev \

--- a/.docker/netremote-dev/vcpkg.json
+++ b/.docker/netremote-dev/vcpkg.json
@@ -3,16 +3,16 @@
   "name": "netremote",
   "version-string": "1",
   "dependencies": [
+    {
+      "name": "sdbus-cpp",
+      "platform": "linux"
+    },
     "grpc",
     "cli11",
     "protobuf",
     "catch2",
     "plog",
     "magic-enum",
-    {
-      "name": "sdbus-cpp",
-      "platform": "linux"
-    },
     {
       "name": "wil",
       "platform": "windows"

--- a/.docker/netremote-dev/vcpkg.json
+++ b/.docker/netremote-dev/vcpkg.json
@@ -10,6 +10,10 @@
     "plog",
     "magic-enum",
     {
+      "name": "sdbus-cpp",
+      "platform": "linux"
+    },
+    {
       "name": "wil",
       "platform": "windows"
     }

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ Testing/
 
 # vcpkg
 vcpkg_installed*/
-/vcpkg/
+# /vcpkg/
 /packaging/vcpkg/ports/netremote/portfile.cmake
 
 # Debug logs.

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ Testing/
 
 # vcpkg
 vcpkg_installed*/
-# /vcpkg/
 /packaging/vcpkg/ports/netremote/portfile.cmake
 
 # Debug logs.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vcpkg"]
-	path = vcpkg
-	url = https://github.com/microsoft/vcpkg.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/microsoft/vcpkg.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ find_package(Threads REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 find_package(CLI11 CONFIG REQUIRED)
 find_package(plog CONFIG REQUIRED)
+find_package(sdbus-c++ REQUIRED)
 
 # Enable POSITION_INDEPENDENT_CODE variable to control passing PIE flags to the linker.
 if (POLICY CMP0083)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,6 @@ find_package(Threads REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 find_package(CLI11 CONFIG REQUIRED)
 find_package(plog CONFIG REQUIRED)
-find_package(sdbus-c++ REQUIRED)
 
 # Enable POSITION_INDEPENDENT_CODE variable to control passing PIE flags to the linker.
 if (POLICY CMP0083)

--- a/src/common/server/NetRemoteServerConfiguration.cxx
+++ b/src/common/server/NetRemoteServerConfiguration.cxx
@@ -4,7 +4,9 @@
 #include <vector>
 
 #include <CLI/App.hpp>
+#include <CLI/Config.hpp>
 #include <CLI/Error.hpp>
+#include <CLI/Formatter.hpp>
 #include <microsoft/net/remote/NetRemoteServerConfiguration.hxx>
 
 using namespace Microsoft::Net::Remote;
@@ -49,7 +51,7 @@ ParseCliAppOptions(bool throwOnParseError, Args&&... args)
         app.parse(std::forward<Args>(args)...);
     } catch (const CLI::ParseError& parseError) {
         if (throwOnParseError) {
-            throw parseError;   // NOLINT(cert-err60-cpp)
+            throw parseError; // NOLINT(cert-err60-cpp)
         }
     }
 

--- a/src/linux/CMakeLists.txt
+++ b/src/linux/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+find_package(sdbus-c++ REQUIRED)
+
 add_subdirectory(external)
 add_subdirectory(libnl-helpers)
 add_subdirectory(wifi)

--- a/src/linux/README.md
+++ b/src/linux/README.md
@@ -66,7 +66,7 @@ Execute the following commands in a shell to install all the tools required to c
 2. Install core build tools and dependencies:
 
     ```bash
-    sudo apt install -y --no-install-recommends build-essential ca-certificates cmake curl dotnet7 git gnupg linux-libc-dev ninja-build pkg-config tar unzip zip
+    sudo apt install -y --no-install-recommends autoconf automake autopoint build-essential ca-certificates cmake curl dotnet7 git gnupg libltdl-dev libmount-dev libtool linux-libc-dev ninja-build pkg-config python3-jinja2 tar unzip zip
     ```
 
 3. Install LLVM compiler dependencies:

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,16 +3,16 @@
   "name": "netremote",
   "version-string": "1",
   "dependencies": [
+    {
+      "name": "sdbus-cpp",
+      "platform": "linux"
+    },
     "grpc",
     "cli11",
     "protobuf",
     "catch2",
     "plog",
     "magic-enum",
-    {
-      "name": "sdbus-cpp",
-      "platform": "linux"
-    },
     {
       "name": "wil",
       "platform": "windows"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,5 +17,12 @@
       "name": "wil",
       "platform": "windows"
     }
-  ]
+  ],
+  "overrides": [
+    {
+      "name": "cli11",
+      "version": "2.3.1"
+    }
+  ],
+  "builtin-baseline": "9224b3bbd8df24999d85720b1d005dd6f969ade0"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,10 @@
     "plog",
     "magic-enum",
     {
+      "name": "sdbus-cpp",
+      "platform": "linux"
+    },
+    {
       "name": "wil",
       "platform": "windows"
     }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Interact with systemd d-bus interfaces, specifically for interaction with thr `org.freedesktop.resolve1.Manager` interface to configure DNS-SD programmatically.

### Technical Details

* Add `sdbus-cpp` to vcpkg dependency list.
* Add transitive system dependencies of `sdbus-cpp` to the Linux README instructions and dev container `Dockerfile`.

### Test Results

* Checked out the project via VSCode devcontainers extension and verified the CMake sdbus-cpp targets were found, then verified a complete build succeeded.

### Reviewer Focus

* None

### Future Work

* Use the sdbus-cpp library targets to implement DNS-SD based service discovery automatically instead of relying on a `.dnssd` configuration file.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
