### PR TITLE
Expose access point mac address from NetworkInterfacesEnumerate API

### DIFF
--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -9,8 +9,9 @@ import "WifiCore.proto";
 message WifiAccessPointsEnumerateResultItem
 {
     string AccessPointId = 1;
-    Microsoft.Net.Wifi.Dot11AccessPointCapabilities Capabilities = 2;
-    bool IsEnabled = 3;
+    string MacAddress = 2;
+    Microsoft.Net.Wifi.Dot11AccessPointCapabilities Capabilities = 3;
+    bool IsEnabled = 4;
 }
 
 message WifiAccessPointsEnumerateRequest

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -206,6 +206,8 @@ IAccessPointToNetRemoteAccessPointResultItem(IAccessPoint& accessPoint)
     auto interfaceName = accessPoint.GetInterfaceName();
     id.assign(std::cbegin(interfaceName), std::cend(interfaceName));
 
+    std::string macAddress = Ieee80211MacAddressToString(accessPoint.GetMacAddress());
+
     auto accessPointController = accessPoint.CreateController();
     if (accessPointController == nullptr) {
         LOGE << std::format("Failed to create controller for access point {}", interfaceName);
@@ -235,6 +237,7 @@ IAccessPointToNetRemoteAccessPointResultItem(IAccessPoint& accessPoint)
     // Populate the result item.
     WifiAccessPointsEnumerateResultItem item{};
     item.set_accesspointid(std::move(id));
+    item.set_macaddress(std::move(macAddress));
     item.set_isenabled(isEnabled);
     *item.mutable_capabilities() = std::move(dot11AccessPointCapabilities);
 

--- a/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandlerOperations.cxx
@@ -322,7 +322,7 @@ NetRemoteCliHandlerOperations::WifiAccessPointsEnumerate(bool detailedOutput)
     std::size_t numAccessPoint = 1;
     for (const auto& accessPoint : result.accesspoints()) {
         std::stringstream ss;
-        ss << '[' << numAccessPoint++ << "] " << accessPoint.accesspointid();
+        ss << '[' << numAccessPoint++ << "] " << accessPoint.macaddress() << " " << accessPoint.accesspointid();
         if (!accessPoint.isenabled()) {
             ss << " (disabled)";
         }

--- a/src/common/wifi/core/AccessPoint.cxx
+++ b/src/common/wifi/core/AccessPoint.cxx
@@ -1,23 +1,32 @@
 
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <utility>
 
 #include <microsoft/net/wifi/AccessPoint.hxx>
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <microsoft/net/wifi/IAccessPointController.hxx>
+#include <microsoft/net/wifi/Ieee80211.hxx>
 
 using namespace Microsoft::Net::Wifi;
 
-AccessPoint::AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory) :
+AccessPoint::AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, std::optional<Ieee80211MacAddress> macAddress) :
     m_interfaceName(interfaceName),
-    m_accessPointControllerFactory(std::move(accessPointControllerFactory))
+    m_accessPointControllerFactory(std::move(accessPointControllerFactory)),
+    m_macAddress(macAddress)
 {}
 
 std::string_view
 AccessPoint::GetInterfaceName() const noexcept
 {
     return m_interfaceName;
+}
+
+Ieee80211MacAddress
+AccessPoint::GetMacAddress() const noexcept
+{
+    return m_macAddress.value_or(Ieee80211MacAddress{});
 }
 
 std::unique_ptr<IAccessPointController>

--- a/src/common/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
@@ -2,11 +2,13 @@
 #ifndef ACCESS_POINT_HXX
 #define ACCESS_POINT_HXX
 
-#include <microsoft/net/wifi/IAccessPoint.hxx>
-#include <microsoft/net/wifi/IAccessPointController.hxx>
-
+#include <optional>
 #include <string>
 #include <string_view>
