### PR TITLE
Add ability to configure bridge interface for access point in Hostapd library

### DIFF
--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -424,6 +424,16 @@ Hostapd::AddSaePassword(SaePassword saePassword, EnforceConfigurationChange enfo
     }
 }
 
+void
+Hostapd::SetBridgeInterface(std::string_view bridgeInterface, EnforceConfigurationChange enforceConfigurationChange)
+{
+    try {
+        SetProperty(ProtocolHostapd::PropertyNameBridgeInterface, bridgeInterface, enforceConfigurationChange);
+    } catch (const HostapdException& e) {
+        throw HostapdException(std::format("Failed to set bridge interface to '{}' ({})", bridgeInterface, e.what()));
+    }
+}
+
 /* static */
 std::string
 Hostapd::GenerateNetworkAccessServerId(std::size_t lengthRequested)

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -195,6 +195,18 @@ struct Hostapd :
     AddSaePassword(SaePassword saePassword, EnforceConfigurationChange enforceConfigurationChange = EnforceConfigurationChange::Defer) override;
 
     /**
+     * @brief Set the network bridge interface the access point interface will be added to.
+     *
+     * Note that this will only take effect after the configuration is reloaded.
+     *
+     * @param bridgeInterface The name of the network bridge interface.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a
+     * configuration reload.
+     */
+    void
+    SetBridgeInterface(std::string_view bridgeInterface, EnforceConfigurationChange enforceConfigurationChange) override;
+
+    /**
      * @brief Generates a new network access server identifier. If no length is specified, a default value will be used.
      *
      * @param lengthRequested The requested length of the identifier. Valid values are in the range [1, 48].

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -200,6 +200,18 @@ struct IHostapd
      */
     virtual void
     AddSaePassword(SaePassword saePassword, EnforceConfigurationChange enforceConfigurationChange) = 0;
+
+    /**
+     * @brief Set the network bridge interface the access point interface will be added to.
+     *
+     * Note that this will only take effect after the configuration is reloaded.
+     *
+     * @param bridgeInterface The name of the network bridge interface.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a
+     * configuration reload.
+     */
+    virtual void
+    SetBridgeInterface(std::string_view bridgeInterface, EnforceConfigurationChange enforceConfigurationChange) = 0;
 };
 
 /**

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -535,6 +535,7 @@ struct ProtocolHostapd :
     static constexpr auto PropertyValueIeee80211WRequired = "2";
 
     static constexpr auto PropertyNameNasIdentifier = "nas_identifier";
+    static constexpr auto PropertyNameBridgeInterface = "bridge";
 
     // Indexed property names for BSS entries in the "STATUS" response.
     static constexpr auto PropertyNameBss = "bss";

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -693,6 +693,7 @@ constexpr std::array<char, WpaPskValueLength> PskHexValid{
 constexpr auto AsciiPassword{ "password" };
 constexpr auto PasswordIdValid{ "someid" };
 constexpr auto PeerMacAddressValid{ "00:11:22:33:44:55" };
+constexpr auto BridgeInterfaceNameDefault{ "brgateway0" };
 constexpr int32_t VlanIdValid{ 1 };
 
 const SaePassword SaePasswordValid1{
@@ -811,5 +812,19 @@ TEST_CASE("Send SetSaePasswords() command (root)", "[wpa][hostapd][client][remot
             REQUIRE_NOTHROW(hostapd.SetSaePasswords({ saePassword }, EnforceConfigurationChange::Now));
             REQUIRE_NOTHROW(hostapd.SetSaePasswords({ saePassword }, EnforceConfigurationChange::Defer));
         }
+    }
+}
+
+TEST_CASE("Send SetBridgeInterface() command (root)", "[wpa][hostapd][client][remote]")
+{
+    using namespace Wpa;
+    using namespace Wpa::Test;
+
+    Hostapd hostapd(WpaDaemonManager::InterfaceNameDefault);
+
+    SECTION("Doesn't throw")
+    {
+        REQUIRE_NOTHROW(hostapd.SetBridgeInterface(BridgeInterfaceNameDefault, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.SetBridgeInterface(BridgeInterfaceNameDefault, EnforceConfigurationChange::Defer));
     }
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow adding access point interfaces to network bridges.

### Technical Details

* Extend `IHostapd::SetNetworkBridge` with function to set network bridge interface.
* Add `Hostapd::SetNetworkBridge` implementation.
* Add unit test for `IHostapd::SetNetworkBridge`.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Expose this functionality into type-neutral layer (`Microsoft::Net::Wifi::AccessPoint*`).
* Expose this functionality into top-level API.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
