### PR TITLE
Add helper function for enumerating IPv4 addresses on Linux

### DIFF
--- a/src/linux/libnl-helpers/CMakeLists.txt
+++ b/src/linux/libnl-helpers/CMakeLists.txt
@@ -37,6 +37,7 @@ target_sources(libnl-helpers
 target_link_libraries(libnl-helpers
     PRIVATE
         magic_enum::magic_enum
+        notstd
         plog::plog
         wifi-core
     PUBLIC

--- a/src/linux/libnl-helpers/CMakeLists.txt
+++ b/src/linux/libnl-helpers/CMakeLists.txt
@@ -10,13 +10,14 @@ target_sources(libnl-helpers
         Ieee80211Nl80211Adapters.cxx
         Netlink80211.cxx
         Netlink80211Interface.cxx
-        NetlinkException.cxx
         Netlink80211ProtocolState.cxx
         Netlink80211Wiphy.cxx
         Netlink80211WiphyBand.cxx
         Netlink80211WiphyBandFrequency.cxx
         NetlinkErrorCategory.cxx
+        NetlinkException.cxx
         NetlinkMessage.cxx
+        NetlinkRoute.cxx
         NetlinkSocket.cxx
     PUBLIC
     FILE_SET HEADERS
@@ -25,9 +26,9 @@ target_sources(libnl-helpers
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkErrorCategory.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkException.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkMessage.hxx
+        ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkRoute.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkSocket.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Ieee80211Nl80211Adapters.hxx
-        ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211Interface.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211ProtocolState.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211Wiphy.hxx

--- a/src/linux/libnl-helpers/CMakeLists.txt
+++ b/src/linux/libnl-helpers/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(libnl-helpers
     PUBLIC
         nl
         nl-genl
+        nl-route-3
 )
 
 install(

--- a/src/linux/libnl-helpers/CMakeLists.txt
+++ b/src/linux/libnl-helpers/CMakeLists.txt
@@ -26,12 +26,12 @@ target_sources(libnl-helpers
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkErrorCategory.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkException.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkMessage.hxx
-        ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkRoute.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/NetlinkSocket.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Ieee80211Nl80211Adapters.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211Interface.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211ProtocolState.hxx
         ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/nl80211/Netlink80211Wiphy.hxx
+        ${LIBNL_HELPERS_PUBLIC_INCLUDE_PREFIX}/route/NetlinkRoute.hxx
 )
 
 target_link_libraries(libnl-helpers

--- a/src/linux/libnl-helpers/NetlinkRoute.cxx
+++ b/src/linux/libnl-helpers/NetlinkRoute.cxx
@@ -63,16 +63,21 @@ NetlinkEnumerateIpv4Addresses()
     for (nlObjectIpAddress = nl_cache_get_first(ipAddressCache); nlObjectIpAddress != nullptr; nlObjectIpAddress = nl_cache_get_next(nlObjectIpAddress)) {
         auto *nlIpAddress = reinterpret_cast<struct rtnl_addr *>(nlObjectIpAddress); // NOLINT
 
-        {
-            const auto family = rtnl_addr_get_family(nlIpAddress);
-            if (family != AF_INET) {
-                continue;
-            }
+        // Process ipv4 addresses only.
+        const auto family = rtnl_addr_get_family(nlIpAddress);
+        if (family != AF_INET) {
+            continue;
         }
 
+        // The maximum length of an ipv4 address is INET_ADDRSTRLEN (16) + 3 (for the subnet mask), eg. xxx.xxx.xxx.xxx/yy.
+        constexpr auto Ipv4AddressLengthMax{ INET_ADDRSTRLEN + 3 };
+
+        // Convert the ipv4 address to a string.
         auto *ipv4Address = rtnl_addr_get_local(nlIpAddress);
-        std::string ipv4AddressAscii(INET_ADDRSTRLEN, '\0');
+        std::string ipv4AddressAscii(Ipv4AddressLengthMax, '\0');
         nl_addr2str(ipv4Address, std::data(ipv4AddressAscii), std::size(ipv4AddressAscii));
+
+        // Resize to the actual null-terminated string length.
         ipv4AddressAscii.resize(std::strlen(std::data(ipv4AddressAscii)));
         ipv4Addresses.push_back(std::move(ipv4AddressAscii));
     }

--- a/src/linux/libnl-helpers/NetlinkRoute.cxx
+++ b/src/linux/libnl-helpers/NetlinkRoute.cxx
@@ -1,13 +1,52 @@
 
 #include <format>
+#include <string>
 #include <system_error>
+#include <vector>
 
+#include <linux/if_addr.h>
 #include <linux/netlink.h>
+#include <linux/rtnetlink.h>
 #include <microsoft/net/netlink/NetlinkErrorCategory.hxx>
-#include <microsoft/net/netlink/NetlinkRoute.hxx>
+#include <microsoft/net/netlink/NetlinkMessage.hxx>
 #include <microsoft/net/netlink/NetlinkSocket.hxx>
+#include <microsoft/net/netlink/route/NetlinkRoute.hxx>
+#include <netlink/attr.h>
+#include <netlink/errno.h>
+#include <netlink/handlers.h>
+#include <netlink/msg.h>
 #include <netlink/netlink.h>
+#include <netlink/socket.h>
 #include <plog/Log.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace detail
+{
+std::vector<std::string>
+ParseNlGetAddressResponse([[maybe_unused]] struct nl_msg *nlMessage) noexcept
+{
+    std::vector<std::string> ipAddresses{};
+    // TODO
+    return ipAddresses;
+}
+
+int
+HandleNlGetAddressResponse([[maybe_unused]] struct nl_msg *nlMessage, void *context) noexcept
+{
+    if (context == nullptr) {
+        LOGE << "Received netlink route get address response with null context";
+        return NL_SKIP;
+    }
+
+    auto &nlGetAddressResult = *static_cast<std::vector<std::string> *>(context);
+    nlGetAddressResult = ParseNlGetAddressResponse(nlMessage);
+
+    LOGD << "Successfully parsed a netlink route get address response message";
+
+    return NL_OK;
+}
+} // namespace detail
 
 namespace Microsoft::Net::Netlink
 {
@@ -27,5 +66,55 @@ CreateNlRouteSocket()
     }
 
     return socket;
+}
+
+std::vector<std::string>
+NetlinkEnumerateIpv4Addresses()
+{
+    // Allocate a new nlroute message for sending a dump r equest for all ipv4 addresses.
+    auto nlMessageGetAddress{ NetlinkMessage::Allocate() };
+    if (nlMessageGetAddress == nullptr) {
+        LOGE << "Failed to allocate netlink message for get address request";
+        return {};
+    }
+
+    // Populate the message with the get address request.
+    struct ifaddrmsg *ifAddressMessage{ nullptr };
+    struct nlmsghdr *nlMessageGetAddressHeader = nlmsg_hdr(nlMessageGetAddress);
+    nlMessageGetAddressHeader->nlmsg_len = NLMSG_LENGTH(sizeof *ifAddressMessage);
+    nlMessageGetAddressHeader->nlmsg_type = RTM_GETADDR;
+    nlMessageGetAddressHeader->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    nlMessageGetAddressHeader->nlmsg_seq = NL_AUTO_SEQ;
+    nlMessageGetAddressHeader->nlmsg_pid = NL_AUTO_PID;
+
+    // Filter the requested addresses to only include IPv4 addresses.
+    ifAddressMessage = static_cast<struct ifaddrmsg *>(NLMSG_DATA(nlMessageGetAddressHeader));
+    ifAddressMessage->ifa_family = AF_INET;
+
+    auto nlRouteSocket{ CreateNlRouteSocket() };
+    std::vector<std::string> ipAddresses{};
+
+    // Configure the callback to invoke to process the response.
+    int ret = nl_socket_modify_cb(nlRouteSocket, NL_CB_VALID, NL_CB_CUSTOM, detail::HandleNlGetAddressResponse, &ipAddresses);
+    if (ret < 0) {
+        LOGE << std::format("Failed to modify netlink socket callback with error {}", ret);
+        return {};
+    }
+
+    // Send the request.
+    ret = nl_send_auto(nlRouteSocket, nlMessageGetAddress);
+    if (ret < 0) {
+        LOGE << std::format("Failed to send netlink get address message with error {}", ret);
+        return {};
+    }
+
+    // Receive the response, which will invoke the configured callback.
+    ret = nl_recvmsgs_default(nlRouteSocket);
+    if (ret < 0) {
+        LOGE << std::format("Failed to receive netlink get address response with error {} ({})", ret, nl_geterror(ret));
+        return {};
+    }
+
+    return ipAddresses;
 }
 } // namespace Microsoft::Net::Netlink

--- a/src/linux/libnl-helpers/NetlinkRoute.cxx
+++ b/src/linux/libnl-helpers/NetlinkRoute.cxx
@@ -1,0 +1,31 @@
+
+#include <format>
+#include <system_error>
+
+#include <linux/netlink.h>
+#include <microsoft/net/netlink/NetlinkErrorCategory.hxx>
+#include <microsoft/net/netlink/NetlinkRoute.hxx>
+#include <microsoft/net/netlink/NetlinkSocket.hxx>
+#include <netlink/netlink.h>
+#include <plog/Log.h>
+
+namespace Microsoft::Net::Netlink
+{
+NetlinkSocket
+CreateNlRouteSocket()
+{
+    // Allocate a new netlink socket.
+    auto socket = NetlinkSocket::Allocate();
+
+    // Connect the socket to the route netlink family.
+    const int ret = nl_connect(socket, NETLINK_ROUTE);
+    if (ret < 0) {
+        const auto errorCode = MakeNetlinkErrorCode(-ret);
+        const auto message = std::format("Failed to connect netlink socket for nl control with error {}", errorCode.value());
+        LOGE << message;
+        throw std::system_error(errorCode, message);
+    }
+
+    return socket;
+}
+} // namespace Microsoft::Net::Netlink

--- a/src/linux/libnl-helpers/NetlinkRoute.cxx
+++ b/src/linux/libnl-helpers/NetlinkRoute.cxx
@@ -1,4 +1,5 @@
 
+#include <cstring>
 #include <format>
 #include <optional>
 #include <string>
@@ -6,101 +7,20 @@
 #include <utility>
 #include <vector>
 
-#include <arpa/inet.h>
-#include <linux/if_addr.h>
 #include <linux/netlink.h>
-#include <linux/rtnetlink.h>
 #include <microsoft/net/netlink/NetlinkErrorCategory.hxx>
-#include <microsoft/net/netlink/NetlinkMessage.hxx>
 #include <microsoft/net/netlink/NetlinkSocket.hxx>
 #include <microsoft/net/netlink/route/NetlinkRoute.hxx>
 #include <netinet/in.h>
-#include <netlink/attr.h>
+#include <netlink/addr.h>
+#include <netlink/cache.h>
 #include <netlink/errno.h>
-#include <netlink/handlers.h>
-#include <netlink/msg.h>
 #include <netlink/netlink.h>
 #include <netlink/object.h>
 #include <netlink/route/addr.h>
-#include <netlink/socket.h>
+#include <notstd/Scope.hxx>
 #include <plog/Log.h>
 #include <sys/socket.h>
-#include <unistd.h>
-
-namespace detail
-{
-std::optional<std::string>
-ParseNlGetAddressMessage([[maybe_unused]] struct nlmsghdr *nlMessageHeader)
-{
-    auto ifAddressMessage = static_cast<struct ifaddrmsg *>(nlmsg_data(nlMessageHeader));
-    auto ifAddressMessageLength = IFA_PAYLOAD(nlMessageHeader);
-    auto ifAddressAttribute = static_cast<struct rtattr *>(IFA_RTA(ifAddressMessage));
-
-    for (;;) {
-        if (!RTA_OK(ifAddressAttribute, ifAddressMessageLength)) {
-            break;
-        }
-
-        switch (ifAddressAttribute->rta_type) {
-        case IFA_LOCAL: {
-            auto ipAddress = *reinterpret_cast<struct in_addr *>(RTA_DATA(ifAddressAttribute));
-            auto *ipAddressString = inet_ntop(AF_INET, &ipAddress, nullptr, 0);
-            if (ipAddressString != nullptr) {
-                return ipAddressString;
-            }
-            break;
-        }
-        }
-
-        ifAddressAttribute = RTA_NEXT(ifAddressAttribute, ifAddressMessageLength);
-    }
-
-    return {};
-}
-
-std::vector<std::string>
-ParseNlGetAddressDumpResponse(struct nl_msg *nlMessage) noexcept
-{
-    std::vector<std::string> ipAddresses{};
-    struct nlmsghdr *nlMessageHeader = nlmsg_hdr(nlMessage);
-    auto nlMessageLength = nlMessageHeader->nlmsg_len;
-
-    for (;;) {
-        if (!NLMSG_OK(nlMessageHeader, nlMessageLength)) {
-            break;
-        }
-        if (nlMessageHeader->nlmsg_type == NLMSG_DONE) {
-            break;
-        }
-        if (nlMessageHeader->nlmsg_type == RTM_NEWADDR) {
-            auto ipAddress = ParseNlGetAddressMessage(nlMessageHeader);
-            if (ipAddress.has_value()) {
-                ipAddresses.push_back(ipAddress.value());
-            }
-        }
-
-        nlMessageHeader = NLMSG_NEXT(nlMessageHeader, nlMessageLength);
-    }
-
-    return ipAddresses;
-}
-
-int
-HandleNlGetAddressResponse([[maybe_unused]] struct nl_msg *nlMessage, void *context) noexcept
-{
-    if (context == nullptr) {
-        LOGE << "Received netlink route get address response with null context";
-        return NL_SKIP;
-    }
-
-    auto &nlGetAddressResult = *static_cast<std::vector<std::string> *>(context);
-    nlGetAddressResult = ParseNlGetAddressDumpResponse(nlMessage);
-
-    LOGD << "Successfully parsed a netlink route get address response message";
-
-    return NL_OK;
-}
-} // namespace detail
 
 namespace Microsoft::Net::Netlink
 {
@@ -122,58 +42,8 @@ CreateNlRouteSocket()
     return socket;
 }
 
-std::vector<std::string>
-NetlinkEnumerateIpv4Addresses()
-{
-    // Allocate a new nlroute message for sending a dump r equest for all ipv4 addresses.
-    auto nlMessageGetAddress{ NetlinkMessage::Allocate() };
-    if (nlMessageGetAddress == nullptr) {
-        LOGE << "Failed to allocate netlink message for get address request";
-        return {};
-    }
-
-    // Populate the message with the get address request.
-    struct ifaddrmsg *ifAddressMessage{ nullptr };
-    struct nlmsghdr *nlMessageGetAddressHeader = nlmsg_hdr(nlMessageGetAddress);
-    nlMessageGetAddressHeader->nlmsg_len = NLMSG_LENGTH(sizeof *ifAddressMessage);
-    nlMessageGetAddressHeader->nlmsg_type = RTM_GETADDR;
-    nlMessageGetAddressHeader->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
-    nlMessageGetAddressHeader->nlmsg_seq = NL_AUTO_SEQ;
-    nlMessageGetAddressHeader->nlmsg_pid = NL_AUTO_PID;
-
-    // Filter the requested addresses to only include IPv4 addresses.
-    ifAddressMessage = static_cast<struct ifaddrmsg *>(NLMSG_DATA(nlMessageGetAddressHeader));
-    ifAddressMessage->ifa_family = AF_INET;
-
-    auto nlRouteSocket{ CreateNlRouteSocket() };
-    std::vector<std::string> ipAddresses{};
-
-    // Configure the callback to invoke to process the response.
-    int ret = nl_socket_modify_cb(nlRouteSocket, NL_CB_VALID, NL_CB_CUSTOM, detail::HandleNlGetAddressResponse, &ipAddresses);
-    if (ret < 0) {
-        LOGE << std::format("Failed to modify netlink socket callback with error {}", ret);
-        return {};
-    }
-
-    // Send the request.
-    ret = nl_send_auto(nlRouteSocket, nlMessageGetAddress);
-    if (ret < 0) {
-        LOGE << std::format("Failed to send netlink get address message with error {}", ret);
-        return {};
-    }
-
-    // Receive the response, which will invoke the configured callback.
-    ret = nl_recvmsgs_default(nlRouteSocket);
-    if (ret < 0) {
-        LOGE << std::format("Failed to receive netlink get address response with error {} ({})", ret, nl_geterror(ret));
-        return {};
-    }
-
-    return ipAddresses;
-}
-
 std::optional<std::vector<std::string>>
-NetlinkEnumerateIpv4Addresses2()
+NetlinkEnumerateIpv4Addresses()
 {
     auto nlRouteSocket{ CreateNlRouteSocket() };
 
@@ -184,26 +54,29 @@ NetlinkEnumerateIpv4Addresses2()
         return std::nullopt;
     }
 
-    std::vector<std::string> ipAddresses{};
-    struct nl_object *nlObjectIpAddress{ nullptr };
-    for (nlObjectIpAddress = nl_cache_get_first(ipAddressCache); nlObjectIpAddress != nullptr;  nlObjectIpAddress = nl_cache_get_next(nlObjectIpAddress)) {
-        auto *nlIpAddress = reinterpret_cast<struct rtnl_addr *>(nlObjectIpAddress);
+    auto freeNlCache = notstd::scope_exit([&ipAddressCache] {
+        nl_cache_free(ipAddressCache);
+    });
 
-        const auto family = rtnl_addr_get_family(nlIpAddress);
-        switch (family) {
-        case AF_INET: {
-            auto *ipAddress = rtnl_addr_get_local(nlIpAddress);
-            std::string ipAddressAscii(INET_ADDRSTRLEN, '\0');
-            nl_addr2str(ipAddress, std::data(ipAddressAscii), std::size(ipAddressAscii));
-            ipAddresses.push_back(ipAddressAscii);
-            break;
+    std::vector<std::string> ipv4Addresses{};
+    struct nl_object *nlObjectIpAddress{ nullptr };
+    for (nlObjectIpAddress = nl_cache_get_first(ipAddressCache); nlObjectIpAddress != nullptr; nlObjectIpAddress = nl_cache_get_next(nlObjectIpAddress)) {
+        auto *nlIpAddress = reinterpret_cast<struct rtnl_addr *>(nlObjectIpAddress); // NOLINT
+
+        {
+            const auto family = rtnl_addr_get_family(nlIpAddress);
+            if (family != AF_INET) {
+                continue;
+            }
         }
-        default: {
-            break;
-        }
-        }
+
+        auto *ipv4Address = rtnl_addr_get_local(nlIpAddress);
+        std::string ipv4AddressAscii(INET_ADDRSTRLEN, '\0');
+        nl_addr2str(ipv4Address, std::data(ipv4AddressAscii), std::size(ipv4AddressAscii));
+        ipv4AddressAscii.resize(std::strlen(std::data(ipv4AddressAscii)));
+        ipv4Addresses.push_back(std::move(ipv4AddressAscii));
     }
 
-    return ipAddresses;
+    return ipv4Addresses;
 }
 } // namespace Microsoft::Net::Netlink

--- a/src/linux/libnl-helpers/NetlinkRoute.cxx
+++ b/src/linux/libnl-helpers/NetlinkRoute.cxx
@@ -42,7 +42,7 @@ CreateNlRouteSocket()
     return socket;
 }
 
-std::optional<std::vector<std::string>>
+std::vector<std::string>
 NetlinkEnumerateIpv4Addresses()
 {
     auto nlRouteSocket{ CreateNlRouteSocket() };
@@ -50,8 +50,10 @@ NetlinkEnumerateIpv4Addresses()
     struct nl_cache *ipAddressCache{ nullptr };
     int ret = rtnl_addr_alloc_cache(nlRouteSocket, &ipAddressCache);
     if (ret != 0) {
-        LOGE << std::format("failed to allocate address cache with error {} ({})", ret, nl_geterror(ret));
-        return std::nullopt;
+        const auto errorCode = MakeNetlinkErrorCode(-ret);
+        const auto message = std::format("Failed to allocate address cache with error {}", errorCode.value());
+        LOGE << message;
+        throw std::system_error(errorCode, message);
     }
 
     auto freeNlCache = notstd::scope_exit([&ipAddressCache] {

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkRoute.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkRoute.hxx
@@ -1,0 +1,21 @@
+
+#ifndef NETLINK_ROUTE_HXX
+#define NETLINK_ROUTE_HXX
+
+#include <microsoft/net/netlink/NetlinkSocket.hxx>
+
+namespace Microsoft::Net::Netlink
+{
+/**
+ * @brief Create a netlink socket for use with the "route" family (NETLINK_ROUTE).
+ *
+ * This creates a netlink socket and connects it to the route netlink family.
+ *
+ * @return Microsoft::Net::Netlink::NetlinkSocket
+ */
+Microsoft::Net::Netlink::NetlinkSocket
+CreateNlRouteSocket();
+
+} // namespace Microsoft::Net::Netlink
+
+#endif // NETLINK_ROUTE_HXX

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/route/NetlinkRoute.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/route/NetlinkRoute.hxx
@@ -22,19 +22,11 @@ CreateNlRouteSocket();
 
 /**
  * @brief Enumerate all ipv4 addresses on the system.
- * 
- * @return std::vector<std::string> 
- */
-std::vector<std::string>
-NetlinkEnumerateIpv4Addresses();
-
-/**
- * @brief Enumerate all ipv4 addresses on the system.
- * 
- * @return std::optional<std::vector<std::string>> 
+ *
+ * @return std::optional<std::vector<std::string>>
  */
 std::optional<std::vector<std::string>>
-NetlinkEnumerateIpv4Addresses2();
+NetlinkEnumerateIpv4Addresses();
 
 } // namespace Microsoft::Net::Netlink
 

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/route/NetlinkRoute.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/route/NetlinkRoute.hxx
@@ -22,10 +22,10 @@ CreateNlRouteSocket();
 
 /**
  * @brief Enumerate all ipv4 addresses on the system.
- *
- * @return std::optional<std::vector<std::string>>
+ * 
+ * @return std::vector<std::string> 
  */
-std::optional<std::vector<std::string>>
+std::vector<std::string>
 NetlinkEnumerateIpv4Addresses();
 
 } // namespace Microsoft::Net::Netlink

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/route/NetlinkRoute.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/route/NetlinkRoute.hxx
@@ -2,6 +2,7 @@
 #ifndef NETLINK_ROUTE_HXX
 #define NETLINK_ROUTE_HXX
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -26,6 +27,14 @@ CreateNlRouteSocket();
  */
 std::vector<std::string>
 NetlinkEnumerateIpv4Addresses();
+
+/**
+ * @brief Enumerate all ipv4 addresses on the system.
+ * 
+ * @return std::optional<std::vector<std::string>> 
+ */
+std::optional<std::vector<std::string>>
+NetlinkEnumerateIpv4Addresses2();
 
 } // namespace Microsoft::Net::Netlink
 

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/route/NetlinkRoute.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/route/NetlinkRoute.hxx
@@ -2,6 +2,9 @@
 #ifndef NETLINK_ROUTE_HXX
 #define NETLINK_ROUTE_HXX
 
+#include <string>
+#include <vector>
+
 #include <microsoft/net/netlink/NetlinkSocket.hxx>
 
 namespace Microsoft::Net::Netlink
@@ -15,6 +18,14 @@ namespace Microsoft::Net::Netlink
  */
 Microsoft::Net::Netlink::NetlinkSocket
 CreateNlRouteSocket();
+
+/**
+ * @brief Enumerate all ipv4 addresses on the system.
+ * 
+ * @return std::vector<std::string> 
+ */
+std::vector<std::string>
+NetlinkEnumerateIpv4Addresses();
 
 } // namespace Microsoft::Net::Netlink
 

--- a/tests/unit/linux/libnl-helpers/CMakeLists.txt
+++ b/tests/unit/linux/libnl-helpers/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(libnl-helpers-test-unit
         Main.cxx
         TestNetlink80211Interface.cxx
         TestNetlink80211ProtocolState.cxx
+        TestNetlinkRoute.cxx
 )
 
 target_include_directories(libnl-helpers-test-unit

--- a/tests/unit/linux/libnl-helpers/TestNetlinkRoute.cxx
+++ b/tests/unit/linux/libnl-helpers/TestNetlinkRoute.cxx
@@ -4,10 +4,10 @@
 
 TEST_CASE("NetlinkEnumerateIpv4Addresses", "[linux][libnl-helpers]")
 {
-    using Microsoft::Net::Netlink::NetlinkEnumerateIpv4Addresses;
+    using Microsoft::Net::Netlink::NetlinkEnumerateIpv4Addresses2;
 
     SECTION("Doesn't cause a crash")
     {
-        REQUIRE_NOTHROW(NetlinkEnumerateIpv4Addresses());
+        REQUIRE_NOTHROW(NetlinkEnumerateIpv4Addresses2());
     }
 }

--- a/tests/unit/linux/libnl-helpers/TestNetlinkRoute.cxx
+++ b/tests/unit/linux/libnl-helpers/TestNetlinkRoute.cxx
@@ -11,21 +11,12 @@ TEST_CASE("NetlinkEnumerateIpv4Addresses", "[linux][libnl-helpers]")
         REQUIRE_NOTHROW(NetlinkEnumerateIpv4Addresses());
     }
 
-    SECTION("If value is returned, it is non-empty")
+    SECTION("Returned values are non-empty")
     {
         const auto addresses = NetlinkEnumerateIpv4Addresses();
-        if (addresses.has_value()) {
-            REQUIRE_FALSE(std::empty(addresses.value()));
-        }
-    }
 
-    SECTION("If values are returned, they are non-empty")
-    {
-        const auto addresses = NetlinkEnumerateIpv4Addresses();
-        if (addresses.has_value()) {
-            for (const auto& address : addresses.value()) {
-                REQUIRE_FALSE(std::empty(address));
-            }
+        for (const auto& address : addresses) {
+            REQUIRE_FALSE(std::empty(address));
         }
     }
 }

--- a/tests/unit/linux/libnl-helpers/TestNetlinkRoute.cxx
+++ b/tests/unit/linux/libnl-helpers/TestNetlinkRoute.cxx
@@ -10,4 +10,22 @@ TEST_CASE("NetlinkEnumerateIpv4Addresses", "[linux][libnl-helpers]")
     {
         REQUIRE_NOTHROW(NetlinkEnumerateIpv4Addresses());
     }
+
+    SECTION("If value is returned, it is non-empty")
+    {
+        const auto addresses = NetlinkEnumerateIpv4Addresses();
+        if (addresses.has_value()) {
+            REQUIRE_FALSE(std::empty(addresses.value()));
+        }
+    }
+
+    SECTION("If values are returned, they are non-empty")
+    {
+        const auto addresses = NetlinkEnumerateIpv4Addresses();
+        if (addresses.has_value()) {
+            for (const auto& address : addresses.value()) {
+                REQUIRE_FALSE(std::empty(address));
+            }
+        }
+    }
 }

--- a/tests/unit/linux/libnl-helpers/TestNetlinkRoute.cxx
+++ b/tests/unit/linux/libnl-helpers/TestNetlinkRoute.cxx
@@ -4,10 +4,10 @@
 
 TEST_CASE("NetlinkEnumerateIpv4Addresses", "[linux][libnl-helpers]")
 {
-    using Microsoft::Net::Netlink::NetlinkEnumerateIpv4Addresses2;
+    using Microsoft::Net::Netlink::NetlinkEnumerateIpv4Addresses;
 
     SECTION("Doesn't cause a crash")
     {
-        REQUIRE_NOTHROW(NetlinkEnumerateIpv4Addresses2());
+        REQUIRE_NOTHROW(NetlinkEnumerateIpv4Addresses());
     }
 }

--- a/tests/unit/linux/libnl-helpers/TestNetlinkRoute.cxx
+++ b/tests/unit/linux/libnl-helpers/TestNetlinkRoute.cxx
@@ -1,0 +1,13 @@
+
+#include <catch2/catch_test_macros.hpp>
+#include <microsoft/net/netlink/route/NetlinkRoute.hxx>
+
+TEST_CASE("NetlinkEnumerateIpv4Addresses", "[linux][libnl-helpers]")
+{
+    using Microsoft::Net::Netlink::NetlinkEnumerateIpv4Addresses;
+
+    SECTION("Doesn't cause a crash")
+    {
+        REQUIRE_NOTHROW(NetlinkEnumerateIpv4Addresses());
+    }
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Enable listing IP addresses to determine which are bound to the netremote-server binary.

### Technical Details

* Add helper to create a socket using the netlink-route protocol.
* Add helper function top enumerate IPv4 address on the system (Linux) using the netlink route3 library.
* Add tests for the `NetlinkEnumerateIpv4Addresses` function.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
