### PR TITLE
Expose NetworkEnumerateInterfaces API to netremote-cli

### DIFF
--- a/protocol/protos/NetRemoteNetwork.proto
+++ b/protocol/protos/NetRemoteNetwork.proto
@@ -12,12 +12,18 @@ enum NetworkOperationStatusCode
     NetworkOperationStatusCodeInvalidParameter = 2;
 }
 
+message NetworkOperationStatus
+{
+    NetworkOperationStatusCode Code = 1;
+    string Message = 2;
+}
+
 message NetworkEnumerateInterfacesRequest
 {
 }
 
 message NetworkEnumerateInterfacesResult
 {
-    NetworkOperationStatusCode Status = 1;
+    NetworkOperationStatus Status = 1;
     repeated NetworkInterface NetworkInterfaces = 2;
 }

--- a/protocol/protos/NetRemoteNetwork.proto
+++ b/protocol/protos/NetRemoteNetwork.proto
@@ -5,11 +5,19 @@ package Microsoft.Net.Remote.Network;
 
 import "NetworkCore.proto";
 
+enum NetworkOperationStatusCode
+{
+    NetworkOperationStatusCodeUnknown = 0;
+    NetworkOperationStatusCodeSuccess = 1;
+    NetworkOperationStatusCodeInvalidParameter = 2;
+}
+
 message NetworkEnumerateInterfacesRequest
 {
 }
 
 message NetworkEnumerateInterfacesResult
 {
-    repeated NetworkInterface NetworkInterfaces = 1;
+    NetworkOperationStatusCode Status = 1;
+    repeated NetworkInterface NetworkInterfaces = 2;
 }

--- a/src/common/net/service-api/adapter/ServiceApiNetworkAdapters.cxx
+++ b/src/common/net/service-api/adapter/ServiceApiNetworkAdapters.cxx
@@ -18,9 +18,16 @@ using Microsoft::Net::NetworkInterfaceId;
 NetworkAddress
 ToServiceNetworkAddress(const NetworkIpAddress& networkIpAddress) noexcept
 {
+    std::string ipAddress{ networkIpAddress.Address };
+    auto ipAddressPrefixSeparatorIndex = ipAddress.find_last_of('/');
+    if (ipAddressPrefixSeparatorIndex != std::string_view::npos)
+    {
+        ipAddress = ipAddress.substr(0, ipAddressPrefixSeparatorIndex);
+    }
+
     NetworkAddress networkAddress{};
     networkAddress.set_family(ToServiceNetworkAddressFamily(networkIpAddress.Family));
-    networkAddress.set_address(networkIpAddress.Address);
+    networkAddress.set_address(ipAddress);
     networkAddress.set_prefixlength(networkIpAddress.PrefixLength);
 
     return networkAddress;

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -291,6 +291,8 @@ NetRemoteService::NetworkInterfacesEnumerate([[maybe_unused]] grpc::ServerContex
         std::make_move_iterator(std::end(networkInterfaces)),
     };
 
+    result->set_status(NetworkOperationStatusCode::NetworkOperationStatusCodeSuccess);
+
     return grpc::Status::OK;
 }
 

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -291,7 +291,7 @@ NetRemoteService::NetworkInterfacesEnumerate([[maybe_unused]] grpc::ServerContex
         std::make_move_iterator(std::end(networkInterfaces)),
     };
 
-    result->set_status(NetworkOperationStatusCode::NetworkOperationStatusCodeSuccess);
+    result->mutable_status()->set_code(NetworkOperationStatusCode::NetworkOperationStatusCodeSuccess);
 
     return grpc::Status::OK;
 }

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -342,6 +342,13 @@ NetRemoteCli::OnServerAddressChanged(const std::string& serverAddressArg)
 }
 
 void
+NetRemoteCli::OnNetworkInterfacesEnumerate()
+{
+    // TODO
+
+}
+
+void
 NetRemoteCli::OnWifiAccessPointsEnumerate(bool detailedOutput)
 {
     m_cliHandler->HandleCommandWifiAccessPointsEnumerate(detailedOutput);

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -85,9 +85,35 @@ NetRemoteCli::CreateParser() noexcept
     optionServer->default_str(serverAddressDefault);
 
     m_cliAppServerAddress = optionServer;
+    m_cliAppNetwork = AddSubcommandNetwork(app.get());
     m_cliAppWifi = AddSubcommandWifi(app.get());
 
     return app;
+}
+
+CLI::App*
+NetRemoteCli::AddSubcommandNetwork(CLI::App* parent)
+{
+    // Top-level command.
+    auto* networkApp = parent->add_subcommand("net", "Network operations");
+    networkApp->needs(m_cliAppServerAddress);
+
+    // Sub-commands.
+    m_cliAppNetworkEnumerateInterfaces = AddSubcommandNetworkEnumerateInterfaces(networkApp);
+
+    return networkApp;
+}
+
+CLI::App*
+NetRemoteCli::AddSubcommandNetworkEnumerateInterfaces(CLI::App* parent)
+{
+    auto* cliAppNetworkEnumerateInterfaces = parent->add_subcommand("enumerate-interfaces", "Enumerate available network interfaces");
+    cliAppNetworkEnumerateInterfaces->alias("enumifs")->alias("enum")->alias("interfaces")->alias("ifaces")->alias("ifs");
+    cliAppNetworkEnumerateInterfaces->callback([this] {
+        OnNetworkInterfacesEnumerate();
+    });
+
+    return cliAppNetworkEnumerateInterfaces;
 }
 
 CLI::App*
