### PR TITLE
Add RADIUS configuration support to hostapd adapter

### DIFF
--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -207,7 +207,9 @@ struct Hostapd :
     SetBridgeInterface(std::string_view bridgeInterface, EnforceConfigurationChange enforceConfigurationChange) override;
 
     /**
-     * @brief Add RADIUS server endpoints to the interface. This may contain multiple endpoints of various types.
+     * @brief Add RADIUS server endpoints to the interface. This may contain multiple endpoints of various types. The
+     * first endpoint configuration for each type is used as the primary server, and any following are used as fallbacks
+     * in case the primary server is unreachable.
      *
      * @param endpointConfigurations The endpoint configurations to add.
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -207,6 +207,16 @@ struct Hostapd :
     SetBridgeInterface(std::string_view bridgeInterface, EnforceConfigurationChange enforceConfigurationChange) override;
 
     /**
+     * @brief Add RADIUS server endpoints to the interface. This may contain multiple endpoints of various types.
+     *
+     * @param endpointConfigurations The endpoint configurations to add.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a
+     * configuration reload.
+     */
+    void
+    AddRadiusEndpoints(std::vector<RadiusEndpointConfiguration> endpointConfigurations, EnforceConfigurationChange enforceConfigurationChange) override;
+
+    /**
      * @brief Generates a new network access server identifier. If no length is specified, a default value will be used.
      *
      * @param lengthRequested The requested length of the identifier. Valid values are in the range [1, 48].

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -214,8 +214,10 @@ struct IHostapd
     SetBridgeInterface(std::string_view bridgeInterface, EnforceConfigurationChange enforceConfigurationChange) = 0;
 
     /**
-     * @brief Add RADIUS server endpoints to the interface. This may contain multiple endpoints of various types.
-     *
+     * @brief Add RADIUS server endpoints to the interface. This may contain multiple endpoints of various types. The
+     * first endpoint configuration for each type is used as the primary server, and any following are used as fallbacks
+     * in case the primary server is unreachable.
+     * 
      * @param endpointConfigurations The endpoint configurations to add.
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a
      * configuration reload.

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -212,6 +212,16 @@ struct IHostapd
      */
     virtual void
     SetBridgeInterface(std::string_view bridgeInterface, EnforceConfigurationChange enforceConfigurationChange) = 0;
+
+    /**
+     * @brief Add RADIUS server endpoints to the interface. This may contain multiple endpoints of various types.
+     *
+     * @param endpointConfigurations The endpoint configurations to add.
+     * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a
+     * configuration reload.
+     */
+    virtual void
+    AddRadiusEndpoints(std::vector<RadiusEndpointConfiguration> endpointConfigurations, EnforceConfigurationChange enforceConfigurationChange) = 0;
 };
 
 /**

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -877,6 +877,16 @@ enum class RadiusEndpointType {
 };
 
 /**
+ * @brief Default port for RADIUS authentication servers.
+ */
+static constexpr uint16_t RadiusAuthenticationPortDefault = 1812;
+
+/**
+ * @brief Default port for RADIUS accounting servers.
+ */
+static constexpr uint16_t RadiusAccountingPortDefault = 1813;
+
+/**
  * @brief Configuration values for a RADIUS endpoint, either a request or accounting server.
  */
 struct RadiusEndpointConfiguration
@@ -887,6 +897,12 @@ struct RadiusEndpointConfiguration
     std::string SharedSecret;
 };
 
