### PR TITLE
Add API to set access point network bridge

### DIFF
--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -13,4 +13,5 @@ service NetRemote
     rpc WifiAccessPointDisable (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableResult);
     rpc WifiAccessPointSetPhyType (Microsoft.Net.Remote.Wifi.WifiAccessPointSetPhyTypeRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetPhyTypeResult);
     rpc WifiAccessPointSetFrequencyBands (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsResult);
+    rpc WifiAccessPointSetNetworkBridge (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeResult);
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -87,3 +87,15 @@ message WifiAccessPointSetFrequencyBandsResult
     string AccessPointId = 1;
     WifiAccessPointOperationStatus Status = 2;
 }
+
+message WifiAccessPointSetNetworkBridgeRequest
+{
+    string AccessPointId = 1;
+    string NetworkBridgeId = 2;
+}
+
+message WifiAccessPointSetNetworkBridgeResult
+{
+    string AccessPointId = 1;
+    WifiAccessPointOperationStatus Status = 2;
+}

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -684,14 +684,6 @@ WifiAccessPointOperationStatus
 NetRemoteService::WifiAccessPointSetNetworkBridgeImpl(std::string_view accessPointId, std::string_view networkBridgeId, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController)
 {
     WifiAccessPointOperationStatus wifiOperationStatus{};
-
-    // Validate basic parameters in the request.
-    if (std::empty(networkBridgeId)) {
-        wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
-        wifiOperationStatus.set_message("No network bridge id provided");
-        return wifiOperationStatus;
-    }
-
     AccessPointOperationStatus operationStatus{ accessPointId };
 
     // Create an AP controller for the requested AP if one wasn't specified.
@@ -711,6 +703,8 @@ NetRemoteService::WifiAccessPointSetNetworkBridgeImpl(std::string_view accessPoi
         wifiOperationStatus.set_message(std::format("Failed to set network bridge for access point {} - {}", accessPointId, operationStatus.ToString()));
         return wifiOperationStatus;
     }
+
+    wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
 
     return wifiOperationStatus;
 }

--- a/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/NetRemoteService.hxx
@@ -97,6 +97,17 @@ private:
     grpc::Status
     WifiAccessPointSetFrequencyBands(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsResult* result) override;
 
