### PR TITLE
Add WifiAccessPointSetSsid API

### DIFF
--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -18,5 +18,6 @@ service NetRemote
     rpc WifiAccessPointDisable (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointDisableResult);
     rpc WifiAccessPointSetPhyType (Microsoft.Net.Remote.Wifi.WifiAccessPointSetPhyTypeRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetPhyTypeResult);
     rpc WifiAccessPointSetFrequencyBands (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsResult);
+    rpc WifiAccessPointSetSsid (Microsoft.Net.Remote.Wifi.WifiAccessPointSetSsidRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetSsidResult);
     rpc WifiAccessPointSetNetworkBridge (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeResult);
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -100,3 +100,15 @@ message WifiAccessPointSetNetworkBridgeResult
     string AccessPointId = 1;
     WifiAccessPointOperationStatus Status = 2;
 }
+
+message WifiAccessPointSetSsidRequest
+{
+    string AccessPointId = 1;
+    Microsoft.Net.Wifi.Dot11Ssid Ssid = 2;
+}
+
+message WifiAccessPointSetSsidResult
+{
+    string AccessPointId = 1;
+    WifiAccessPointOperationStatus Status = 2;
+}

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -376,6 +376,26 @@ NetRemoteService::WifiAccessPointSetFrequencyBands([[maybe_unused]] grpc::Server
 }
 
 grpc::Status
+NetRemoteService::WifiAccessPointSetSsid([[maybe_unused]] grpc::ServerContext* context, const WifiAccessPointSetSsidRequest* request, WifiAccessPointSetSsidResult* result)
+{
+    WifiAccessPointOperationStatus wifiOperationStatus{};
+    const NetRemoteWifiApiTrace traceMe{ request->accesspointid(), result->mutable_status() };
+
+    if (request->has_ssid()) {
+        const auto& ssid = request->ssid();
+        wifiOperationStatus = WifiAccessPointSetSsidImpl(request->accesspointid(), ssid);
+    } else {
+        wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+        wifiOperationStatus.set_message("No SSID provided");
+    }
+
+    result->set_accesspointid(request->accesspointid());
+    *result->mutable_status() = std::move(wifiOperationStatus);
+
+    return grpc::Status::OK;
+}
+
+grpc::Status
 NetRemoteService::WifiAccessPointSetNetworkBridge([[maybe_unused]] grpc::ServerContext* context, const WifiAccessPointSetNetworkBridgeRequest* request, WifiAccessPointSetNetworkBridgeResult* result)
 {
     const NetRemoteWifiApiTrace traceMe{ request->accesspointid(), result->mutable_status() };

--- a/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
@@ -113,6 +113,17 @@ private:
     WifiAccessPointSetFrequencyBands(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointSetFrequencyBandsResult* result) override;
 
     /**
+     * @brief Set the SSID of the access point.
+     * 
+     * @param context 
+     * @param request 
+     * @param result 
+     * @return grpc::Status 
+     */
+    grpc::Status
+    WifiAccessPointSetSsid(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointSetSsidRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointSetSsidResult* result) override;
+
+    /**
      * @brief Set the network bridge interface the access point interface will be added to.
      *
      * @param context


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow the SSID of an access point to be set independently of other configuration.

### Technical Details

* Add `WifiAccessPointSetSsid` API and implement it using existing support in the stack.

### Test Results

* TBD

### Reviewer Focus

* None

### Future Work

* Add basic unit tests.
* Expose to cli.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