+/**
+ * @brief Get the radius endpoint property names given a radius endpoint type.
+ * 
+ * @param type The type of radius endpoint.
+ * @return constexpr std::tuple<std::string_view, std::string_view, std::string_view> 
+ */
 constexpr std::tuple<std::string_view, std::string_view, std::string_view>
 GetRadiusEndpointPropertyNames(RadiusEndpointType type)
 {

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -548,7 +548,7 @@ struct ProtocolHostapd :
     static constexpr auto PropertyNameRadiusAuthReqAttr = "radius_auth_req_attr";
 
     static constexpr auto PropertyNameRadiusAcctServerAddr = "acct_server_addr";
-    static constexpr auto PropertyNameRadiusAcctServerPort = "acctserver_port";
+    static constexpr auto PropertyNameRadiusAcctServerPort = "acct_server_port";
     static constexpr auto PropertyNameRadiusAcctServerShared = "acct_server_shared_secret";
     static constexpr auto PropertyNameRadiusAcctReqAttr = "radius_acct_req_attr";
 

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -8,6 +8,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -537,6 +538,20 @@ struct ProtocolHostapd :
     static constexpr auto PropertyNameNasIdentifier = "nas_identifier";
     static constexpr auto PropertyNameBridgeInterface = "bridge";
 
+    static constexpr auto PropertyNameOwnIpAddr = "own_ip_addr";
+    static constexpr auto PropertyNameRadiusClientAddr = "radius_client_addr";
+    static constexpr auto PropertyNameRadiusClientDev = "radius_client_dev";
+
+    static constexpr auto PropertyNameRadiusAuthServerAddr = "auth_server_addr";
+    static constexpr auto PropertyNameRadiusAuthServerPort = "auth_server_port";
+    static constexpr auto PropertyNameRadiusAuthServerShared = "auth_server_shared_secret";
+    static constexpr auto PropertyNameRadiusAuthReqAttr = "radius_auth_req_attr";
+
+    static constexpr auto PropertyNameRadiusAcctServerAddr = "acct_server_addr";
+    static constexpr auto PropertyNameRadiusAcctServerPort = "acctserver_port";
+    static constexpr auto PropertyNameRadiusAcctServerShared = "acct_server_shared_secret";
+    static constexpr auto PropertyNameRadiusAcctReqAttr = "radius_acct_req_attr";
+
     // Indexed property names for BSS entries in the "STATUS" response.
     static constexpr auto PropertyNameBss = "bss";
     static constexpr auto PropertyNameBssBssid = "bssid";
@@ -851,6 +866,45 @@ struct SaePassword
     std::optional<std::string> PeerMacAddress;
     std::optional<int32_t> VlanId;
 };
