### PR TITLE
Enable mDNS on each selected interface 

### DIFF
--- a/packaging/deb/server/scripts/confnetdiscovery
+++ b/packaging/deb/server/scripts/confnetdiscovery
@@ -99,6 +99,7 @@ function mdns_configure() {
 
     for interface in ${interfaces}; do
         mdns_enable_on_interface "${interface}"
+        resolvectl mdns "${interface}" yes
     done
 
     systemctl restart systemd-resolved.service
@@ -177,7 +178,6 @@ function network_service_discovery_configure_interactive() {
     case "${NETWORK_CONFIGURE_MDNS_METHOD}" in
         "Automatic")
             mdns_configure_interfaces_select_automatically
-            mdns_configure "${NETWORK_INTERFACES_SELECTED_FOR_MDNS}"
             ;;
         "Manual")
             mdns_configure_interfaces_select_manually

--- a/packaging/deb/server/scripts/templates
+++ b/packaging/deb/server/scripts/templates
@@ -9,6 +9,7 @@ Description: How should multicast DNS (mDNS) be configured?
   Automatic: Automatically enable mDNS on all valid interfaces.
   Manual: Manually select the interfaces on which to enable mDNS.
   Skip: Skip enabling mDNS on any interfaces.
+ .
  If 'Skip' is selected, you must manually enable mDNS on at least one (1) interface for netremote service discovery to work.
 
 Template: netremote/network/mdns-configure-interfaces-manually


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure mDNS is actually enabled on each selected interface; PR #266 missed the commit that added this.

### Technical Details

* Remove duplicate call to `mdns_configure`.
* Invoke `resolvectl mdns <interface> yes`
* Add newline in mDNS configuration prompt template.

### Test Results

* Tests from prior PR were actually performed with this version of the code.

### Reviewer Focus

* None

### Future Work

* Global mDNS setting still needs to be configured.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
