### PR TITLE
Add PMF setting to default hostapd.conf

### DIFF
--- a/src/linux/external/hostap/systemd/hostapd-example.conf.in
+++ b/src/linux/external/hostap/systemd/hostapd-example.conf.in
@@ -9,4 +9,5 @@ wpa=2
 wpa_passphrase=password
 wpa_key_mgmt=SAE
 rsn_pairwise=CCMP
+ieee80211w=2
 bridge=brgateway0


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

Ensure the default hostapd.conf configuration that is installed with the `netremote-hostapd` package is valid.

### Technical Details

* Add protected management frames (PMF) setting (`ieee80211w`) with value `2` (required) to default `hostapd-example.conf.in` file.

### Test Results

* Re-installed package, cleared Windows AP profile setting, then validated connection was successful.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