+
+/**
+ * @brief Type of endpoint used for RADIUS.
+ */
+enum class RadiusEndpointType {
+    Unknown,
+    Authentication,
+    Accounting,
+};
+
+/**
+ * @brief Configuration values for a RADIUS endpoint, either a request or accounting server.
+ */
+struct RadiusEndpointConfiguration
+{
+    RadiusEndpointType Type{ RadiusEndpointType::Unknown };
+    std::string Address;
+    std::optional<uint16_t> Port;
+    std::string SharedSecret;
+};
+
+constexpr std::tuple<std::string_view, std::string_view, std::string_view>
+GetRadiusEndpointPropertyNames(RadiusEndpointType type)
+{
+    switch (type) {
+    case RadiusEndpointType::Authentication:
+        return { ProtocolHostapd::PropertyNameRadiusAuthServerAddr,
+            ProtocolHostapd::PropertyNameRadiusAuthServerPort,
+            ProtocolHostapd::PropertyNameRadiusAuthServerShared };
+    case RadiusEndpointType::Accounting:
+        return { ProtocolHostapd::PropertyNameRadiusAcctServerAddr,
+            ProtocolHostapd::PropertyNameRadiusAcctServerPort,
+            ProtocolHostapd::PropertyNameRadiusAcctServerShared };
+    default:
+        return { ProtocolHostapd::PropertyNameInvalid,
+            ProtocolHostapd::PropertyNameInvalid,
+            ProtocolHostapd::PropertyNameInvalid };
+    }
+}
 } // namespace Wpa
 
 #endif // HOSTAPD_PROTOCOL_HXX

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -834,20 +834,105 @@ TEST_CASE("Send AddRadiusEndpoints() command (root)", "[wpa][hostapd][client][re
     using namespace Wpa;
     using namespace Wpa::Test;
 
-    static constexpr auto RadiusServerIpValid{ "127.0.0.1" };
-    static constexpr auto RadiusServerPortValid{ RadiusAuthenticationPortDefault };
-    static constexpr auto RadiusSecretValid{ "shared-secret" };
-    static constexpr RadiusEndpointConfiguration RadiusEndpointConfigurationValid1{
+    static constexpr auto RadiusServerIpValid1{ "127.0.0.1" };
+    static constexpr auto RadiusServerIpValid2{ "192.168.0.1" };
+    static constexpr auto RadiusServerPortValid1{ RadiusAuthenticationPortDefault };
+    static constexpr auto RadiusServerPortValid2{ 1234 };
+    static constexpr auto RadiusSecretValid1{ "shared-secret-1" };
+    static constexpr auto RadiusSecretValid2{ "shared-secret-2" };
+
+    static constexpr RadiusEndpointConfiguration RadiusEndpointConfigurationAuthenticationValid1{
         .Type = RadiusEndpointType::Authentication,
-        .Address = RadiusServerIpValid,
-        .SharedSecret = RadiusSecretValid,
+        .Address = RadiusServerIpValid1,
+        .Port = RadiusServerPortValid1,
+        .SharedSecret = RadiusSecretValid1,
+    };
+
+    static constexpr RadiusEndpointConfiguration RadiusEndpointConfigurationAccountingValid1{
+        .Type = RadiusEndpointType::Accounting,
+        .Address = RadiusServerIpValid2,
+        .Port = RadiusServerPortValid2,
+        .SharedSecret = RadiusSecretValid2,
     };
 
     Hostapd hostapd(WpaDaemonManager::InterfaceNameDefault);
 
     SECTION("Doesn't throw")
     {
-        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationValid1 }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationValid1 }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1 }, EnforceConfigurationChange::Defer));
+    }
+
+    SECTION("Fails with invalid endpoint type")
+    {
+        static constexpr RadiusEndpointConfiguration radiusEndpointConfigurationInvalid{
+            .Type = RadiusEndpointType::Unknown,
+            .Address = RadiusServerIpValid1,
+            .SharedSecret = RadiusSecretValid1,
+        };
+
+        REQUIRE_THROWS_AS(hostapd.AddRadiusEndpoints({ radiusEndpointConfigurationInvalid }, EnforceConfigurationChange::Now), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.AddRadiusEndpoints({ radiusEndpointConfigurationInvalid }, EnforceConfigurationChange::Defer), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, radiusEndpointConfigurationInvalid }, EnforceConfigurationChange::Now), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, radiusEndpointConfigurationInvalid }, EnforceConfigurationChange::Defer), HostapdException);
+    }
+
+    SECTION("Fails with missing address input")
+    {
+        static constexpr RadiusEndpointConfiguration RadiusEndpointConfigurationInvalid{
+            .Type = RadiusEndpointType::Authentication,
+            .Address = "",
+            .SharedSecret = RadiusSecretValid1,
+        };
+
+        REQUIRE_THROWS_AS(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationInvalid }, EnforceConfigurationChange::Now), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationInvalid }, EnforceConfigurationChange::Defer), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationInvalid }, EnforceConfigurationChange::Now), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationInvalid }, EnforceConfigurationChange::Defer), HostapdException);
+    }
+
+    SECTION("Fails with missing shared secret input")
+    {
+        static constexpr RadiusEndpointConfiguration RadiusEndpointConfigurationInvalid{
+            .Type = RadiusEndpointType::Authentication,
+            .Address = RadiusServerIpValid1,
+            .SharedSecret = "",
+        };
+
+        REQUIRE_THROWS_AS(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationInvalid }, EnforceConfigurationChange::Now), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationInvalid }, EnforceConfigurationChange::Defer), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationInvalid }, EnforceConfigurationChange::Now), HostapdException);
+        REQUIRE_THROWS_AS(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationInvalid }, EnforceConfigurationChange::Defer), HostapdException);
+    }
+
+    SECTION("Succeeds with a port specified")
+    {
+        static constexpr RadiusEndpointConfiguration RadiusEndpointConfigurationValid{
+            .Type = RadiusEndpointType::Authentication,
+            .Address = RadiusServerIpValid1,
+            .Port = RadiusServerPortValid1,
+            .SharedSecret = RadiusSecretValid1,
+        };
+
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationValid }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationValid }, EnforceConfigurationChange::Defer));
+    }
+
+    SECTION("Succeeds without a port specified")
+    {
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1 }, EnforceConfigurationChange::Defer));
+    }
+
+    SECTION("Succeeds with a single authentication server specified")
+    {
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1 }, EnforceConfigurationChange::Defer));
+    }
+
+    SECTION("Succeeds with multiple authentication servers specified")
+    {
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationAuthenticationValid1 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationAuthenticationValid1 }, EnforceConfigurationChange::Defer));
     }
 }

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -828,3 +828,26 @@ TEST_CASE("Send SetBridgeInterface() command (root)", "[wpa][hostapd][client][re
         REQUIRE_NOTHROW(hostapd.SetBridgeInterface(BridgeInterfaceNameDefault, EnforceConfigurationChange::Defer));
     }
 }
