### PR TITLE
Add missing change for hostapd config file truncation

### DIFF
--- a/tests/unit/linux/wpa-controller/detail/WpaDaemonManager.cxx
+++ b/tests/unit/linux/wpa-controller/detail/WpaDaemonManager.cxx
@@ -73,14 +73,8 @@ WpaDaemonManager::CreateAndWriteDefaultConfigurationFile(Wpa::WpaType wpaType, s
     const auto daemon = Wpa::GetWpaTypeDaemonBinaryName(wpaType);
     const auto daemonConfigurationFilePath = std::filesystem::temp_directory_path() / std::format("{}.conf", daemon);
 
-    // Create the configuration file.
-    const auto daemonConfigurationFileStatus = std::filesystem::status(daemonConfigurationFilePath);
-    if (std::filesystem::exists(daemonConfigurationFileStatus)) {
-        return daemonConfigurationFilePath;
-    }
-
-    // Write default configuration file contents.
-    std::ofstream daemonConfigurationFile{ daemonConfigurationFilePath };
+    // Create and write default configuration file contents.
+    std::ofstream daemonConfigurationFile{ daemonConfigurationFilePath, std::ios::out | std::ios::trunc };
     detail::WriteDefaultConfigurationFileContents(wpaType, interfaceName, daemonConfigurationFile);
     daemonConfigurationFile.flush();
     daemonConfigurationFile.close();


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure CMake configurations can be switched from dev to release and vice versa.

### Technical Details

* Truncate the temp generated configuration file to ensure old control socket setting is re-applied.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
