### PR TITLE
Improve internal AP management 

### DIFF
--- a/src/common/wifi/apmanager/AccessPointDiscoveryAgent.cxx
+++ b/src/common/wifi/apmanager/AccessPointDiscoveryAgent.cxx
@@ -91,5 +91,6 @@ AccessPointDiscoveryAgent::Stop()
 std::future<std::vector<std::shared_ptr<IAccessPoint>>>
 AccessPointDiscoveryAgent::ProbeAsync()
 {
+    LOGI << "Access point probe initiated";
     return m_operations->ProbeAsync();
 }

--- a/src/common/wifi/apmanager/AccessPointManager.cxx
+++ b/src/common/wifi/apmanager/AccessPointManager.cxx
@@ -41,6 +41,14 @@ AccessPointManager::AddAccessPoint(std::shared_ptr<IAccessPoint> accessPoint)
     const auto interfaceName{ accessPoint->GetInterfaceName() };
     LOGI << std::format("Attempting to add access point {} to manager", interfaceName);
 
+    {
+        auto accessPointController = accessPoint->CreateController();
+        if (!accessPointController) {
+            LOGW << std::format("Access point {} not added (not controllable)", interfaceName);
+            return;
+        }
+    }
+
     const auto accessPointsLock = std::scoped_lock{ m_accessPointGate };
     const auto accessPointExists = std::ranges::any_of(m_accessPoints, [&](const auto& accessPointExisting) {
         return (accessPointExisting->GetInterfaceName() == interfaceName);

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
@@ -38,8 +38,8 @@ struct AccessPoint :
      *
      * @return std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController>
      */
-    virtual std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController>
-    CreateController() override;
+    std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController>
+    CreateController() override final;
 
 private:
     const std::string m_interfaceName;

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -87,6 +87,13 @@ AccessPointControllerLinux::GetOperationalState(AccessPointOperationalState& ope
     AccessPointOperationStatus status{ GetInterfaceName() };
     const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
 
+    // If there is no active hostapd daemon, the operational state is disabled, so status is not needed.
+    if (!m_hostapd.IsActive()) {
+        operationalState = AccessPointOperationalState::Disabled;
+        status.Code = AccessPointOperationStatusCode::Succeeded;
+        return status;
+    }
+
     try {
         auto hostapdStatus = m_hostapd.GetStatus();
         operationalState = (hostapdStatus.State == Wpa::HostapdInterfaceState::Enabled)

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include <Wpa/Hostapd.hxx>
 #include <Wpa/IHostapd.hxx>
 #include <Wpa/ProtocolHostapd.hxx>
 #include <magic_enum.hpp>
@@ -32,6 +33,7 @@ using namespace Microsoft::Net::Wifi;
 
 using Microsoft::Net::Netlink::Nl80211::Nl80211Wiphy;
 using Wpa::EnforceConfigurationChange;
+using Wpa::Hostapd;
 using Wpa::HostapdException;
 
 AccessPointControllerLinux::AccessPointControllerLinux(std::string_view interfaceName) :
@@ -430,5 +432,9 @@ AccessPointControllerLinux::SetSsid(std::string_view ssid) noexcept
 std::unique_ptr<IAccessPointController>
 AccessPointControllerLinuxFactory::Create(std::string_view interfaceName)
 {
+    if (!Hostapd::IsManagingInterface(interfaceName)) {
+        return nullptr;
+    }
+
     return std::make_unique<AccessPointControllerLinux>(interfaceName);
 }

--- a/src/linux/wifi/core/AccessPointLinux.cxx
+++ b/src/linux/wifi/core/AccessPointLinux.cxx
@@ -22,12 +22,6 @@ AccessPointLinux::AccessPointLinux(std::string_view interfaceName, std::shared_p
 {
 }
 
-std::unique_ptr<IAccessPointController>
-AccessPointLinux::CreateController()
-{
-    return std::make_unique<AccessPointControllerLinux>(GetInterfaceName());
-}
-
 std::shared_ptr<IAccessPoint>
 AccessPointFactoryLinux::Create(std::string_view interfaceName)
 {

--- a/src/linux/wifi/core/AccessPointLinux.cxx
+++ b/src/linux/wifi/core/AccessPointLinux.cxx
@@ -16,7 +16,7 @@ using Microsoft::Net::Netlink::Nl80211::Nl80211Interface;
 
 using namespace Microsoft::Net::Wifi;
 
-AccessPointLinux::AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Microsoft::Net::Netlink::Nl80211::Nl80211Interface nl80211Interface) :
+AccessPointLinux::AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Nl80211Interface nl80211Interface) :
     AccessPoint(interfaceName, std::move(accessPointControllerFactory)),
     m_nl80211Interface{ std::move(nl80211Interface) }
 {

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointLinux.hxx
@@ -28,14 +28,6 @@ struct AccessPointLinux :
      */
     AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Microsoft::Net::Netlink::Nl80211::Nl80211Interface nl80211Interface);
 
-    /**
-     * @brief Create a IAccessPointController object of type AccessPointControllerLinux.
-     * 
-     * @return std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController> 
-     */
-    std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController>
-    CreateController() override;
-
 private:
     Microsoft::Net::Netlink::Nl80211::Nl80211Interface m_nl80211Interface;
 };

--- a/src/linux/wpa-controller/CMakeLists.txt
+++ b/src/linux/wpa-controller/CMakeLists.txt
@@ -16,11 +16,13 @@ target_sources(wpa-controller
         WpaCommandSet.cxx
         WpaCommandStatus.cxx
         WpaController.cxx
+        WpaControlSocket.cxx
+        WpaControlSocketConnection.cxx
         WpaKeyValuePair.cxx
+        WpaParsingUtilities.cxx
+        WpaParsingUtilities.hxx
         WpaResponse.cxx
         WpaResponseParser.cxx
-        WpaParsingUtilities.hxx
-        WpaParsingUtilities.cxx
     PUBLIC
     FILE_SET HEADERS
     BASE_DIRS ${WPA_CONTROLLER_PUBLIC_INCLUDE}
@@ -35,6 +37,8 @@ target_sources(wpa-controller
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaCommandSet.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaCommandStatus.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaController.hxx
+        ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaControlSocket.hxx
+        ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaControlSocketConnection.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaCore.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaKeyValuePair.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaResponse.hxx

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -129,6 +129,12 @@ Hostapd::SetProperty(std::string_view propertyName, std::string_view propertyVal
     }
 }
 
+bool
+Hostapd::IsActive() const noexcept
+{
+    return m_controller.IsValid();
+}
+
 void
 Hostapd::Enable()
 {

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -27,7 +27,7 @@ using namespace Wpa;
 
 /* static */
 bool
-Hostapd::IsManagingInterface(std::string_view interfaceName)
+Hostapd::IsManagingInterface(std::string_view interfaceName) noexcept
 {
     return WpaControlSocket::Exists(interfaceName, WpaType::Hostapd);
 }

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -15,6 +15,7 @@
 #include <Wpa/WpaCommandGet.hxx>
 #include <Wpa/WpaCommandSet.hxx>
 #include <Wpa/WpaCommandStatus.hxx>
+#include <Wpa/WpaControlSocket.hxx>
 #include <Wpa/WpaCore.hxx>
 #include <Wpa/WpaResponseStatus.hxx>
 #include <magic_enum.hpp>
@@ -23,6 +24,13 @@
 #include <strings/StringHelpers.hxx>
 
 using namespace Wpa;
+
+/* static */
+bool
+Hostapd::IsManagingInterface(std::string_view interfaceName)
+{
+    return WpaControlSocket::Exists(interfaceName, WpaType::Hostapd);
+}
 
 Hostapd::Hostapd(std::string_view interfaceName) :
     m_interface(interfaceName),

--- a/src/linux/wpa-controller/WpaControlSocket.cxx
+++ b/src/linux/wpa-controller/WpaControlSocket.cxx
@@ -1,0 +1,19 @@
+
+#include <filesystem>
+#include <string_view>
+
+#include <Wpa/WpaControlSocket.hxx>
+#include <Wpa/WpaControlSocketConnection.hxx>
+
+using namespace Wpa;
+
+/* static */
+bool
+WpaControlSocket::IsPathValidForInterface(std::filesystem::path controlSocketPath, std::string_view interfaceName)
+{
+    // Attempt to create a control socket connection to the specified path and interface. If it succeeds, the path is
+    // valid. There's no real way around this without trying to connect to the control socket since calling open() on it
+    // will fail even if the socket is valid and accessible.
+    const auto wpaControlSocketConnection = WpaControlSocketConnection::TryCreate(std::move(controlSocketPath), interfaceName);
+    return wpaControlSocketConnection != nullptr;
+}

--- a/src/linux/wpa-controller/WpaControlSocket.cxx
+++ b/src/linux/wpa-controller/WpaControlSocket.cxx
@@ -1,6 +1,7 @@
 
 #include <filesystem>
 #include <string_view>
+#include <utility>
 
 #include <Wpa/WpaControlSocket.hxx>
 #include <Wpa/WpaControlSocketConnection.hxx>
@@ -9,11 +10,18 @@ using namespace Wpa;
 
 /* static */
 bool
-WpaControlSocket::IsPathValidForInterface(std::filesystem::path controlSocketPath, std::string_view interfaceName)
+WpaControlSocket::Exists(std::string_view interfaceName, std::filesystem::path controlSocketPath)
 {
     // Attempt to create a control socket connection to the specified path and interface. If it succeeds, the path is
     // valid. There's no real way around this without trying to connect to the control socket since calling open() on it
     // will fail even if the socket is valid and accessible.
-    const auto wpaControlSocketConnection = WpaControlSocketConnection::TryCreate(std::move(controlSocketPath), interfaceName);
+    const auto wpaControlSocketConnection = WpaControlSocketConnection::TryCreate(interfaceName, std::move(controlSocketPath));
     return wpaControlSocketConnection != nullptr;
+}
+
+/* static */
+bool
+WpaControlSocket::Exists(std::string_view interfaceName, WpaType wpaType)
+{
+    return Exists(interfaceName, DefaultPath(wpaType));
 }

--- a/src/linux/wpa-controller/WpaControlSocket.cxx
+++ b/src/linux/wpa-controller/WpaControlSocket.cxx
@@ -10,7 +10,7 @@ using namespace Wpa;
 
 /* static */
 bool
-WpaControlSocket::Exists(std::string_view interfaceName, std::filesystem::path controlSocketPath)
+WpaControlSocket::Exists(std::string_view interfaceName, std::filesystem::path controlSocketPath) noexcept
 {
     // Attempt to create a control socket connection to the specified path and interface. If it succeeds, the path is
     // valid. There's no real way around this without trying to connect to the control socket since calling open() on it
@@ -21,7 +21,7 @@ WpaControlSocket::Exists(std::string_view interfaceName, std::filesystem::path c
 
 /* static */
 bool
-WpaControlSocket::Exists(std::string_view interfaceName, WpaType wpaType)
+WpaControlSocket::Exists(std::string_view interfaceName, WpaType wpaType) noexcept
 {
     return Exists(interfaceName, DefaultPath(wpaType));
 }

--- a/src/linux/wpa-controller/WpaControlSocketConnection.cxx
+++ b/src/linux/wpa-controller/WpaControlSocketConnection.cxx
@@ -5,6 +5,7 @@
 #include <notstd/Memory.hxx>
 #include <wpa_ctrl.h>
 
+#include <Wpa/WpaControlSocket.hxx>
 #include <Wpa/WpaControlSocketConnection.hxx>
 
 using namespace Wpa;
@@ -14,16 +15,15 @@ WpaControlSocketConnection::~WpaControlSocketConnection()
     Disconnect();
 }
 
-WpaControlSocketConnection::WpaControlSocketConnection(std::filesystem::path controlSocketPathDir, std::string_view interfaceName) :
+WpaControlSocketConnection::WpaControlSocketConnection(std::string_view interfaceName, std::filesystem::path controlSocketPathDir) :
     m_controlSocketPath(std::move(controlSocketPathDir) / interfaceName)
 {
 }
 
-/* static */
 std::unique_ptr<WpaControlSocketConnection>
-WpaControlSocketConnection::TryCreate(std::filesystem::path controlSocketPathDir, std::string_view interfaceName)
+WpaControlSocketConnection::TryCreate(std::string_view interfaceName, std::filesystem::path controlSocketPathDir)
 {
-    auto controlSocketConnection = std::make_unique<notstd::enable_make_protected<WpaControlSocketConnection>>(std::move(controlSocketPathDir), interfaceName);
+    auto controlSocketConnection = std::make_unique<notstd::enable_make_protected<WpaControlSocketConnection>>(interfaceName, std::move(controlSocketPathDir));
     if (!controlSocketConnection->Connect()) [[unlikely]] {
         return nullptr;
     }

--- a/src/linux/wpa-controller/WpaControlSocketConnection.cxx
+++ b/src/linux/wpa-controller/WpaControlSocketConnection.cxx
@@ -1,0 +1,65 @@
+
+#include <filesystem>
+#include <memory>
+
+#include <notstd/Memory.hxx>
+#include <wpa_ctrl.h>
+
+#include <Wpa/WpaControlSocketConnection.hxx>
+
+using namespace Wpa;
+
+WpaControlSocketConnection::~WpaControlSocketConnection()
+{
+    Disconnect();
+}
+
+WpaControlSocketConnection::WpaControlSocketConnection(std::filesystem::path controlSocketPathDir, std::string_view interfaceName) :
+    m_controlSocketPath(std::move(controlSocketPathDir) / interfaceName)
+{
+}
+
+/* static */
+std::unique_ptr<WpaControlSocketConnection>
+WpaControlSocketConnection::TryCreate(std::filesystem::path controlSocketPathDir, std::string_view interfaceName)
+{
+    auto controlSocketConnection = std::make_unique<notstd::enable_make_protected<WpaControlSocketConnection>>(std::move(controlSocketPathDir), interfaceName);
+    if (!controlSocketConnection->Connect()) [[unlikely]] {
+        return nullptr;
+    }
+
+    return controlSocketConnection;
+}
+
+WpaControlSocketConnection::operator struct wpa_ctrl *() const noexcept
+{
+    return m_controlSocket;
+}
+
+bool
+WpaControlSocketConnection::Connect(bool forceReconnect) noexcept
+{
+    if (m_controlSocket != nullptr) {
+        if (!forceReconnect) {
+            return true;
+        }
+
+        Disconnect();
+    }
+
+    auto controlSocket = wpa_ctrl_open(m_controlSocketPath.c_str());
+    if (controlSocket != nullptr) {
+        m_controlSocket = controlSocket;
+    }
+
+    return (m_controlSocket != nullptr);
+}
+
+void
+WpaControlSocketConnection::Disconnect() noexcept
+{
+    if (m_controlSocket != nullptr) [[likely]] {
+        wpa_ctrl_close(m_controlSocket);
+        m_controlSocket = nullptr;
+    }
+}

--- a/src/linux/wpa-controller/WpaControlSocketConnection.cxx
+++ b/src/linux/wpa-controller/WpaControlSocketConnection.cxx
@@ -37,10 +37,10 @@ WpaControlSocketConnection::operator struct wpa_ctrl *() const noexcept
 }
 
 bool
-WpaControlSocketConnection::Connect(bool forceReconnect) noexcept
+WpaControlSocketConnection::Connect(ExistingConnectionPolicy existingConnectionPolicy) noexcept
 {
     if (m_controlSocket != nullptr) {
-        if (!forceReconnect) {
+        if (existingConnectionPolicy != ExistingConnectionPolicy::Reconnect) {
             return true;
         }
 

--- a/src/linux/wpa-controller/WpaController.cxx
+++ b/src/linux/wpa-controller/WpaController.cxx
@@ -12,6 +12,7 @@
 #include <wpa_ctrl.h>
 
 #include <Wpa/WpaCommand.hxx>
+#include <Wpa/WpaControlSocket.hxx>
 #include <Wpa/WpaController.hxx>
 #include <Wpa/WpaCore.hxx>
 #include <Wpa/WpaResponse.hxx>

--- a/src/linux/wpa-controller/WpaController.cxx
+++ b/src/linux/wpa-controller/WpaController.cxx
@@ -37,6 +37,12 @@ WpaController::WpaController(std::string_view interfaceName, WpaType type, std::
 {
 }
 
+bool
+WpaController::IsValid() const noexcept
+{
+    return WpaControlSocket::IsPathValidForInterface(m_controlSocketPath, m_interfaceName);
+}
+
 WpaType
 WpaController::Type() const noexcept
 {

--- a/src/linux/wpa-controller/WpaController.cxx
+++ b/src/linux/wpa-controller/WpaController.cxx
@@ -9,8 +9,6 @@
 #include <string_view>
 #include <utility>
 
-#include <wpa_ctrl.h>
-
 #include <Wpa/WpaCommand.hxx>
 #include <Wpa/WpaControlSocket.hxx>
 #include <Wpa/WpaController.hxx>
@@ -18,6 +16,7 @@
 #include <Wpa/WpaResponse.hxx>
 #include <magic_enum.hpp>
 #include <plog/Log.h>
+#include <wpa_ctrl.h>
 
 using namespace Wpa;
 
@@ -38,14 +37,6 @@ WpaController::WpaController(std::string_view interfaceName, WpaType type, std::
 {
 }
 
-WpaController::~WpaController()
-{
-    if (m_controlSocketCommand != nullptr) {
-        wpa_ctrl_close(m_controlSocketCommand);
-        m_controlSocketCommand = nullptr;
-    }
-}
-
 WpaType
 WpaController::Type() const noexcept
 {
@@ -58,45 +49,44 @@ WpaController::ControlSocketPath() const noexcept
     return m_controlSocketPath;
 }
 
-struct wpa_ctrl*
-WpaController::GetCommandControlSocket()
+WpaControlSocketConnection*
+WpaController::GetCommandControlSocketConnection()
 {
     // Check if a socket connection is already established.
     {
-        const std::shared_lock lockShared{ m_controlSocketCommandGate };
-        if (m_controlSocketCommand != nullptr) {
-            return m_controlSocketCommand;
+        const std::shared_lock lockShared{ m_controlSocketCommandConnectionGate };
+        if (m_controlSocketCommandConnection != nullptr) {
+            return m_controlSocketCommandConnection.get();
         }
     }
 
     // Check if socket was updated between releasing the shared lock and acquiring the exclusive lock.
-    const std::scoped_lock lockExclusive{ m_controlSocketCommandGate };
-    if (m_controlSocketCommand != nullptr) {
-        return m_controlSocketCommand;
+    const std::scoped_lock lockExclusive{ m_controlSocketCommandConnectionGate };
+    if (m_controlSocketCommandConnection != nullptr) {
+        return m_controlSocketCommandConnection.get();
     }
 
     // Establish a new socket connection. Continue holding the exclusive lock
     // until the connection is established to prevent multiple connections.
-    const auto controlSocketPath = m_controlSocketPath / m_interfaceName;
-    struct wpa_ctrl* controlSocket = wpa_ctrl_open(controlSocketPath.c_str());
-    if (controlSocket == nullptr) {
-        LOGE << std::format("Failed to open control socket for {} interface at {}.", m_interfaceName, controlSocketPath.c_str());
+    auto controlSocketCommandConnection = WpaControlSocketConnection::TryCreate(m_controlSocketPath, m_interfaceName);
+    if (controlSocketCommandConnection == nullptr) {
+        LOGE << std::format("Failed to establish {} control socket connection for {} interface at {}.", magic_enum::enum_name(m_type), m_interfaceName, m_controlSocketPath.c_str());
         return nullptr;
     }
 
-    LOGD << std::format("Opened {} control socket for {} interface at {}.", magic_enum::enum_name(m_type), m_interfaceName, controlSocketPath.c_str());
+    LOGD << std::format("Established {} control socket for {} interface at {}.", magic_enum::enum_name(m_type), m_interfaceName, m_controlSocketPath.c_str());
 
     // Update the member and return it.
-    m_controlSocketCommand = controlSocket;
-    return controlSocket;
+    m_controlSocketCommandConnection = std::move(controlSocketCommandConnection);
+    return m_controlSocketCommandConnection.get();
 }
 
 std::shared_ptr<WpaResponse>
 WpaController::SendCommand(const WpaCommand& command)
 {
     // Obtain a control socket connection to send the command over.
-    struct wpa_ctrl* controlSocket = GetCommandControlSocket();
-    if (controlSocket == nullptr) {
+    auto controlSocketCommandConnection = GetCommandControlSocketConnection();
+    if (controlSocketCommandConnection == nullptr) {
         LOGE << std::format("Failed to get control socket for {}.", m_interfaceName);
         return nullptr;
     }
@@ -107,7 +97,7 @@ WpaController::SendCommand(const WpaCommand& command)
 
     auto commandPayload = command.GetPayload();
     LOGD << std::format("Sending wpa command to {} interface: '{}'", m_interfaceName, commandPayload);
-    int ret = wpa_ctrl_request(controlSocket, std::data(commandPayload), std::size(commandPayload), std::data(responseBuffer), &responseSize, nullptr);
+    int ret = wpa_ctrl_request(*controlSocketCommandConnection, std::data(commandPayload), std::size(commandPayload), std::data(responseBuffer), &responseSize, nullptr);
     switch (ret) {
     case 0: {
         const std::string_view responsePayload{ std::data(responseBuffer), responseSize };

--- a/src/linux/wpa-controller/WpaController.cxx
+++ b/src/linux/wpa-controller/WpaController.cxx
@@ -40,7 +40,7 @@ WpaController::WpaController(std::string_view interfaceName, WpaType type, std::
 bool
 WpaController::IsValid() const noexcept
 {
-    return WpaControlSocket::IsPathValidForInterface(m_controlSocketPath, m_interfaceName);
+    return WpaControlSocket::Exists(m_interfaceName, m_controlSocketPath);
 }
 
 WpaType
@@ -74,7 +74,7 @@ WpaController::GetCommandControlSocketConnection()
 
     // Establish a new socket connection. Continue holding the exclusive lock
     // until the connection is established to prevent multiple connections.
-    auto controlSocketCommandConnection = WpaControlSocketConnection::TryCreate(m_controlSocketPath, m_interfaceName);
+    auto controlSocketCommandConnection = WpaControlSocketConnection::TryCreate(m_interfaceName, m_controlSocketPath);
     if (controlSocketCommandConnection == nullptr) {
         LOGE << std::format("Failed to establish {} control socket connection for {} interface at {}.", magic_enum::enum_name(m_type), m_interfaceName, m_controlSocketPath.c_str());
         return nullptr;

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -34,7 +34,7 @@ struct Hostapd :
      * @return false If hostapd is not managing the interface.
      */
     static bool
-    IsManagingInterface(std::string_view interfaceName);
+    IsManagingInterface(std::string_view interfaceName) noexcept;
 
     /**
      * @brief Determines if hostapd is active for this interface.

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -37,7 +37,7 @@ struct Hostapd :
     IsManagingInterface(std::string_view interfaceName);
 
     /**
-     * @brief Determines if hostapd is active for thios interface.
+     * @brief Determines if hostapd is active for this interface.
      *
      * @return true If a hostapd daemon is active for this interface.
      * @return false If a hostapd daemon is not active for this interface.

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -27,8 +27,18 @@ struct Hostapd :
     explicit Hostapd(std::string_view interfaceName);
 
     /**
+     * @brief Determines if the specified interface is being managed by hostapd.
+     *
+     * @param interfaceName The interface to check.
+     * @return true If hostapd is actively managing the interface.
+     * @return false If hostapd is not managing the interface.
+     */
+    static bool
+    IsManagingInterface(std::string_view interfaceName);
+
+    /**
      * @brief Determines if hostapd is active for thios interface.
-     * 
+     *
      * @return true If a hostapd daemon is active for this interface.
      * @return false If a hostapd daemon is not active for this interface.
      */
@@ -186,9 +196,9 @@ struct Hostapd :
 
     /**
      * @brief Generates a new network access server identifier. If no length is specified, a default value will be used.
-     * 
+     *
      * @param lengthRequested The requested length of the identifier. Valid values are in the range [1, 48].
-     * @return std::string 
+     * @return std::string
      */
     static std::string
     GenerateNetworkAccessServerId(std::size_t lengthRequested = Microsoft::Net::Wifi::Ieee80211FtR0KeyHolderIdLengthOctetsMaximum);

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -27,6 +27,15 @@ struct Hostapd :
     explicit Hostapd(std::string_view interfaceName);
 
     /**
+     * @brief Determines if hostapd is active for thios interface.
+     * 
+     * @return true If a hostapd daemon is active for this interface.
+     * @return false If a hostapd daemon is not active for this interface.
+     */
+    bool
+    IsActive() const noexcept;
+
+    /**
      * @brief Enables the interface for use.
      */
     void

--- a/src/linux/wpa-controller/include/Wpa/WpaControlSocket.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaControlSocket.hxx
@@ -3,7 +3,6 @@
 #define WPA_CONTROL_SOCKET_HXX
 
 #include <filesystem>
-#include <stdexcept>
 #include <string_view>
 
 #include <Wpa/ProtocolWpaConfig.hxx>
@@ -32,7 +31,7 @@ struct WpaControlSocket
      * @return constexpr auto A string containing the default control socket path.
      */
     static constexpr auto
-    DefaultPath(WpaType wpaType)
+    DefaultPath(WpaType wpaType) noexcept
     {
         switch (wpaType) {
         case WpaType::Hostapd:
@@ -40,7 +39,7 @@ struct WpaControlSocket
         case WpaType::WpaSupplicant:
             return ProtocolWpaConfig::ControlSocketPathWpaSupplicant;
         default:
-            throw std::runtime_error("Unknown WpaType");
+            return ProtocolWpaConfig::ControlSocketPathBase;
         }
     }
 
@@ -53,7 +52,7 @@ struct WpaControlSocket
      * @return false If a control socket does not exist for the specified interface.
      */
     static bool
-    Exists(std::string_view interfaceName, WpaType wpaType);
+    Exists(std::string_view interfaceName, WpaType wpaType) noexcept;
 
     /**
      * @brief Determine if a control socket exists for the specified interface and control socket path.
@@ -64,7 +63,7 @@ struct WpaControlSocket
      * @return false If a control socket does not exist for the specified interface.
      */
     static bool
-    Exists(std::string_view interfaceName, std::filesystem::path controlSocketPathDir);
+    Exists(std::string_view interfaceName, std::filesystem::path controlSocketPathDir) noexcept;
 };
 } // namespace Wpa
 

--- a/src/linux/wpa-controller/include/Wpa/WpaControlSocket.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaControlSocket.hxx
@@ -1,0 +1,60 @@
+
+#ifndef WPA_CONTROL_SOCKET_HXX
+#define WPA_CONTROL_SOCKET_HXX
+
+#include <filesystem>
+#include <stdexcept>
+#include <string_view>
+
+#include <Wpa/ProtocolWpaConfig.hxx>
+#include <Wpa/WpaCore.hxx>
+
+namespace Wpa
+{
+/**
+ * @brief Helper class for working with the wpa control socket.
+ */
+struct WpaControlSocket
+{
+    WpaControlSocket() = delete;
+
+    /**
+     * @brief Maximum WPA control interface message size, im bytes. The
+     * official wpa_cli tool uses this as an upper bound, so is used
+     * similarly here.
+     */
+    static constexpr auto MessageSizeMax = 4096;
+
+    /**
+     * @brief Get the default path for the control socket of the specified daemon.
+     *
+     * @param wpaType The wpa daemon type to get the default control socket for.
+     * @return constexpr auto A string containing the default control socket path.
+     */
+    static constexpr auto
+    DefaultPath(WpaType wpaType)
+    {
+        switch (wpaType) {
+        case WpaType::Hostapd:
+            return ProtocolWpaConfig::ControlSocketPathHostapd;
+        case WpaType::WpaSupplicant:
+            return ProtocolWpaConfig::ControlSocketPathWpaSupplicant;
+        default:
+            throw std::runtime_error("Unknown WpaType");
+        }
+    }
+
+    /**
+     * @brief Determine if the specified control socket path is valid for the specified interface.
+     * 
+     * @param controlSocketPath The control socket path to check.
+     * @param interfaceName The interface name for the control socket.
+     * @return true 
+     * @return false 
+     */
+    static bool
+    IsPathValidForInterface(std::filesystem::path controlSocketPath, std::string_view interfaceName);
+};
+} // namespace Wpa
+
+#endif // WPA_CONTROL_SOCKET_HXX

--- a/src/linux/wpa-controller/include/Wpa/WpaControlSocket.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaControlSocket.hxx
@@ -45,15 +45,26 @@ struct WpaControlSocket
     }
 
     /**
-     * @brief Determine if the specified control socket path is valid for the specified interface.
-     * 
-     * @param controlSocketPath The control socket path to check.
-     * @param interfaceName The interface name for the control socket.
-     * @return true 
-     * @return false 
+     * @brief Determine if a control socket exists for the specified interface and control socket path.
+     *
+     * @param interfaceName The interface to check.
+     * @param wpaType The type of wpa daemon to check for.
+     * @return true If a control socket exists for the specified interface.
+     * @return false If a control socket does not exist for the specified interface.
      */
     static bool
-    IsPathValidForInterface(std::filesystem::path controlSocketPath, std::string_view interfaceName);
+    Exists(std::string_view interfaceName, WpaType wpaType);
+
+    /**
+     * @brief Determine if a control socket exists for the specified interface and control socket path.
+     *
+     * @param interfaceName The interface to check.
+     * @param controlSocketPathDir The directory containing the control socket.
+     * @return true If a control socket exists for the specified interface.
+     * @return false If a control socket does not exist for the specified interface.
+     */
+    static bool
+    Exists(std::string_view interfaceName, std::filesystem::path controlSocketPathDir);
 };
 } // namespace Wpa
 

--- a/src/linux/wpa-controller/include/Wpa/WpaControlSocketConnection.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaControlSocketConnection.hxx
@@ -25,12 +25,12 @@ public:
     /**
      * @brief Attempt to make a connection to a WPA control socket for the specicied interface.
      *
-     * @param controlSocketPathDir The directory containing the control socket.
      * @param interfaceName The name of the interface to connect to.
+     * @param controlSocketPathDir The directory containing the control socket.
      * @return std::unique_ptr<WpaControlSocketConnection>
      */
     static std::unique_ptr<WpaControlSocketConnection>
-    TryCreate(std::filesystem::path controlSocketPathDir, std::string_view interfaceName);
+    TryCreate(std::string_view interfaceName, std::filesystem::path controlSocketPathDir);
 
     /**
      * @brief Attempt to make a connection to a WPA control socket for the specicied interface.
@@ -52,10 +52,10 @@ protected:
     /**
      * @brief Construct a new WpaControlSocketConnection object.
      *
-     * @param controlSocketPathDir The directory containing the control socket.
      * @param interfaceName The name of the interface to connect to.
+     * @param controlSocketPathDir The directory containing the control socket.
      */
-    WpaControlSocketConnection(std::filesystem::path controlSocketPathDir, std::string_view interfaceName);
+    WpaControlSocketConnection(std::string_view interfaceName, std::filesystem::path controlSocketPathDir);
 
 private:
     std::filesystem::path m_controlSocketPath;

--- a/src/linux/wpa-controller/include/Wpa/WpaControlSocketConnection.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaControlSocketConnection.hxx
@@ -11,6 +11,14 @@
 namespace Wpa
 {
 /**
+ * @brief Policy to use when an existing connection is detected.
+ */
+enum class ExistingConnectionPolicy {
+    Reconnect,
+    Ignore,
+};
+
+/**
  * @brief Helper class to create a connection on a WPA control socket.
  *
  * This automatically manages the resources required to connect to a WPA control socket.
@@ -35,12 +43,12 @@ public:
     /**
      * @brief Attempt to make a connection to a WPA control socket for the specicied interface.
      *
-     * @param forceReconnect Force a reconnection to the control socket if it is already connected.
+     * @param existingConnectionPolicy The policy to use when an existing connection is detected.
      * @return true The connection was successful.
      * @return false The connection was not successful.
      */
     bool
-    Connect(bool forceReconnect = false) noexcept;
+    Connect(ExistingConnectionPolicy existingConnectionPolicy = ExistingConnectionPolicy::Ignore) noexcept;
 
     /**
      * @brief Disconnect from the control socket.

--- a/src/linux/wpa-controller/include/Wpa/WpaControlSocketConnection.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaControlSocketConnection.hxx
@@ -1,0 +1,66 @@
+
+#ifndef WPA_CONTROL_SOCKET_CONNECTION_HXX
+#define WPA_CONTROL_SOCKET_CONNECTION_HXX
+
+#include <filesystem>
+#include <memory>
+#include <string_view>
+
+#include <wpa_ctrl.h>
+
+namespace Wpa
+{
+/**
+ * @brief Helper class to create a connection on a WPA control socket.
+ *
+ * This automatically manages the resources required to connect to a WPA control socket.
+ */
+class WpaControlSocketConnection
+{
+public:
+    ~WpaControlSocketConnection();
+
+    operator struct wpa_ctrl *() const noexcept; // NOLINT(hicpp-explicit-conversions)
+
+    /**
+     * @brief Attempt to make a connection to a WPA control socket for the specicied interface.
+     *
+     * @param controlSocketPathDir The directory containing the control socket.
+     * @param interfaceName The name of the interface to connect to.
+     * @return std::unique_ptr<WpaControlSocketConnection>
+     */
+    static std::unique_ptr<WpaControlSocketConnection>
+    TryCreate(std::filesystem::path controlSocketPathDir, std::string_view interfaceName);
+
+    /**
+     * @brief Attempt to make a connection to a WPA control socket for the specicied interface.
+     *
+     * @param forceReconnect Force a reconnection to the control socket if it is already connected.
+     * @return true The connection was successful.
+     * @return false The connection was not successful.
+     */
+    bool
+    Connect(bool forceReconnect = false) noexcept;
+
+    /**
+     * @brief Disconnect from the control socket.
+     */
+    void
+    Disconnect() noexcept;
+
+protected:
+    /**
+     * @brief Construct a new WpaControlSocketConnection object.
+     *
+     * @param controlSocketPathDir The directory containing the control socket.
+     * @param interfaceName The name of the interface to connect to.
+     */
+    WpaControlSocketConnection(std::filesystem::path controlSocketPathDir, std::string_view interfaceName);
+
+private:
+    std::filesystem::path m_controlSocketPath;
+    struct wpa_ctrl* m_controlSocket{ nullptr };
+};
+} // namespace Wpa
+
+#endif // WPA_CONTROL_SOCKET_CONNECTION_HXX

--- a/src/linux/wpa-controller/include/Wpa/WpaController.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaController.hxx
@@ -111,40 +111,6 @@ struct WpaController
         return std::dynamic_pointer_cast<ResponseT>(SendCommand(command));
     }
 
-    /**
-     * @brief Helper class for working with the wpa control socket.
-     */
-    struct WpaControlSocket
-    {
-        WpaControlSocket() = delete;
-
-        /**
-         * @brief Maximum WPA control interface message size, im bytes. The
-         * official wpa_cli tool uses this as an upper bound, so is used
-         * similarly here.
-         */
-        static constexpr auto MessageSizeMax = 4096;
-
-        /**
-         * @brief Get the default path for the control socket of the specified daemon.
-         *
-         * @param wpaType The wpa daemon type to get the default control socket for.
-         * @return constexpr auto A string containing the default control socket path.
-         */
-        static constexpr auto
-        DefaultPath(WpaType wpaType)
-        {
-            switch (wpaType) {
-            case WpaType::Hostapd:
-                return ProtocolWpaConfig::ControlSocketPathHostapd;
-            case WpaType::WpaSupplicant:
-                return ProtocolWpaConfig::ControlSocketPathWpaSupplicant;
-            default:
-                throw std::runtime_error("Unknown WpaType");
-            }
-        }
-    };
-
 private:
     /**
      * @brief Get the control socket object. If a socket connection does not

--- a/src/linux/wpa-controller/include/Wpa/WpaController.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaController.hxx
@@ -11,6 +11,7 @@
 
 #include <Wpa/ProtocolWpaConfig.hxx>
 #include <Wpa/WpaCommand.hxx>
+#include <Wpa/WpaControlSocketConnection.hxx>
 #include <Wpa/WpaCore.hxx>
 #include <Wpa/WpaResponse.hxx>
 
@@ -64,7 +65,7 @@ struct WpaController
     /**
      * @brief Destroy the WpaController object.
      */
-    virtual ~WpaController();
+    virtual ~WpaController() = default;
 
     /**
      * @brief The type of daemon this object is controlling.
@@ -113,21 +114,20 @@ struct WpaController
 
 private:
     /**
-     * @brief Get the control socket object. If a socket connection does not
-     * exist, one will be established.
+     * @brief Get a control socket connection. If one does not exist, one will be established and cached for future use.
      *
-     * @return struct wpa_ctrl*
+     * @return WpaControlSocketConnection*
      */
-    struct wpa_ctrl*
-    GetCommandControlSocket();
+    WpaControlSocketConnection*
+    GetCommandControlSocketConnection();
 
 private:
     const WpaType m_type;
     const std::string m_interfaceName;
     std::filesystem::path m_controlSocketPath;
-    // Protects m_controlSocketCommand.
-    std::shared_mutex m_controlSocketCommandGate;
-    struct wpa_ctrl* m_controlSocketCommand{ nullptr };
+    // Protects m_controlSocketCommandConnection.
+    std::shared_mutex m_controlSocketCommandConnectionGate;
+    std::unique_ptr<WpaControlSocketConnection> m_controlSocketCommandConnection;
 };
 } // namespace Wpa
 

--- a/src/linux/wpa-controller/include/Wpa/WpaController.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaController.hxx
@@ -68,6 +68,17 @@ struct WpaController
     virtual ~WpaController() = default;
 
     /**
+     * @brief Determines if this controller is valid, meaning that it can be used to control the interface for which it
+     * was configured. TThe controller will be invalid if the control socket path is not valid, either because it is
+     * inacessible (bad permissions) or it does not exist (wpa_supplicant or hostapd is not controlling this interface).
+     * 
+     * @return true 
+     * @return false 
+     */
+    bool
+    IsValid() const noexcept;
+
+    /**
      * @brief The type of daemon this object is controlling.
      *
      * @return WpaType


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Prevent APs that aren't controllable via hostapd from being shown through API.
* Provide logging for basic AP presence events.

### Technical Details

* Add helpers to detect when a WPA control socket exists.
* Add C++ wrapper `WpaControlSocketConnection` for the C-based `struct wpa_ctrl`.
* Fix `AccessPointLinux` to ensure it uses the configured `IAccessPointControllerFactory` of the `AccessPoint` base class, instead of circumventing it and creating instances directly. Mark the `CreateCotroller` function as `final` to avoid any potential similar issues in the future.
* Add helper functions to `Hostapd` and `WpaController` to determine if they're active and valid respectively. Use these to avoid querying for hostapd status if the proxy isn't controlling the interface in question.

## Test Results

* Ad-hoc tests with `netremote-cli` exercising `WifiAccessPointEnumerate` API validated successfully.
* Other testing still in progress.

### Reviewer Focus

* None

### Future Work

* Other logging for basic access point events should be added.
* clang-tidy needs running.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