+
+#include <microsoft/net/wifi/IAccessPoint.hxx>
+#include <microsoft/net/wifi/IAccessPointController.hxx>
+#include <microsoft/net/wifi/Ieee80211.hxx>
 
 namespace Microsoft::Net::Wifi
 {
@@ -23,7 +25,7 @@ struct AccessPoint :
      * @param interfaceName The network interface name representing the access point.
      * @param accessPointControllerFactory The factory used to create controller objects.
      */
-    AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory);
+    AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, std::optional<Ieee80211MacAddress> macAddress = std::nullopt);
 
     /**
      * @brief Get the network interface name representing the access point.
@@ -32,6 +34,14 @@ struct AccessPoint :
      */
     std::string_view
     GetInterfaceName() const noexcept override;
+
+    /**
+     * @brief Get the mac address of the access point.
+     *
+     * @return Ieee80211MacAddress
+     */
+    Ieee80211MacAddress
+    GetMacAddress() const noexcept override;
 
     /**
      * @brief Create a controller object.
@@ -44,6 +54,7 @@ struct AccessPoint :
 private:
     const std::string m_interfaceName;
     std::shared_ptr<IAccessPointControllerFactory> m_accessPointControllerFactory;
+    std::optional<Ieee80211MacAddress> m_macAddress;
 };
 
 /**

--- a/src/common/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
@@ -6,6 +6,7 @@
 #include <string_view>
 
 #include <microsoft/net/wifi/IAccessPointController.hxx>
+#include <microsoft/net/wifi/Ieee80211.hxx>
 
 namespace Microsoft::Net::Wifi
 {
@@ -41,6 +42,14 @@ struct IAccessPoint
      */
     virtual std::string_view
     GetInterfaceName() const noexcept = 0;
+
+    /**
+     * @brief Get the mac address of the access point.
+     *
+     * @return Ieee80211MacAddress
+     */
+    virtual Ieee80211MacAddress
+    GetMacAddress() const noexcept = 0;
 
     /**
      * @brief Create a new instance that can control the access point.

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/nl80211/Netlink80211Interface.hxx
@@ -2,6 +2,7 @@
 #ifndef NETLINK_82011_INTERFACE_HXX
 #define NETLINK_82011_INTERFACE_HXX
 
+#include <array>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -16,12 +17,17 @@
 
 namespace Microsoft::Net::Netlink::Nl80211
 {
+static constexpr auto Nl80211MacAddressNumOctets{ 6 };
+
+using Nl80211MacAddress = std::array<uint8_t, Nl80211MacAddressNumOctets>;
+
 /**
  * @brief Represents a netlink 802.11 interface.
  */
 struct Nl80211Interface
 {
     std::string Name;
+    std::array<uint8_t, Nl80211MacAddressNumOctets> MacAddress{};
     nl80211_iftype Type{ nl80211_iftype::NL80211_IFTYPE_UNSPECIFIED };
     uint32_t Index{ 0 };
     uint32_t WiphyIndex{ 0 };
@@ -35,11 +41,12 @@ struct Nl80211Interface
      * @brief Construct a new Nl80211Interface object with the specified attributes.
      *
      * @param name The name of the interface.
+     * @param macAddress The MAC address of the interface.
      * @param type The nl80211_iftype of the interface.
      * @param index The interface index in the kernel.
      * @param wiphyIndex The phy interface index in the kernel.
      */
-    Nl80211Interface(std::string_view name, nl80211_iftype type, uint32_t index, uint32_t wiphyIndex) noexcept;
+    Nl80211Interface(std::string_view name, std::array<uint8_t, Nl80211MacAddressNumOctets> macAddress, nl80211_iftype type, uint32_t index, uint32_t wiphyIndex) noexcept;
 
     /**
      * @brief Parse a netlink message into an Nl80211Interface. The netlink message must contain a response to the

--- a/src/linux/wifi/core/AccessPointLinux.cxx
+++ b/src/linux/wifi/core/AccessPointLinux.cxx
@@ -22,6 +22,12 @@ AccessPointLinux::AccessPointLinux(std::string_view interfaceName, std::shared_p
 {
 }
 
+Ieee80211MacAddress
+AccessPointLinux::GetMacAddress() const noexcept
+{
+    return m_nl80211Interface.MacAddress;
+}
+
 std::shared_ptr<IAccessPoint>
 AccessPointFactoryLinux::Create(std::string_view interfaceName)
 {

--- a/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointLinux.hxx
+++ b/src/linux/wifi/core/include/microsoft/net/wifi/AccessPointLinux.hxx
@@ -5,10 +5,11 @@
 #include <memory>
 #include <string_view>
 
+#include <microsoft/net/netlink/nl80211/Netlink80211Interface.hxx>
+#include <microsoft/net/wifi/AccessPoint.hxx>
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <microsoft/net/wifi/IAccessPointController.hxx>
-#include <microsoft/net/wifi/AccessPoint.hxx>
-#include <microsoft/net/netlink/nl80211/Netlink80211Interface.hxx>
+#include <microsoft/net/wifi/Ieee80211.hxx>
 
 namespace Microsoft::Net::Wifi
 {
@@ -21,12 +22,20 @@ struct AccessPointLinux :
     /**
      * @brief Construct a new AccessPointLinux object with the specified interface name, access point controller
      * factory, and nl80211 interface.
-     * 
+     *
      * @param interfaceName The name of the interface.
      * @param accessPointControllerFactory The access point controller factory to use for creating access point.
      * @param nl80211Interface The nl80211 interface object.
      */
     AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Microsoft::Net::Netlink::Nl80211::Nl80211Interface nl80211Interface);
