### PR TITLE
Differentiate bridge network interface type from others

### DIFF
--- a/src/common/net/include/microsoft/net/IpAddressInformation.hxx
+++ b/src/common/net/include/microsoft/net/IpAddressInformation.hxx
@@ -11,7 +11,7 @@ namespace Microsoft::Net
 /**
  * @brief Determine if a string contains an IPv4 or IPv6 "any" address. The port is optional for both forms, and square
  * brackets are optional for the IPv6 form.
- * 
+ *
  * @param ipAddressView The view of the string to check.
  * @return true If the string contains an IPv4 or IPv6 "any" address.
  * @return false If the string does not contain an IPv4 or IPv6 "any" address.
@@ -32,6 +32,7 @@ IsAnyAddress(std::string_view ipAddressView) noexcept
 enum class NetworkInterfaceType {
     Unknown,
     Wifi,
+    Bridge,
     Other,
 };
 

--- a/src/linux/net/NetworkOperationsLinux.cxx
+++ b/src/linux/net/NetworkOperationsLinux.cxx
@@ -21,7 +21,10 @@ GetNetworkInterfaceType(const Netlink::NetlinkLink& netlinkLink) noexcept
     if (netlinkLink.Type == "wireless") {
         return NetworkInterfaceType::Wifi;
     }
-    if (netlinkLink.Type == "ethernet" || netlinkLink.Type == "loopback" || netlinkLink.Type == "bridge") {
+    if (netlinkLink.Type == "bridge") {
+        return NetworkInterfaceType::Bridge;
+    }
+    if (netlinkLink.Type == "ethernet" || netlinkLink.Type == "loopback") {
         return NetworkInterfaceType::Other;
     }
     return NetworkInterfaceType::Unknown;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure bridge interfaces are explicitly identified, instead of labeling them as `Other`.

### Technical Details

* Update the interface name checking code to explicitly check for `"bridge"` to map to bridge interfaces.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Possibly identify other interface types as well, including ethernet, but there is no current need.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
