### PR TITLE
Install netplan config files to proper location

### DIFF
--- a/config/linux/network/cloud/CMakeLists.txt
+++ b/config/linux/network/cloud/CMakeLists.txt
@@ -4,4 +4,13 @@ install(
         ${CMAKE_CURRENT_LIST_DIR}/99-disable-network-config.cfg
         DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/cloud/cloud.cfg.d
         COMPONENT config-netplan
+        CONFIGURATIONS Debug
+)
+
+install(
+    FILES
+        ${CMAKE_CURRENT_LIST_DIR}/99-disable-network-config.cfg
+        DESTINATION /${CMAKE_INSTALL_SYSCONFDIR}/cloud/cloud.cfg.d
+        COMPONENT config-netplan
+        CONFIGURATIONS Release RelWithDebInfo MinSizeRel
 )

--- a/config/linux/network/netplan/CMakeLists.txt
+++ b/config/linux/network/netplan/CMakeLists.txt
@@ -3,5 +3,16 @@ install(
     FILES
         ${CMAKE_CURRENT_LIST_DIR}/10-network-netremote-all-template.yaml
         DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/netplan
+        PERMISSIONS OWNER_READ OWNER_WRITE
         COMPONENT config-netplan
+        CONFIGURATIONS Debug
+)
+
+install(
+    FILES
+        ${CMAKE_CURRENT_LIST_DIR}/10-network-netremote-all-template.yaml
+        DESTINATION /${CMAKE_INSTALL_SYSCONFDIR}/netplan
+        PERMISSIONS OWNER_READ OWNER_WRITE
+        COMPONENT config-netplan
+        CONFIGURATIONS Release RelWithDebInfo MinSizeRel
 )


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure ubuntu cloud init is disabled to prevent conflicts with netplan configuration.

### Technical Details

Ubuntu's cloud configuration applies some netplan configuration which eventually conflicts with the netplan configuration we generate. The solution is to disable cloud config, which is accomplished using rules in the file `99-disable-network-config.cfg` which must be installed to `/etc/cloud/cloud.cfg.d`/. Since our install prefix is `/usr/local`, this ended up getting installed to `/usr/local/etc/cloud/cloud.cfg.d` instead, which made it ineffective.

* Install `99-disable-network-config.cfg` to filesystem root `/etc/cloud/cloud.cfg.d` for release configurations.
* Install netplan template `10-network-netremote-all-template.yaml` to filesystem root `/etc/netplan` for release configurations.
* Set correct permissions (`0600`) on `10-network-netremote-all-template.yaml`

### Test Results

* Installed the netremote-config-netplan*.deb package on a machine with a single ethernet interface and verified that a bridge was created for it and network connectivity was established.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
