### PR TITLE
Add workaround for broken d-bus dependency resolution of libsystemd

### DIFF
--- a/src/linux/CMakeLists.txt
+++ b/src/linux/CMakeLists.txt
@@ -1,5 +1,11 @@
 
-find_package(sdbus-c++ CONFIG REQUIRED)
+find_package(sdbus-c++ REQUIRED)
+
+# The d-bus vcpkg port fails to export the libsystemd dependency properly via an imported target which causes the build
+# to fail. This is a workaround to fix that by finding the libsystemd dependency via pkg-config and defining a global
+# imported target.
+include(FindPkgConfig)
+pkg_check_modules(Systemd REQUIRED IMPORTED_TARGET GLOBAL libsystemd)
 
 add_subdirectory(external)
 add_subdirectory(libnl-helpers)

--- a/src/linux/server/CMakeLists.txt
+++ b/src/linux/server/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(${PROJECT_NAME}-server-linux
         logging-utils
         notstd
         plog::plog
+        SDBusCpp::sdbus-c++
         wifi-apmanager-linux
         wifi-core-linux
 )

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,6 +7,10 @@
       "name": "sdbus-cpp",
       "platform": "linux"
     },
+    {
+      "name": "libsystemd",
+      "platform": "linux"
+    },
     "grpc",
     "cli11",
     "protobuf",


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [x] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure sdbus-c++ dependency can be used.

### Technical Details

* d-bus vcpkg requires libsystemd and finds the dependency using CMake's pkg-config macros. However, the created import target is not exported with the dbus cmake config file, so the target is not available for consumers, and so the build fails since it cannot find this target.
* Fix this by replicating the pkg-config macro usage in our project and adding the libsystemd dependency explicitly to ensure our code will continue to work even after d-bus is patched with a fix.
* Add proper link target `SDBusCpp::sdbus-c++` to netremote-server Linux binary.
* Add libsystemd vcpkg dependency.

### Test Results

* Verified clean rebuild with deleted CMake and vcpkg caches.

### Reviewer Focus

Describe what reviewers should focus on. Eg.

> The event loop could cause the service to exit early if it does not manage object lifetime correctly. Please pay careful attention to how this is achieved in the new event loop.

### Future Work

Describe any future work that is required as a result of this change. Eg.

>
> - Long-running stress testing needs to be completed.
> - The old event loop code needs to be removed once stress-testing with libevent has been completed.
>

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