+
+TEST_CASE("Send AddRadiusEndpoints() command (root)", "[wpa][hostapd][client][remote]")
+{
+    using namespace Wpa;
+    using namespace Wpa::Test;
+
+    static constexpr auto RadiusServerIpValid{ "127.0.0.1" };
+    static constexpr auto RadiusServerPortValid{ RadiusAuthenticationPortDefault };
+    static constexpr auto RadiusSecretValid{ "shared-secret" };
+    static constexpr RadiusEndpointConfiguration RadiusEndpointConfigurationValid1{
+        .Type = RadiusEndpointType::Authentication,
+        .Address = RadiusServerIpValid,
+        .SharedSecret = RadiusSecretValid,
+    };
+
+    Hostapd hostapd(WpaDaemonManager::InterfaceNameDefault);
+
+    SECTION("Doesn't throw")
+    {
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationValid1 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationValid1 }, EnforceConfigurationChange::Defer));
+    }
+}

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -847,8 +847,20 @@ TEST_CASE("Send AddRadiusEndpoints() command (root)", "[wpa][hostapd][client][re
         .Port = RadiusServerPortValid1,
         .SharedSecret = RadiusSecretValid1,
     };
+    static constexpr RadiusEndpointConfiguration RadiusEndpointConfigurationAuthenticationValid2{
+        .Type = RadiusEndpointType::Authentication,
+        .Address = RadiusServerIpValid2,
+        .Port = RadiusServerPortValid2,
+        .SharedSecret = RadiusSecretValid2,
+    };
 
     static constexpr RadiusEndpointConfiguration RadiusEndpointConfigurationAccountingValid1{
+        .Type = RadiusEndpointType::Accounting,
+        .Address = RadiusServerIpValid2,
+        .Port = RadiusServerPortValid2,
+        .SharedSecret = RadiusSecretValid2,
+    };
+    static constexpr RadiusEndpointConfiguration RadiusEndpointConfigurationAccountingValid2{
         .Type = RadiusEndpointType::Accounting,
         .Address = RadiusServerIpValid2,
         .Port = RadiusServerPortValid2,
@@ -932,7 +944,31 @@ TEST_CASE("Send AddRadiusEndpoints() command (root)", "[wpa][hostapd][client][re
 
     SECTION("Succeeds with multiple authentication servers specified")
     {
-        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationAuthenticationValid1 }, EnforceConfigurationChange::Now));
-        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationAuthenticationValid1 }, EnforceConfigurationChange::Defer));
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationAuthenticationValid2 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationAuthenticationValid2 }, EnforceConfigurationChange::Defer));
+    }
+
+    SECTION("Succeeds with a single accounting server specified")
+    {
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAccountingValid1 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAccountingValid1 }, EnforceConfigurationChange::Defer));
+    }
+
+    SECTION("Succeeds with multiple accounting servers specified")
+    {
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAccountingValid1, RadiusEndpointConfigurationAccountingValid2 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAccountingValid1, RadiusEndpointConfigurationAccountingValid2 }, EnforceConfigurationChange::Defer));
+    }
+
+    SECTION("Succeeds with single authentication and accounting servers specified")
+    {
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationAccountingValid1 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationAccountingValid1 }, EnforceConfigurationChange::Defer));
+    }
+
+    SECTION("Succeeds with mixtures of authentication and accounting servers specified")
+    {
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationAuthenticationValid2, RadiusEndpointConfigurationAccountingValid1, RadiusEndpointConfigurationAccountingValid2 }, EnforceConfigurationChange::Now));
+        REQUIRE_NOTHROW(hostapd.AddRadiusEndpoints({ RadiusEndpointConfigurationAuthenticationValid1, RadiusEndpointConfigurationAuthenticationValid2, RadiusEndpointConfigurationAccountingValid1, RadiusEndpointConfigurationAccountingValid2 }, EnforceConfigurationChange::Defer));
     }
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow configuring APs using hostapd with basic RADIUS settings including the server address, port, and shared secret.

### Technical Details

* Add `IHostapd::AddRadiusEndpoints` interface function for applying RADIUS endpoint configuration in hostapd adapter.
* Implement `Hostapd::AddRadiusEndpoints`.
* Add unit tests.

### Test Results

* All unit tests pass.

### Reviewer Focus

* Consider whether this minimum set of RADIUS configuration is sufficient for enterprise AP tests.

### Future Work

* Consume this functionality in neutral stack layer vias `IAccessPointController` et al.
* Expose ability to configure RADIUS settings in API layer.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