+
+    /**
+     * @brief Get the mac address of the access point.
+     *
+     * @return Ieee80211MacAddress
+     */
+    Ieee80211MacAddress
+    GetMacAddress() const noexcept override;
 
 private:
     Microsoft::Net::Netlink::Nl80211::Nl80211Interface m_nl80211Interface;
@@ -68,7 +77,7 @@ struct AccessPointCreateArgsLinux :
 {
     /**
      * @brief Construct a new AccessPointCreateArgsLinux object with the specified nl80211 interface.
-     * 
+     *
      * @param nl80211Interface The nl80211 interface object.
      */
     explicit AccessPointCreateArgsLinux(Microsoft::Net::Netlink::Nl80211::Nl80211Interface nl80211Interface);

--- a/tests/unit/wifi/helpers/AccessPointTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointTest.cxx
@@ -4,6 +4,7 @@
 
 #include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <microsoft/net/wifi/IAccessPointController.hxx>
+#include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
 #include <microsoft/net/wifi/test/AccessPointControllerTest.hxx>
 #include <microsoft/net/wifi/test/AccessPointTest.hxx>
@@ -24,6 +25,12 @@ std::string_view
 AccessPointTest::GetInterfaceName() const noexcept
 {
     return InterfaceName;
+}
+
+Ieee80211MacAddress
+AccessPointTest::GetMacAddress() const noexcept
+{
+    return MacAddress;
 }
 
 std::unique_ptr<IAccessPointController>

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -28,6 +28,7 @@ struct AccessPointTest final :
     std::string Ssid;
     std::string InterfaceName;
     std::string BridgeInterfaceId;
+    Microsoft::Net::Wifi::Ieee80211MacAddress MacAddress{};
     Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities Capabilities;
     Microsoft::Net::Wifi::Ieee80211PhyType PhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
     Microsoft::Net::Wifi::Ieee80211AuthenticationData AuthenticationData;
@@ -75,6 +76,14 @@ struct AccessPointTest final :
      */
     std::string_view
     GetInterfaceName() const noexcept override;
+
+    /**
+     * @brief Get the mac address of the access point.
+     *
+     * @return Microsoft::Net::Wifi::Ieee80211MacAddress
+     */
+    Microsoft::Net::Wifi::Ieee80211MacAddress
+    GetMacAddress() const noexcept override;
 
     /**
      * @brief Create a new instance that can control the access point.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [X] Breaking change
- [ ] Non-functional change

### Goals

* Ensure API clients can uniquely identify an access point using its MAC address.

### Technical Details

* Plumb the mac address throughout the Wi-Fi portion of the stack, from Hostapd up to the protobuf API.

### Test Results

* All unit tests pass.
* `netremote-cli wifi aps` shows the mac address of each result per below:
<img width="746" alt="image" src="https://github.com/microsoft/netremote/assets/2082148/602b4ac5-e9ce-4914-bc2e-1df681a0cee9">


### Reviewer Focus

* Consider whether this is sufficient for test scenarios.

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