+    /**
+     * @brief Set the network bridge interface the access point interface will be added to.
+     * 
+     * @param context 
+     * @param request 
+     * @param result 
+     * @return grpc::Status 
+     */
+    grpc::Status
+    WifiAccessPointSetNetworkBridge(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointSetNetworkBridgeRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointSetNetworkBridgeResult* result) override;
+
 protected:
     /**
      * @brief Attempt to obtain an IAccessPoint instance for the specified access point identifier.
@@ -172,6 +183,17 @@ protected:
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
     WifiAccessPointSetFrequencyBandsImpl(std::string_view accessPointId, std::vector<Microsoft::Net::Wifi::Dot11FrequencyBand>& dot11FrequencyBands, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
+
+    /**
+     * @brief Set the network bridge interface the access point interface will be added to.
+     * 
+     * @param accessPointId The access point identifier.
+     * @param networkBridgeId The network bridge interface id.
+     * @param accessPointController The access point controller for the specified access point (optional).
+     * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus 
+     */
+    Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+    WifiAccessPointSetNetworkBridgeImpl(std::string_view accessPointId, std::string_view networkBridgeId, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
     /**
      * @brief Set the active authentication algorithms of the access point. If the access point is online, this will

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPointController.hxx
@@ -138,6 +138,15 @@ struct IAccessPointController
      */
     virtual AccessPointOperationStatus
     SetSsid(std::string_view ssid) noexcept = 0;
+
+    /**
+     * @brief Set the network bridge interface the access point interface will be added to.
+     *
+     * @param networkBridgeId The network bridge interface id. The specific format of the id is platform dependent.
+     * @return AccessPointOperationStatus
+     */
+    virtual AccessPointOperationStatus
+    SetNetworkBridge(std::string_view networkBridgeId) noexcept = 0;
 };
 
 /**

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -429,6 +429,24 @@ AccessPointControllerLinux::SetSsid(std::string_view ssid) noexcept
     return status;
 }
 
+AccessPointOperationStatus
+AccessPointControllerLinux::SetNetworkBridge([[maybe_unused]] std::string_view networkBridgeId) noexcept
+{
+    AccessPointOperationStatus status{ GetInterfaceName() };
+    const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
+
+    try {
+        m_hostapd.SetBridgeInterface(networkBridgeId, EnforceConfigurationChange::Now);
+    } catch (const Wpa::HostapdException& ex) {
+        status.Code = AccessPointOperationStatusCode::InternalError;
+        status.Details = std::format("failed to set bridge interface to {} - {}", networkBridgeId, ex.what());
+        return status;
+    }
+
+    status.Code = AccessPointOperationStatusCode::Succeeded;
+    return status;
+}
+
 std::unique_ptr<IAccessPointController>
 AccessPointControllerLinuxFactory::Create(std::string_view interfaceName)
 {

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointControllerLinux.hxx
@@ -137,6 +137,15 @@ struct AccessPointControllerLinux :
     AccessPointOperationStatus
     SetSsid(std::string_view ssid) noexcept override;
 
+    /**
+     * @brief Set the network bridge interface the access point interface will be added to.
+     *
+     * @param networkBridgeId The network bridge interface id. The specific format of the id is platform dependent.
+     * @return AccessPointOperationStatus
+     */
+    AccessPointOperationStatus
+    SetNetworkBridge(std::string_view networkBridgeId) noexcept override;
+
 private:
     Wpa::Hostapd m_hostapd;
 };

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -177,6 +177,19 @@ AccessPointControllerTest::SetSsid(std::string_view ssid) noexcept
     return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 
+AccessPointOperationStatus
+AccessPointControllerTest::SetNetworkBridge(std::string_view networkBridgeId) noexcept
+{
+    assert(AccessPoint != nullptr);
+
+    if (AccessPoint == nullptr) {
+        return AccessPointOperationStatus::InvalidAccessPoint("null AccessPoint");
+    }
+
+    AccessPoint->BridgeInterfaceId = networkBridgeId;
+    return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
+}
+
 AccessPointControllerFactoryTest::AccessPointControllerFactoryTest(AccessPointTest *accessPoint) :
     AccessPoint(accessPoint)
 {}

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointControllerTest.hxx
@@ -147,6 +147,15 @@ struct AccessPointControllerTest final :
      */
     AccessPointOperationStatus
     SetSsid(std::string_view ssid) noexcept override;
+
+    /**
+     * @brief Set the network bridge interface the access point interface will be added to.
+     *
+     * @param networkBridgeId The network bridge interface id. The specific format of the id is platform dependent.
+     * @return AccessPointOperationStatus
+     */
+    AccessPointOperationStatus
+    SetNetworkBridge(std::string_view networkBridgeId) noexcept override;
 };
 
 /**

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -27,6 +27,7 @@ struct AccessPointTest final :
 {
     std::string Ssid;
     std::string InterfaceName;
+    std::string BridgeInterfaceId;
     Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities Capabilities;
     Microsoft::Net::Wifi::Ieee80211PhyType PhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
     Microsoft::Net::Wifi::Ieee80211AuthenticationData AuthenticationData;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow clients to set a network bridge to add access points to.

### Technical Details

* Add new API `WifiAccessPointSetNetworkBridge` and associated reqest/result structures to set a network bridge for an access point.
* Add `IAccessPointController::SetNetworkBridge` interface function and implementation in `AccessPointControllerLinux`.
* Add API unit tests.

### Test Results

* All unit tests pass.

### Reviewer Focus

* Consider whether this API is sufficient for roaming tests.

### Future Work

* There is presently no way for clients to learn which network bridges exist. Another API to enumerate network interfaces/properties will be added in a separate PR.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