@@ -344,8 +370,7 @@ NetRemoteCli::OnServerAddressChanged(const std::string& serverAddressArg)
 void
 NetRemoteCli::OnNetworkInterfacesEnumerate()
 {
-    // TODO
-
+    m_cliHandler->HandleCommandNetworkInterfacesEnumerate();
 }
 
 void

--- a/src/common/tools/cli/NetRemoteCliHandler.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandler.cxx
@@ -38,6 +38,24 @@ NetRemoteCliHandler::GetParentStrongRef() const
 }
 
 void
+NetRemoteCliHandler::HandleCommandNetworkInterfacesEnumerate()
+{
+    if (!m_operations) {
+        LOGE << "No operations instance available to handle command";
+        return;
+    }
+
+    auto parentStrong{ GetParentStrongRef() };
+    if (parentStrong == nullptr) {
+        LOGW << "Parent cli object is no longer valid, aborting command";
+        return;
+    }
+
+    LOGD << "Executing command NetworkInterfacesEnumerate";
+    m_operations->NetworkInterfacesEnumerate();
+}
+
+void
 NetRemoteCliHandler::HandleCommandWifiAccessPointsEnumerate(bool detailedOutput)
 {
     if (!m_operations) {

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -15,6 +15,8 @@
 #include <microsoft/net/remote/INetRemoteCliHandlerOperations.hxx>
 #include <microsoft/net/remote/NetRemoteCliHandlerOperations.hxx>
 #include <microsoft/net/remote/NetRemoteServerConnection.hxx>
+#include <microsoft/net/remote/protocol/NetRemoteNetwork.grpc.pb.h>
+#include <microsoft/net/remote/protocol/NetRemoteNetwork.pb.h>
 #include <microsoft/net/remote/protocol/NetRemoteService.grpc.pb.h>
 #include <microsoft/net/remote/protocol/NetRemoteWifi.pb.h>
 #include <microsoft/net/remote/protocol/WifiCore.pb.h>
@@ -23,6 +25,7 @@
 #include <plog/Log.h>
 
 using namespace Microsoft::Net::Remote;
+using namespace Microsoft::Net::Remote::Network;
 using namespace Microsoft::Net::Remote::Service;
 using namespace Microsoft::Net::Remote::Wifi;
 using namespace Microsoft::Net::Wifi;
@@ -246,6 +249,20 @@ NetRemoteAccessPointCapabilitiesToString(const Dot11AccessPointCapabilities& acc
     return NetRemoteAccessPointCapabilitiesToStringDetailed(accessPointCapabilities, indent0, indent1);
 }
 } // namespace detail
+
+void
+NetRemoteCliHandlerOperations::NetworkInterfacesEnumerate()
+{
+    const NetworkEnumerateInterfacesRequest request{};
+    NetworkEnumerateInterfacesResult result{};
+    grpc::ClientContext clientContext{};
+
+    // auto status = m_connection->Client->NetworkInterfacesEnumerate(&clientContext, request, &result);
+    // if (!status.ok()) {
+    //     LOGE std::format("Failed to enumerate network interfaces ({})\n{}\n", magic_enum::enum_name(result.status().code()), result.status().message());
+    //     return;
+    // }
+}
 
 void
 NetRemoteCliHandlerOperations::WifiAccessPointsEnumerate(bool detailedOutput)

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -282,11 +282,11 @@ NetRemoteCliHandlerOperations::NetworkInterfacesEnumerate()
         networkInterfaceKind.remove_prefix(std::size(std::string_view("NetworkInterfaceKind")));
 
         std::stringstream ss;
-        ss << '[' << numNetworkInterface++ << "] " << networkInterface.id() << ": " << networkInterface.kind() << " Addresses: ";
+        ss << '[' << numNetworkInterface++ << "] " << networkInterface.id() << ": " << networkInterfaceKind << " Addresses: ";
         for (const auto& networkAddress : networkInterface.addresses()) {
             std::string_view networkAddressFamily = magic_enum::enum_name(networkAddress.family());
-            networkAddressFamily.remove_prefix(std::size(std::string_view("AddressFamily")));
-            ss << networkAddress.address() << "/" << networkAddress.prefixlength() << "(" << networkAddressFamily << ")";
+            networkAddressFamily.remove_prefix(std::size(std::string_view("NetworkAddressFamily")));
+            ss << networkAddress.address() << "/" << networkAddress.prefixlength() << " (" << networkAddressFamily << ") ";
         }
 
         std::cout << ss.str() << '\n';

--- a/src/common/tools/cli/include/microsoft/net/remote/INetRemoteCliHandlerOperations.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/INetRemoteCliHandlerOperations.hxx
@@ -33,6 +33,12 @@ struct INetRemoteCliHandlerOperations
     operator=(INetRemoteCliHandlerOperations&&) = delete;
 
     /**
+     * @brief Enumerate available network interfaces.
+     */
+    virtual void
+    NetworkInterfacesEnumerate() = 0;
+
+    /**
      * @brief Enumerate available WiFi access points.
      *
      * @param detailedOutput Whether the output should be detailed (false) or brief (true, single line).

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
@@ -78,6 +78,24 @@ private:
     CreateParser() noexcept;
 
     /**
+     * @brief Add the 'net' sub-command.
+     *
+     * @param parent The parent app to add the sub-command to.
+     * @return CLI::App*
+     */
+    CLI::App*
+    AddSubcommandNetwork(CLI::App* parent);
+
+    /**
+     * @brief Add the 'net enumerate-interfaces' sub-command.
+     *
+     * @param parent The parent app to add the sub-command to.
+     * @return CLI::App*
+     */
+    CLI::App*
+    AddSubcommandNetworkEnumerateInterfaces(CLI::App* parent);
+
+    /**
      * @brief Add the 'wifi' sub-command.
      *
      * @param parent The parent app to add the sub-command to.
@@ -166,6 +184,8 @@ private:
 
     // The following are helper references to the subcommands of m_cliApp; the memory is managed by CLI11.
     CLI::Option* m_cliAppServerAddress{ nullptr };
+    CLI::App* m_cliAppNetwork{ nullptr };
+    CLI::App* m_cliAppNetworkEnumerateInterfaces{ nullptr };
     CLI::App* m_cliAppWifi{ nullptr };
     CLI::App* m_cliAppWifiAccessPointsEnumerate{ nullptr };
     CLI::App* m_cliAppWifiAccessPointEnable{ nullptr };

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
@@ -122,6 +122,12 @@ private:
     OnServerAddressChanged(const std::string& serverAddress);
 
     /**
+     * @brief Handle the 'net enumerate-interfaces' command.
+     */
+    void
+    OnNetworkInterfacesEnumerate();
+
+    /**
      * @brief Handle the 'wifi enumerate-access-points' command.
      *
      * @param detailedOutput Whether the output should be detailed (false) or brief (true, single line).

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandler.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandler.hxx
@@ -60,6 +60,12 @@ struct NetRemoteCliHandler
     SetConnection(std::shared_ptr<NetRemoteServerConnection> connection);
 
     /**
+     * @brief Handle a command request to enumerate available network interfaces.
+     */
+    void
+    HandleCommandNetworkInterfacesEnumerate();
+
+    /**
      * @brief Handle a command request to enumerate available Wi-Fi access points.
      *
      * @param detailedOutput Whether the output should be detailed (false) or brief (true, single line).

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandlerOperations.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandlerOperations.hxx
@@ -42,6 +42,12 @@ struct NetRemoteCliHandlerOperations :
     explicit NetRemoteCliHandlerOperations(std::shared_ptr<NetRemoteServerConnection> connection);
 
     /**
+     * @brief Enumerate available network interfaces.
+     */
+    void
+    NetworkInterfacesEnumerate() override;
+
+    /**
      * @brief Enumerate available WiFi access points.
      *
      * @param detailedOutput Whether the output should be detailed (false) or brief (true, single line).


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow the `NetworkEnumerateInterfaces` API to be invoked from the cli tool.
* Enable richer status to be returned from `NetworkEnumerateInterfaces` API.

### Technical Details

* Add `NetworkOperationStatus` and `NetworkOperationStatusCode` to enable reporting richer error information from the `NetworkEnumerateInterfaces` API.
* Add new `net` top-level command to `netremote-cli` app.
* Add `enumerate-interfaces` sub-command to `net` top-level command in `netremote-cli`.

### Test Results

* All unit tests pass.
* Invoked the new cli command validated output was as expected, per below:
<img width="875" alt="image" src="https://github.com/microsoft/netremote/assets/2082148/e36ce2ca-bef6-4af0-866f-8f24bf786be9">

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
