### PR TITLE
Add system support for mDNS

### DIFF
--- a/packaging/deb/CMakeLists.txt
+++ b/packaging/deb/CMakeLists.txt
@@ -20,5 +20,6 @@ set(CPACK_COMPONENTS_ALL
 )
 
 add_subdirectory(config-netplan)
+add_subdirectory(server)
 
 include(CPack)

--- a/packaging/deb/server/CMakeLists.txt
+++ b/packaging/deb/server/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 set(CPACK_DEBIAN_SERVER_PACKAGE_CONTROL_EXTRA 
     "${CMAKE_CURRENT_LIST_DIR}/scripts/config"
+    "${CMAKE_CURRENT_LIST_DIR}/scripts/confnetdiscovery"
     "${CMAKE_CURRENT_LIST_DIR}/scripts/postinst"
     "${CMAKE_CURRENT_LIST_DIR}/scripts/postrm"
     "${CMAKE_CURRENT_LIST_DIR}/scripts/templates" 

--- a/packaging/deb/server/CMakeLists.txt
+++ b/packaging/deb/server/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+set(CPACK_DEBIAN_SERVER_PACKAGE_CONTROL_EXTRA 
+    "${CMAKE_CURRENT_LIST_DIR}/scripts/config"
+    "${CMAKE_CURRENT_LIST_DIR}/scripts/postinst"
+    "${CMAKE_CURRENT_LIST_DIR}/scripts/postrm"
+    "${CMAKE_CURRENT_LIST_DIR}/scripts/templates" 
+    PARENT_SCOPE
+)

--- a/packaging/deb/server/scripts/config
+++ b/packaging/deb/server/scripts/config
@@ -1,0 +1,25 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+# Uncomment the below lines to help debug script execution.
+# set -x
+# readonly DEBCONF_DEBUG=developer
+# export DEBCONF_DEBUG
+
+# Include helper libraries.
+. /usr/share/debconf/confmodule
+
+# shellcheck source=./confnetdiscovery
+. "$(dirname "${0}")"/netremote-server.confnetdiscovery
+
+# Main script execution entrypoint.
+#
+# Arguments:
+#   Must be those passed to the script (ie. "$@")
+#
+function main() {
+    network_service_discovery_configure_interactive
+}
+
+main "$@"

--- a/packaging/deb/server/scripts/confnetdiscovery
+++ b/packaging/deb/server/scripts/confnetdiscovery
@@ -55,6 +55,8 @@ function systemd_create_network_mdns_dropin_file() {
         mkdir -p "${basedir}/${component_dir}"
     fi
 
+    echo -n "Creating systemd network drop-in file ${filepath} to enable mDNS on ${component_name}..."
+
 	# The following line specifies a "here document". The <<- operator is used instead of << which ignores leading tabs,
 	# as opposed to the typical << operator which preserves tabs. Conseauently, the lines of content below are indented
 	# with tabs instead of spaces, and these must be preserved for the file content to be written without tabs.
@@ -63,6 +65,8 @@ function systemd_create_network_mdns_dropin_file() {
 	# Enable multicast DNS (mDNS) to allow discovery of netremote-server instances on the network.
 	MulticastDNS=yes
 	EOF
+
+    echo "done"
 }
 
 # Enable multicast DNS (mDNS) on the specified network interface.
@@ -82,7 +86,6 @@ function mdns_enable_on_interface() {
     readonly component_name="${interface}"
     readonly filename="${SYSTEMD_NETWORK_DROPIN_MDNS_CONF_FILE_NAME}"
 
-    echo "Creating drop-in file to enable mDNS on interface ${interface}"
     systemd_create_network_mdns_dropin_file "${dropin_file_dir_base}" "${priority}" "${filename}" "${component_name}"
 }
 

--- a/packaging/deb/server/scripts/confnetdiscovery
+++ b/packaging/deb/server/scripts/confnetdiscovery
@@ -1,0 +1,149 @@
+# shellcheck shell=bash
+
+# Include debconf shell utility library
+. /usr/share/debconf/confmodule
+
+# Define and initialize constants.
+readonly SYSTEMD_NETWORK_DROPIN_DIR_BASE_DEFAULT=/etc/systemd/network
+readonly SYSTEMD_NETOWRK_DROPIN_DIR_INSTANCE_SUFFIX=.network.d
+
+readonly SYSTEMD_NETWORK_DROPIN_MDNS_CONF_FILE_NAME=enable-mdns
+readonly SYSTEMD_NETWORK_DROPIN_MDNS_CONF_FILE_PRIORITY_DEFAULT=10
+
+readonly QUESTION_NETWORK_CONFIGURE_MDNS_METHOD=netremote/network/mdns-configure-interfaces-method
+readonly QUESTION_NETWORK_CONFIGURE_MDNS_INTERFACES_MANUALLY=netremote/network/mdns-configure-interfaces-manually
+readonly QUESTION_NETWORK_CONFIGURE_MDNS_INTERFACES_MANUALLY_INTERFACES_VAR=network-mdns-interfaces-choices
+
+# Enumerate all network interfaces on the system, excluding the loopback interface.
+NETWORK_INTERFACES=
+NETWORK_INTERFACES=$(find -L /sys/class/net -mindepth 1 -maxdepth 1 -type d -not -name "lo*" -printf "%f " | xargs -n1 | sort | xargs)
+readonly NETWORK_INTERFACES
+
+QUESTION_NETWORK_CONFIGURE_MDNS_INTERFACES_MANUALLY_CHOICES=
+QUESTION_NETWORK_CONFIGURE_MDNS_INTERFACES_MANUALLY_CHOICES=$(echo "${NETWORK_INTERFACES// /, }" | head -c-1)
+readonly QUESTION_NETWORK_CONFIGURE_MDNS_INTERFACES_MANUALLY_CHOICES
+
+# Globals to be defined later.
+NETWORK_CONFIGURE_MDNS_METHOD=
+NETWORK_INTERFACES_SELECTED_FOR_MDNS=
+
+# Create a systemd network drop-in file
+function systemd_create_network_mdns_dropin_file() {
+    local basedir
+    local priority
+    local component_name
+    local component_dir
+    local filename
+    local filepath
+
+    readonly basedir="$1"
+    readonly priority="$2"
+    readonly filename="$3"
+    readonly component_name="$4"
+    readonly component_dir="${priority}-${component_name}${SYSTEMD_NETOWRK_DROPIN_DIR_INSTANCE_SUFFIX}"
+    readonly filepath="${basedir}/${component_dir}/${filename}.conf"
+
+    # Create the destination directory if it does not exist.
+    if [[ ! -d "${basedir}/${component_dir}" ]]; then
+        mkdir -p "${basedir}/${component_dir}"
+    fi
+
+	# The following line specifies a "here document". The <<- operator is used instead of << which ignores leading tabs,
+	# as opposed to the typical << operator which preserves tabs. Conseauently, the lines of content below are indented
+	# with tabs instead of spaces, and these must be preserved for the file content to be written without tabs.
+	cat <<- EOF > "${filepath}"
+	[Network]
+	# Enable multicast DNS (mDNS) to allow discovery of netremote-server instances on the network.
+	MulticastDNS=yes
+	EOF
+}
+
+function mdns_enable_on_interface() {
+    local interface=$1
+    local dropin_file_dir_base
+    local priority
+    local component_name
+    local filename
+
+    readonly dropin_file_dir_base="${SYSTEMD_NETWORK_DROPIN_DIR_BASE_DEFAULT}"
+    readonly priority="${SYSTEMD_NETWORK_DROPIN_MDNS_CONF_FILE_PRIORITY_DEFAULT}"
+    readonly component_name="${interface}"
+    readonly filename="${SYSTEMD_NETWORK_DROPIN_MDNS_CONF_FILE_NAME}"
+
+    echo "Creating drop-in file to enable mDNS on interface ${interface}"
+    systemd_create_network_mdns_dropin_file "${dropin_file_dir_base}" "${priority}" "${filename}" "${component_name}"
+}
+
+function mdns_configure() {
+    local interfaces="$1"
+
+    for interface in ${interfaces}; do
+        mdns_enable_on_interface "${interface}"
+    done
+}
+
+function debconf_prompt_network_configure_mdns_interfaces_manually() {
+    # Clear the question from the debconf database to force the prompt.
+    db_clear
+    db_fset "${QUESTION_NETWORK_CONFIGURE_MDNS_INTERFACES_MANUALLY}" seen false
+
+    # Prompt to select interfaces to create network bridges for.
+    db_subst "${QUESTION_NETWORK_CONFIGURE_MDNS_INTERFACES_MANUALLY}" "${QUESTION_NETWORK_CONFIGURE_MDNS_INTERFACES_MANUALLY_INTERFACES_VAR}" "${QUESTION_NETWORK_CONFIGURE_MDNS_INTERFACES_MANUALLY_CHOICES}"
+    db_input high "${QUESTION_NETWORK_CONFIGURE_MDNS_INTERFACES_MANUALLY}" || true
+    db_go || true
+
+    db_get "${QUESTION_NETWORK_CONFIGURE_MDNS_INTERFACES_MANUALLY}" || true
+    readonly network_interfaces_selected_for_mdns=${RET//\, / }
+    readonly NETWORK_INTERFACES_SELECTED_FOR_MDNS="${network_interfaces_selected_for_mdns}"
+}
+
+function mdns_configure_interfaces_select_manually() {
+    echo "Configuring mDNS for manually specified interfaces"
+    debconf_prompt_network_configure_mdns_interfaces_manually
+}
+
+function mdns_configure_interfaces_select_automatically() {
+    echo "Configuring mDNS for all interfaces"
+    readonly NETWORK_INTERFACES_SELECTED_FOR_MDNS="${NETWORK_INTERFACES}"
+}
+
+# Prompt the user to select the multicast DNS configuration option. This stores the user's choice, either "auto",
+# "manual", or "none", in the NETWORK_CONFIGURE_MDNS_METHOD global variable.
+#
+# Arguments:
+#   None
+function debconf_prompt_network_configure_mdns_method() {
+    # Clear the question from the debconf database to force the prompt.
+    db_clear
+    db_fset "${QUESTION_NETWORK_CONFIGURE_MDNS_METHOD}" seen false
+
+    db_input high "${QUESTION_NETWORK_CONFIGURE_MDNS_METHOD}" || true
+    # shellcheck disable=SC2119
+    db_go || true
+    db_get "${QUESTION_NETWORK_CONFIGURE_MDNS_METHOD}" || true
+    NETWORK_CONFIGURE_MDNS_METHOD=${RET}
+
+    export NETWORK_CONFIGURE_MDNS_METHOD
+}
+
+function network_service_discovery_configure_interactive() {
+    debconf_prompt_network_configure_mdns_method
+
+    case "${NETWORK_CONFIGURE_MDNS_METHOD}" in
+        "Automatic")
+            mdns_configure_interfaces_select_automatically
+            mdns_configure "${NETWORK_INTERFACES_SELECTED_FOR_MDNS}"
+            ;;
+        "Manual")
+            mdns_configure_interfaces_select_manually
+            ;;
+        "Skip" | *)
+            NETWORK_INTERFACES_SELECTED_FOR_MDNS=
+            echo "Not configuring mDNS"
+            ;;
+    esac
+
+    if [[ -n "${NETWORK_INTERFACES_SELECTED_FOR_MDNS}" ]]; then
+        mdns_configure "${NETWORK_INTERFACES_SELECTED_FOR_MDNS}"
+    fi
+}

