### PR TITLE
Bug fix: use sdbus::ObjectPath instead of std::string for the systemd-resolved…

### DIFF
--- a/src/linux/server/SystemdResolvedDnssd.cxx
+++ b/src/linux/server/SystemdResolvedDnssd.cxx
@@ -125,10 +125,11 @@ ResolvedDnssd::UnregisterService(std::string_view serviceObjectPath)
     static constexpr auto Timeout = std::chrono::seconds(2);
 
     try {
+        const sdbus::ObjectPath dnssdObjectPath{ serviceObjectPath };
         auto sdbusProxy = sdbus::createProxy(DbusServiceName, DbusServiceObjectPath, sdbus::dont_run_event_loop_thread);
         sdbusProxy->callMethod(MethodNameUnregisterService)
             .onInterface(DbusServiceInterface)
-            .withArguments(std::data(serviceObjectPath))
+            .withArguments(dnssdObjectPath)
             .withTimeout(Timeout);
         return true;
     } catch (const sdbus::Error& sdbusError) {


### PR DESCRIPTION
… UnregisterService argument.


### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure DNS-SD unregistration works.
* Fixes bug introduced in #271.

### Technical Details

* Use the `sdbus::ObjectPath` type instead of `std::string` as the argument to `org.freedesktop.resolve1.Manager.UnregisterService`, as this is the required type, despite `std::string` being an alias for it.

### Test Results

* All unit tests pass.
* Validated that DNS-SD service entry disappeared from Linux remote machine when `netremote-server` is stopped and no log warning messages were observed.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