--- a/packaging/deb/server/scripts/confnetdiscovery
+++ b/packaging/deb/server/scripts/confnetdiscovery
@@ -27,7 +27,14 @@ readonly QUESTION_NETWORK_CONFIGURE_MDNS_INTERFACES_MANUALLY_CHOICES
 NETWORK_CONFIGURE_MDNS_METHOD=
 NETWORK_INTERFACES_SELECTED_FOR_MDNS=
 
-# Create a systemd network drop-in file
+# Create a drop-in file for a systemd network configuration file to enable multicast DNS (mDNS) on the specified interface.
+#
+# Arguments:
+#   1: The base directory for the drop-in file.
+#   2: The priority of the drop-in file. This is used by systemd to lexicographically order drop-in files.
+#   3: The name of the drop-in file.
+#   4: The name of the component to create the drop-in file for.
+#
 function systemd_create_network_mdns_dropin_file() {
     local basedir
     local priority
@@ -58,6 +65,11 @@ function systemd_create_network_mdns_dropin_file() {
 	EOF
 }
 
+# Enable multicast DNS (mDNS) on the specified network interface.
+#
+# Arguments:
+#   1: The network interface to enable mDNS on.
+#
 function mdns_enable_on_interface() {
     local interface=$1
     local dropin_file_dir_base
@@ -74,6 +86,11 @@ function mdns_enable_on_interface() {
     systemd_create_network_mdns_dropin_file "${dropin_file_dir_base}" "${priority}" "${filename}" "${component_name}"
 }
 
+# Enable multicast DNS (mDNS) on the specified network interfaces.
+#
+# Arguments:
+#   1: A space-separated list of network interfaces to enable mDNS on.
+#
 function mdns_configure() {
     local interfaces="$1"
 
@@ -82,6 +99,12 @@ function mdns_configure() {
     done
 }
 
+# Prompt the user to select the network interfaces to configure multicast DNS (mDNS) on. This stores the user's choice
+# in the NETWORK_INTERFACES_SELECTED_FOR_MDNS global variable.
+#
+# Arguments:
+#   None
+#
 function debconf_prompt_network_configure_mdns_interfaces_manually() {
     # Clear the question from the debconf database to force the prompt.
     db_clear
@@ -97,11 +120,22 @@ function debconf_prompt_network_configure_mdns_interfaces_manually() {
     readonly NETWORK_INTERFACES_SELECTED_FOR_MDNS="${network_interfaces_selected_for_mdns}"
 }
 
+# Configure multicast DNS (mDNS) on manually selected network interfaces. This will prompt the user to select the
+# network interfaces.
+#
+# Arguments:
+#   None
+#
 function mdns_configure_interfaces_select_manually() {
     echo "Configuring mDNS for manually specified interfaces"
     debconf_prompt_network_configure_mdns_interfaces_manually
 }
 
+# Configure multicast DNS (mDNS) on all network interfaces. This will automatically select all network interfaces.
+#
+# Arguments:
+#   None
+#
 function mdns_configure_interfaces_select_automatically() {
     echo "Configuring mDNS for all interfaces"
     readonly NETWORK_INTERFACES_SELECTED_FOR_MDNS="${NETWORK_INTERFACES}"
@@ -126,6 +160,12 @@ function debconf_prompt_network_configure_mdns_method() {
     export NETWORK_CONFIGURE_MDNS_METHOD
 }
 
+# Configure multicast DNS (mDNS) on the network interfaces. This will prompt the user to select the configuration
+# method.
+#
+# Arguments:
+#   None
+# 
 function network_service_discovery_configure_interactive() {
     debconf_prompt_network_configure_mdns_method
 

--- a/packaging/deb/server/scripts/confnetdiscovery
+++ b/packaging/deb/server/scripts/confnetdiscovery
@@ -100,6 +100,8 @@ function mdns_configure() {
     for interface in ${interfaces}; do
         mdns_enable_on_interface "${interface}"
     done
+
+    systemctl restart systemd-resolved.service
 }
 
 # Prompt the user to select the network interfaces to configure multicast DNS (mDNS) on. This stores the user's choice

--- a/packaging/deb/server/scripts/postinst
+++ b/packaging/deb/server/scripts/postinst
@@ -1,0 +1,23 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+# Uncomment the below lines to help debug script execution.
+# set -x
+# readonly DEBCONF_DEBUG=developer
+# export DEBCONF_DEBUG
+
+# Include helper libraries.
+. /usr/share/debconf/confmodule
+
+# Main script execution entrypoint.
+#
+# Arguments:
+#   Must be those passed to the script (ie. "$@")
+#
+function main() {
+    :;
+}
+
+main "$@"
+

--- a/packaging/deb/server/scripts/postrm
+++ b/packaging/deb/server/scripts/postrm
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+# Uncomment the below lines to help debug script execution.
+# set -x
+# readonly DEBCONF_DEBUG=developer
+# export DEBCONF_DEBUG
+
+# Include debconf shell utility library
+. /usr/share/debconf/confmodule

--- a/packaging/deb/server/scripts/templates
+++ b/packaging/deb/server/scripts/templates
@@ -1,0 +1,19 @@
+
+Template: netremote/network/mdns-configure-interfaces-method
+Type: select
+Default: Automatic
+Choices: Automatic, Manual, Skip
+Description: How should multicast DNS (mDNS) be configured?
+ Multicast DNS (mDNS) is a protocol that allows devices on a local network to discover services running on other devices. mDNS is used by netremote to allow clients to discover netremote servers on the network. Which configuration mode should be used to configure multicast DNS (mDNS)? 
+ .
+  Automatic: Automatically enable mDNS on all valid interfaces.
+  Manual: Manually select the interfaces on which to enable mDNS.
+  Skip: Skip enabling mDNS on any interfaces.
+ If 'Skip' is selected, you must manually enable mDNS on at least one (1) interface for netremote service discovery to work.
+
+Template: netremote/network/mdns-configure-interfaces-manually
+Type: multiselect
+Default: ${network-mdns-interfaces-choices}
+Choices: ${network-mdns-interfaces-choices}
+Description: Select the network interfaces for which multicast DNS (mDNS) will be enabled:
+ For each network interface selected below, a systemd network drop-in file will be created under /usr/lib/system/network that enables multicast DNS (mDNS). At least one (1) network interface must have mDNS enabled to allow netremote servers to be discovered on the network.

--- a/packaging/deb/server/scripts/test-config-server-discovery.sh
+++ b/packaging/deb/server/scripts/test-config-server-discovery.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+# Uncomment the below lines to help debug script execution.
+set -x
+readonly DEBCONF_DEBUG=developer
+export DEBCONF_DEBUG
+
+# Include helper libraries.
+. /usr/share/debconf/confmodule
+
+# shellcheck source=./confnetdiscovery
+. confnetdiscovery
+
+# Main script execution entrypoint.
+#
+# Arguments:
+#   Must be those passed to the script (ie. "$@")
+#
+function main() {
+    db_x_loadtemplatefile ./templates
+    network_service_discovery_configure_interactive
+}
+
+main "$@"


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Lay more groundwork for configuring netremote service discovery using multicast DNS (mDNS). Specifically, ensure the server is capable of advertising itself using mDNS by effecting the system network configuration required.

### Technical Details

* Add deb packaging scripts to run on installation (config), post-configuration, and post-removal.
* Add config packaging script which provides interactive menu prompts to configure mDNS either automatically (on all interfaces), or manually, allow the user to select the interfaces to enable mDNS for.
* Add helper scripts to enable mDNS on a specific interface. 

### Test Results

* All unit tests pass.
* Validated `Automatic` and `Manual` configuration methods produce expected system network drop-in files at `/usr/lib/systemd/network/*.network.d`.
* Validated `Skip` configuration method does nothing.

![netremote-server-config-mdns-2](https://github.com/microsoft/netremote/assets/2082148/dc1013aa-58c6-443a-a57e-09f7eda0b192)

### Reviewer Focus

* None

### Future Work

* `systemd-resolved` requires that mDNS is enabled globally for any of the per interface settings to take effect. The configuration scripts must be updated to enable this setting. I could not find a way to do this with the existing cli tools like `resolvectl`, so this is left for another PR.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
