### PR TITLE
Add API to configure 802.1X RADIUS settings

### DIFF
--- a/protocol/CMakeLists.txt
+++ b/protocol/CMakeLists.txt
@@ -6,7 +6,6 @@ set(NETREMOTE_PROTOCOL_PUBLIC_INCLUDE_PREFIX ${NETREMOTE_PROTOCOL_PUBLIC_INCLUDE
 set(PROTO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/protos)
 set(PROTO_DIR_BINARY ${CMAKE_CURRENT_BINARY_DIR}/${NETREMOTE_PROTOCOL_PUBLIC_INCLUDE_SUFFIX})
 set(PROTO_FILES
-    ${PROTO_DIR}/NetRemote.proto
     ${PROTO_DIR}/NetRemoteDataStream.proto
     ${PROTO_DIR}/NetRemoteDataStreamingService.proto
     ${PROTO_DIR}/NetRemoteNetwork.proto
@@ -27,7 +26,6 @@ set(PROTO_FILES
 # string(REGEX REPLACE "[.]proto$" ".pb.grpc.h" PROTO_HEADERS_GENERATED_GRPC "${PROTO_FILES_GENERATED}")
 #
 set(PROTO_HEADERS_GENERATED
-    ${PROTO_DIR_BINARY}/NetRemote.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteDataStream.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteDataStreamingService.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteNetwork.pb.h
@@ -38,7 +36,6 @@ set(PROTO_HEADERS_GENERATED
 )
 
 set(PROTO_HEADERS_GENERATED_GRPC
-    ${PROTO_DIR_BINARY}/NetRemote.grpc.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteDataStream.grpc.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteDataStreamingService.grpc.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteNetwork.grpc.pb.h

--- a/protocol/CMakeLists.txt
+++ b/protocol/CMakeLists.txt
@@ -11,6 +11,7 @@ set(PROTO_FILES
     ${PROTO_DIR}/NetRemoteNetwork.proto
     ${PROTO_DIR}/NetRemoteService.proto
     ${PROTO_DIR}/NetRemoteWifi.proto
+    ${PROTO_DIR}/Network8021x.proto
     ${PROTO_DIR}/NetworkCore.proto
     ${PROTO_DIR}/WifiCore.proto
 )
@@ -31,6 +32,7 @@ set(PROTO_HEADERS_GENERATED
     ${PROTO_DIR_BINARY}/NetRemoteNetwork.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteService.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteWifi.pb.h
+    ${PROTO_DIR_BINARY}/Network8021x.pb.h
     ${PROTO_DIR_BINARY}/NetworkCore.pb.h
     ${PROTO_DIR_BINARY}/WifiCore.pb.h
 )
@@ -41,6 +43,7 @@ set(PROTO_HEADERS_GENERATED_GRPC
     ${PROTO_DIR_BINARY}/NetRemoteNetwork.grpc.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteService.grpc.pb.h
     ${PROTO_DIR_BINARY}/NetRemoteWifi.grpc.pb.h
+    ${PROTO_DIR_BINARY}/Network8021x.grpc.pb.h
     ${PROTO_DIR_BINARY}/NetworkCore.grpc.pb.h
     ${PROTO_DIR_BINARY}/WifiCore.grpc.pb.h
 )

--- a/protocol/protos/NetRemote.proto
+++ b/protocol/protos/NetRemote.proto
@@ -1,4 +1,0 @@
-
-syntax = "proto3";
-
-package Microsoft.Net.Remote;

--- a/protocol/protos/NetRemoteDataStreamingService.proto
+++ b/protocol/protos/NetRemoteDataStreamingService.proto
@@ -5,7 +5,6 @@ package Microsoft.Net.Remote.Service;
 
 import "google/protobuf/empty.proto";
 
-import "NetRemote.proto";
 import "NetRemoteDataStream.proto";
 
 service NetRemoteDataStreaming

--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -19,4 +19,5 @@ service NetRemote
     rpc WifiAccessPointSetFrequencyBands (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsResult);
     rpc WifiAccessPointSetSsid (Microsoft.Net.Remote.Wifi.WifiAccessPointSetSsidRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetSsidResult);
     rpc WifiAccessPointSetNetworkBridge (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeResult);
+    rpc WifiAccessPointSet8021xConfiguration (Microsoft.Net.Remote.Wifi.WifiAccessPointSet8021xConfigurationRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSet8021xConfigurationResult);
 }

--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 
 package Microsoft.Net.Remote.Service;
 
-import "NetRemote.proto";
 import "NetRemoteNetwork.proto";
 import "NetRemoteWifi.proto";
 

--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -19,5 +19,5 @@ service NetRemote
     rpc WifiAccessPointSetFrequencyBands (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsResult);
     rpc WifiAccessPointSetSsid (Microsoft.Net.Remote.Wifi.WifiAccessPointSetSsidRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetSsidResult);
     rpc WifiAccessPointSetNetworkBridge (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeResult);
-    rpc WifiAccessPointSet8021xConfiguration (Microsoft.Net.Remote.Wifi.WifiAccessPointSet8021xConfigurationRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSet8021xConfigurationResult);
+    rpc WifiAccessPointSetDot1xConfiguration (Microsoft.Net.Remote.Wifi.WifiAccessPointSetDot1xConfigurationRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetDot1xConfigurationResult);
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -114,13 +114,13 @@ message WifiAccessPointSetSsidResult
     WifiAccessPointOperationStatus Status = 2;
 }
 
-message WifiAccessPointSet8021xConfigurationRequest
+message WifiAccessPointSetDot1xConfigurationRequest
 {
     string AccessPointId = 1;
-    Microsoft.Net.Wifi.Dot118021xConfiguration Configuration = 2;
+    Microsoft.Net.Wifi.Dot11Dot1xConfiguration Configuration = 2;
 }
 
-message WifiAccessPointSet8021xConfigurationResult
+message WifiAccessPointSetDot1xConfigurationResult
 {
     string AccessPointId = 1;
     WifiAccessPointOperationStatus Status = 2;

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -4,6 +4,7 @@ syntax = "proto3";
 package Microsoft.Net.Remote.Wifi;
 
 import "google/protobuf/any.proto";
+import "Network8021x.proto";
 import "WifiCore.proto";
 
 message WifiAccessPointsEnumerateResultItem
@@ -108,6 +109,18 @@ message WifiAccessPointSetSsidRequest
 }
 
 message WifiAccessPointSetSsidResult
+{
+    string AccessPointId = 1;
+    WifiAccessPointOperationStatus Status = 2;
+}
+
+message WifiAccessPointSet8021xConfigurationRequest
+{
+    string AccessPointId = 1;
+    Microsoft.Net.Wifi.Dot118021xConfiguration Configuration = 2;
+}
+
+message WifiAccessPointSet8021xConfigurationResult
 {
     string AccessPointId = 1;
     WifiAccessPointOperationStatus Status = 2;

--- a/protocol/protos/Network8021x.proto
+++ b/protocol/protos/Network8021x.proto
@@ -1,0 +1,4 @@
+
+syntax = "proto3";
+
+package Microsoft.Net;

--- a/protocol/protos/Network8021x.proto
+++ b/protocol/protos/Network8021x.proto
@@ -2,3 +2,25 @@
 syntax = "proto3";
 
 package Microsoft.Net;
+
+enum Dot1xRadiusServerEndpoint
+{
+    Dot1xRadiusServerEndpointUnknown = 0;
+    Dot1xRadiusServerEndpointAuthentication = 1;
+    Dot1xRadiusServerEndpointAccounting = 2;
+}
+
+message Dot1xRadiusServerEndpointConfiguration
+{
+    Dot1xRadiusServerEndpoint Endpoint = 1;
+    string Address = 2;
+    uint32 Port = 3;
+    string SharedSecret = 4;
+}
+
+message Dot1xRadiusConfiguration
+{
+    Dot1xRadiusServerEndpointConfiguration AuthenticationServer = 1;
+    Dot1xRadiusServerEndpointConfiguration AccountingServer = 2;
+    repeated Dot1xRadiusServerEndpointConfiguration FallbackServers = 3;
+}

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -196,7 +196,7 @@ message Dot11CipherSuiteConfiguration
     repeated Dot11CipherSuite CipherSuites = 2;
 }
 
-message Dot118021xConfiguration
+message Dot11Dot1xConfiguration
 {
     Dot1xRadiusConfiguration Radius = 1;
 }

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 
 package Microsoft.Net.Wifi;
 
+import "Network8021x.proto";
+
 enum Dot11FrequencyBand
 {
     option allow_alias = true;
@@ -192,6 +194,11 @@ message Dot11CipherSuiteConfiguration
 {
     Dot11SecurityProtocol SecurityProtocol = 1;
     repeated Dot11CipherSuite CipherSuites = 2;
+}
+
+message Dot118021xConfiguration
+{
+    Dot1xRadiusConfiguration Radius = 1;
 }
 
 message Dot11AccessPointConfiguration

--- a/src/common/dotnet/NetRemoteClient/NetRemoteClient.csproj
+++ b/src/common/dotnet/NetRemoteClient/NetRemoteClient.csproj
@@ -21,9 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\..\..\protocol\protos\NetRemote.proto" GrpcServices="None">
-      <Link>Protos\NetRemote.proto</Link>
-    </Protobuf>
     <Protobuf Include="..\..\..\protocol\protos\NetRemoteService.proto" GrpcServices="Client">
       <Link>Protos\NetRemoteService.proto</Link>
     </Protobuf>

--- a/src/common/dotnet/NetRemoteService/NetRemoteService.csproj
+++ b/src/common/dotnet/NetRemoteService/NetRemoteService.csproj
@@ -16,9 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\..\..\protocol\protos\NetRemote.proto" GrpcServices="None">
-      <Link>Protos\NetRemote.proto</Link>
-    </Protobuf>
     <Protobuf Include="..\..\..\protocol\protos\NetRemoteService.proto" GprcServices="Server">
       <Link>Protos\NetRemoteService.proto</Link>
     </Protobuf>

--- a/src/common/net/core/include/microsoft/net/Ieee8021xRadiusAuthentication.hxx
+++ b/src/common/net/core/include/microsoft/net/Ieee8021xRadiusAuthentication.hxx
@@ -64,7 +64,7 @@ struct Ieee8021xRadiusConfiguration
 {
     Ieee8021xRadiusServerEndpointConfiguration AuthenticationServer;
     std::optional<Ieee8021xRadiusServerEndpointConfiguration> AccountingServer;
-    std::vector<Ieee8021xRadiusServerEndpointConfiguration> ServerFallbacks;
+    std::vector<Ieee8021xRadiusServerEndpointConfiguration> FallbackServers;
 };
 } // namespace Microsoft::Net
 

--- a/src/common/net/core/include/microsoft/net/Ieee8021xRadiusAuthentication.hxx
+++ b/src/common/net/core/include/microsoft/net/Ieee8021xRadiusAuthentication.hxx
@@ -64,9 +64,7 @@ struct Ieee8021xRadiusConfiguration
 {
     Ieee8021xRadiusServerEndpointConfiguration AuthenticationServer;
     std::optional<Ieee8021xRadiusServerEndpointConfiguration> AccountingServer;
-
-    std::vector<Ieee8021xRadiusServerEndpointConfiguration> AuthenticationServerFallbacks;
-    std::vector<Ieee8021xRadiusServerEndpointConfiguration> AccountingServerFallbacks;
+    std::vector<Ieee8021xRadiusServerEndpointConfiguration> ServerFallbacks;
 };
 } // namespace Microsoft::Net
 

--- a/src/common/net/service-api/adapter/CMakeLists.txt
+++ b/src/common/net/service-api/adapter/CMakeLists.txt
@@ -8,11 +8,13 @@ set(NET_REMOTE_NET_ADAPTER_SERVICE_API_PUBLIC_INCLUDE_PREFIX ${NET_REMOTE_NET_AD
 target_sources(${PROJECT_NAME}-net-adapter-service-api
     PRIVATE
         ServiceApiNetworkAdapters.cxx
+        ServiceApiNetworkDot1xAdapters.cxx
     PUBLIC
     FILE_SET HEADERS
     BASE_DIRS ${NET_REMOTE_NET_ADAPTER_SERVICE_API_PUBLIC_INCLUDE}
     FILES
         ${NET_REMOTE_NET_ADAPTER_SERVICE_API_PUBLIC_INCLUDE_PREFIX}/ServiceApiNetworkAdapters.hxx 
+        ${NET_REMOTE_NET_ADAPTER_SERVICE_API_PUBLIC_INCLUDE_PREFIX}/ServiceApiNetworkDot1xAdapters.hxx 
 )
 
 target_link_libraries(${PROJECT_NAME}-net-adapter-service-api

--- a/src/common/net/service-api/adapter/ServiceApiNetworkDot1xAdapters.cxx
+++ b/src/common/net/service-api/adapter/ServiceApiNetworkDot1xAdapters.cxx
@@ -1,0 +1,81 @@
+
+#include <iterator>
+#include <ranges>
+
+#include <microsoft/net/ServiceApiNetworkDot1xAdapters.hxx>
+
+namespace Microsoft::Net
+{
+Dot1xRadiusServerEndpointConfiguration
+ToServiceDot1xRadiusServerEndpointConfiguration(const Ieee8021xRadiusServerEndpointConfiguration& ieee8021xRadiusServerEndpointConfiguration) noexcept
+{
+    Dot1xRadiusServerEndpointConfiguration dot1xRadiusServerEndpointConfiguration;
+    dot1xRadiusServerEndpointConfiguration.set_endpoint(ToServiceDot1xRadiusServerEndpoint(ieee8021xRadiusServerEndpointConfiguration.Type));
+    dot1xRadiusServerEndpointConfiguration.set_address(ieee8021xRadiusServerEndpointConfiguration.Address);
+    if (ieee8021xRadiusServerEndpointConfiguration.Port.has_value()) {
+        dot1xRadiusServerEndpointConfiguration.set_port(ieee8021xRadiusServerEndpointConfiguration.Port.value());
+    }
+    *dot1xRadiusServerEndpointConfiguration.mutable_sharedsecret() = {
+        std::cbegin(ieee8021xRadiusServerEndpointConfiguration.SharedSecret),
+        std::cend(ieee8021xRadiusServerEndpointConfiguration.SharedSecret),
+    };
+
+    return dot1xRadiusServerEndpointConfiguration;
+}
+
+Ieee8021xRadiusServerEndpointConfiguration
+FromServiceDot1xRadiusServerEndpointConfiguration(const Dot1xRadiusServerEndpointConfiguration& dot1xRadiusServerEndpointConfiguration) noexcept
+{
+    Ieee8021xRadiusServerEndpointConfiguration ieee8021xRadiusServerEndpointConfiguration;
+    ieee8021xRadiusServerEndpointConfiguration.Type = FromServiceDot1xRadiusServerEndpoint(dot1xRadiusServerEndpointConfiguration.endpoint());
+    ieee8021xRadiusServerEndpointConfiguration.Address = dot1xRadiusServerEndpointConfiguration.address();
+    if (dot1xRadiusServerEndpointConfiguration.port() != 0) {
+        ieee8021xRadiusServerEndpointConfiguration.Port = dot1xRadiusServerEndpointConfiguration.port();
+    }
+    ieee8021xRadiusServerEndpointConfiguration.SharedSecret = {
+        std::cbegin(dot1xRadiusServerEndpointConfiguration.sharedsecret()),
+        std::cend(dot1xRadiusServerEndpointConfiguration.sharedsecret()),
+    };
+
+    return ieee8021xRadiusServerEndpointConfiguration;
+}
+
+Dot1xRadiusConfiguration
+ToServiceDot1xRadiusConfiguration(const Ieee8021xRadiusConfiguration& ieee8021xRadiusConfiguration) noexcept
+{
+    Dot1xRadiusConfiguration dot1xRadiusConfiguration;
+    *dot1xRadiusConfiguration.mutable_authenticationserver() = ToServiceDot1xRadiusServerEndpointConfiguration(ieee8021xRadiusConfiguration.AuthenticationServer);
+    if (ieee8021xRadiusConfiguration.AccountingServer.has_value()) {
+        *dot1xRadiusConfiguration.mutable_accountingserver() = ToServiceDot1xRadiusServerEndpointConfiguration(ieee8021xRadiusConfiguration.AccountingServer.value());
+    }
+    if (!std::empty(ieee8021xRadiusConfiguration.FallbackServers)) {
+        std::vector<Dot1xRadiusServerEndpointConfiguration> fallbackServers{ std::size(ieee8021xRadiusConfiguration.FallbackServers) };
+        std::ranges::transform(ieee8021xRadiusConfiguration.FallbackServers, std::begin(fallbackServers), ToServiceDot1xRadiusServerEndpointConfiguration);
+        *dot1xRadiusConfiguration.mutable_fallbackservers() = {
+            std::make_move_iterator(std::begin(fallbackServers)),
+            std::make_move_iterator(std::end(fallbackServers)),
+        };
+    }
+
+    return dot1xRadiusConfiguration;
+}
+
+Ieee8021xRadiusConfiguration
+FromServiceDot1xRadiusConfiguration(const Dot1xRadiusConfiguration& dot1xRadiusConfiguration) noexcept
+{
+    Ieee8021xRadiusConfiguration ieee8021xRadiusConfiguration;
+    if (dot1xRadiusConfiguration.has_authenticationserver()) {
+        ieee8021xRadiusConfiguration.AuthenticationServer = FromServiceDot1xRadiusServerEndpointConfiguration(dot1xRadiusConfiguration.authenticationserver());
+    }
+    if (dot1xRadiusConfiguration.has_accountingserver()) {
+        ieee8021xRadiusConfiguration.AccountingServer = FromServiceDot1xRadiusServerEndpointConfiguration(dot1xRadiusConfiguration.accountingserver());
+    }
+    if (!std::empty(dot1xRadiusConfiguration.fallbackservers())) {
+        std::vector<Ieee8021xRadiusServerEndpointConfiguration> fallbackServers{ static_cast<std::size_t>(std::size(dot1xRadiusConfiguration.fallbackservers())) };
+        std::ranges::transform(dot1xRadiusConfiguration.fallbackservers(), std::begin(fallbackServers), FromServiceDot1xRadiusServerEndpointConfiguration);
+        ieee8021xRadiusConfiguration.FallbackServers = std::move(fallbackServers);
+    }
+
+    return ieee8021xRadiusConfiguration;
+}
+} // namespace Microsoft::Net

--- a/src/common/net/service-api/adapter/include/microsoft/net/ServiceApiNetworkDot1xAdapters.hxx
+++ b/src/common/net/service-api/adapter/include/microsoft/net/ServiceApiNetworkDot1xAdapters.hxx
@@ -1,0 +1,90 @@
+
+#ifndef SERVICE_API_NETWORK_DOT1X_ADAPTERS_HXX
+#define SERVICE_API_NETWORK_DOT1X_ADAPTERS_HXX
+
+#include <microsoft/net/Ieee8021xRadiusAuthentication.hxx>
+#include <microsoft/net/remote/protocol/Network8021x.pb.h>
+
+namespace Microsoft::Net
+{
+/**
+ * @brief Convert neutral type radius server endpoint to the corresponding service type.
+ *
+ * @param ieee8021xRadiusServerEndpointType The neutral type radius server endpoint.
+ * @return constexpr Dot1xRadiusServerEndpoint The corresponding service type radius server endpoint.
+ */
+constexpr Dot1xRadiusServerEndpoint
+ToServiceDot1xRadiusServerEndpoint(Ieee8021xRadiusServerEndpointType ieee8021xRadiusServerEndpointType) noexcept
+{
+    switch (ieee8021xRadiusServerEndpointType) {
+    case Ieee8021xRadiusServerEndpointType::Authentication:
+        return Dot1xRadiusServerEndpointAuthentication;
+    case Ieee8021xRadiusServerEndpointType::Accounting:
+        return Dot1xRadiusServerEndpointAccounting;
+    case Ieee8021xRadiusServerEndpointType::Unknown:
+        [[fallthrough]];
+    default:
+        return Dot1xRadiusServerEndpointUnknown;
+    }
+}
+
+/**
+ * @brief Convert service type radius server endpoint to the corresponding neutral type.
+ *
+ * @param dot1xRadiusServerEndpoint The service type radius server endpoint.
+ * @return constexpr Ieee8021xRadiusServerEndpointType The corresponding neutral type radius server endpoint.
+ */
+constexpr Ieee8021xRadiusServerEndpointType
+FromServiceDot1xRadiusServerEndpoint(Dot1xRadiusServerEndpoint dot1xRadiusServerEndpoint) noexcept
+{
+    switch (dot1xRadiusServerEndpoint) {
+    case Dot1xRadiusServerEndpointAuthentication:
+        return Ieee8021xRadiusServerEndpointType::Authentication;
+    case Dot1xRadiusServerEndpointAccounting:
+        return Ieee8021xRadiusServerEndpointType::Accounting;
+    case Dot1xRadiusServerEndpointUnknown:
+        [[fallthrough]];
+    default:
+        return Ieee8021xRadiusServerEndpointType::Unknown;
+    }
+}
+
+/**
+ * @brief Convert neutral type radius server endpoint configuration to the corresponding service type.
+ *
+ * @param ieee8021xRadiusServerEndpointConfiguration The neutral type radius server endpoint configuration.
+ * @return Dot1xRadiusServerEndpointConfiguration The corresponding service type radius server endpoint configuration.
+ */
+Dot1xRadiusServerEndpointConfiguration
+ToServiceDot1xRadiusServerEndpointConfiguration(const Ieee8021xRadiusServerEndpointConfiguration& ieee8021xRadiusServerEndpointConfiguration) noexcept;
+
+/**
+ * @brief Convert service type radius server endpoint configuration to the corresponding neutral type.
+ *
+ * @param dot1xRadiusServerEndpointConfiguration The service type radius server endpoint configuration.
+ * @return Ieee8021xRadiusServerEndpointConfiguration The corresponding neutral type radius server endpoint configuration.
+ */
+Ieee8021xRadiusServerEndpointConfiguration
+FromServiceDot1xRadiusServerEndpointConfiguration(const Dot1xRadiusServerEndpointConfiguration& dot1xRadiusServerEndpointConfiguration) noexcept;
+
+/**
+ * @brief Convert neutral type radius configuration to the corresponding service type.
+ *
+ * @param ieee8021xRadiusConfiguration The neutral type radius configuration.
+ * @return Dot1xRadiusConfiguration The corresponding service type radius configuration.
+ */
+Dot1xRadiusConfiguration
+ToServiceDot1xRadiusConfiguration(const Ieee8021xRadiusConfiguration& ieee8021xRadiusConfiguration) noexcept;
+
+/**
+ * @brief Convert service type radius configuration to the corresponding neutral type.
+ *
+ * @param dot1xRadiusConfiguration The service type radius configuration.
+ * @return Ieee8021xRadiusConfiguration The corresponding neutral type radius configuration.
+ */
+Ieee8021xRadiusConfiguration
+FromServiceDot1xRadiusConfiguration(const Dot1xRadiusConfiguration& dot1xRadiusConfiguration) noexcept;
+
+} // namespace Microsoft::Net
+
+#endif // SERVICE_API_NETWORK_DOT1X_ADAPTERS_HXX

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -1074,9 +1074,100 @@ NetRemoteService::WifiAccessPointSetSsidImpl(std::string_view accessPointId, con
     return wifiOperationStatus;
 }
 
+namespace detail
+{
+/**
+ * @brief The result of validating an 802.1x RADIUS server endpoint configuration.
+ */
+enum class Dot1xRadiusServerEndpointConfigurationValidationResult {
+    Valid,
+    MissingAddress,
+    MissingSharedSecret,
+};
+
+/**
+ * @brief Get a string representation of the 802.1x RADIUS server endpoint configuration validation result.
+ *
+ * @param validationResult The validation result.
+ * @return constexpr auto
+ */
+constexpr auto
+GetDot1xRadiusServerEndpointConfigurationValidationResultMessage(Dot1xRadiusServerEndpointConfigurationValidationResult validationResult) noexcept
+{
+    switch (validationResult) {
+    case Dot1xRadiusServerEndpointConfigurationValidationResult::MissingAddress:
+        return "missing address";
+    case Dot1xRadiusServerEndpointConfigurationValidationResult::MissingSharedSecret:
+        return "missing shared secret";
+    case Dot1xRadiusServerEndpointConfigurationValidationResult::Valid:
+        [[fallthrough]];
+    default:
+        return "valid";
+    }
+}
+
+/**
+ * @brief Check if the 802.1x RADIUS server endpoint configuration is valid.
+ *
+ * @param validationResult The validation result.
+ * @return true
+ * @return false
+ */
+constexpr bool
+IsDot1xRadiusServerEndpointConfigurationValid(Dot1xRadiusServerEndpointConfigurationValidationResult validationResult) noexcept
+{
+    return (validationResult == Dot1xRadiusServerEndpointConfigurationValidationResult::Valid);
+}
+
+/**
+ * @brief Validate the 802.1x RADIUS server endpoint configuration.
+ *
+ * @param dot1xRadiusServerEndpointConfiguration The 802.1x RADIUS server endpoint configuration.
+ * @return Dot1xRadiusServerEndpointConfigurationValidationResult The validation result.
+ */
+Dot1xRadiusServerEndpointConfigurationValidationResult
+ValidateDot1xRadiusServerEndpointConfiguration(const Dot1xRadiusServerEndpointConfiguration& dot1xRadiusServerEndpointConfiguration) noexcept
+{
+    if (std::empty(dot1xRadiusServerEndpointConfiguration.address())) {
+        return Dot1xRadiusServerEndpointConfigurationValidationResult::MissingAddress;
+    }
+    if (std::empty(dot1xRadiusServerEndpointConfiguration.sharedsecret())) {
+        return Dot1xRadiusServerEndpointConfigurationValidationResult::MissingSharedSecret;
+    }
+    return Dot1xRadiusServerEndpointConfigurationValidationResult::Valid;
+}
+
+/**
+ * @brief Get a string representation of the 802.1x RADIUS server endpoint.
+ *
+ * @param endpoint The 802.1x RADIUS server endpoint.
+ * @return constexpr std::string_view
+ */
+constexpr std::string_view
+GetDot1xRadiusServerEndpointName(Dot1xRadiusServerEndpoint dot1xRadiusServerEndpoint) noexcept
+{
+    switch (dot1xRadiusServerEndpoint) {
+    case Dot1xRadiusServerEndpoint::Dot1xRadiusServerEndpointAuthentication:
+        return "authentication";
+    case Dot1xRadiusServerEndpoint::Dot1xRadiusServerEndpointAccounting:
+        return "accounting";
+    case Dot1xRadiusServerEndpoint::Dot1xRadiusServerEndpointUnknown:
+        [[fallthrough]];
+    default:
+        return "unknown";
+    }
+}
+} // namespace detail
+
 WifiAccessPointOperationStatus
 NetRemoteService::WifiAccessPointSetDot1xConfigurationImpl(std::string_view accessPointId, const Dot11Dot1xConfiguration& dot11Dot1xConfiguration, std::shared_ptr<IAccessPointController> accessPointController)
 {
+    using detail::Dot1xRadiusServerEndpointConfigurationValidationResult;
+    using detail::GetDot1xRadiusServerEndpointConfigurationValidationResultMessage;
+    using detail::GetDot1xRadiusServerEndpointName;
+    using detail::IsDot1xRadiusServerEndpointConfigurationValid;
+    using detail::ValidateDot1xRadiusServerEndpointConfiguration;
+
     WifiAccessPointOperationStatus wifiOperationStatus{};
 
     // Validate basic parameters in the request.
@@ -1110,16 +1201,33 @@ NetRemoteService::WifiAccessPointSetDot1xConfigurationImpl(std::string_view acce
         }
 
         // Validate the authentication server configuration.
-        {
-            const auto& dot1xAuthenticationServer = dot1xRadiusConfiguration.authenticationserver();
-            if (std::empty(dot1xAuthenticationServer.address())) {
+        auto dot1xRadiusServerEndpointConfigurationValidationResult = ValidateDot1xRadiusServerEndpointConfiguration(dot1xRadiusConfiguration.authenticationserver());
+        if (!IsDot1xRadiusServerEndpointConfigurationValid(dot1xRadiusServerEndpointConfigurationValidationResult)) {
+            auto validationError = GetDot1xRadiusServerEndpointConfigurationValidationResultMessage(dot1xRadiusServerEndpointConfigurationValidationResult);
+            wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+            wifiOperationStatus.set_message(std::format("802.1x RADIUS primary authentication server configuration {}", std::move(validationError)));
+            return wifiOperationStatus;
+        }
+
+        // Validate accounting server if present.
+        if (dot1xRadiusConfiguration.has_accountingserver()) {
+            const auto& dot1xRadiusAccountingServerEndpointConfiguration = dot1xRadiusConfiguration.accountingserver();
+            dot1xRadiusServerEndpointConfigurationValidationResult = ValidateDot1xRadiusServerEndpointConfiguration(dot1xRadiusAccountingServerEndpointConfiguration);
+            if (!IsDot1xRadiusServerEndpointConfigurationValid(dot1xRadiusServerEndpointConfigurationValidationResult)) {
+                auto validationError = GetDot1xRadiusServerEndpointConfigurationValidationResultMessage(dot1xRadiusServerEndpointConfigurationValidationResult);
                 wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
-                wifiOperationStatus.set_message("No 802.1x RADIUS authentication server address provided");
+                wifiOperationStatus.set_message(std::format("802.1x RADIUS primary accounting server configuration {}", std::move(validationError)));
                 return wifiOperationStatus;
             }
-            if (std::empty(dot1xAuthenticationServer.sharedsecret())) {
+        }
+
+        // Validate fallback servers.
+        for (const auto& fallbackServer : dot1xRadiusConfiguration.fallbackservers()) {
+            dot1xRadiusServerEndpointConfigurationValidationResult = ValidateDot1xRadiusServerEndpointConfiguration(fallbackServer);
+            if (!IsDot1xRadiusServerEndpointConfigurationValid(dot1xRadiusServerEndpointConfigurationValidationResult)) {
+                auto validationError = GetDot1xRadiusServerEndpointConfigurationValidationResultMessage(dot1xRadiusServerEndpointConfigurationValidationResult);
                 wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
-                wifiOperationStatus.set_message("No 802.1x RADIUS authentication server shared secret provided");
+                wifiOperationStatus.set_message(std::format("802.1x RADIUS fallback {} server configuration {}", GetDot1xRadiusServerEndpointName(fallbackServer.endpoint()), std::move(validationError)));
                 return wifiOperationStatus;
             }
         }

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -408,11 +408,11 @@ NetRemoteService::WifiAccessPointSetNetworkBridge([[maybe_unused]] grpc::ServerC
 }
 
 grpc::Status
-NetRemoteService::WifiAccessPointSet8021xConfiguration([[maybe_unused]] grpc::ServerContext* context, const WifiAccessPointSet8021xConfigurationRequest* request, WifiAccessPointSet8021xConfigurationResult* result)
+NetRemoteService::WifiAccessPointSetDot1xConfiguration([[maybe_unused]] grpc::ServerContext* context, const WifiAccessPointSetDot1xConfigurationRequest* request, WifiAccessPointSetDot1xConfigurationResult* result)
 {
     const NetRemoteWifiApiTrace traceMe{ request->accesspointid(), result->mutable_status() };
 
-    auto wifiOperationStatus = WifiAccessPointSet8021xConfigurationImpl(request->accesspointid(), request->configuration());
+    auto wifiOperationStatus = WifiAccessPointSetDot1xConfigurationImpl(request->accesspointid(), request->configuration());
     result->set_accesspointid(request->accesspointid());
     *result->mutable_status() = std::move(wifiOperationStatus);
 
@@ -1074,12 +1074,12 @@ NetRemoteService::WifiAccessPointSetSsidImpl(std::string_view accessPointId, con
 }
 
 WifiAccessPointOperationStatus
-NetRemoteService::WifiAccessPointSet8021xConfigurationImpl(std::string_view accessPointId, const Dot118021xConfiguration& dot118021xConfiguration, std::shared_ptr<IAccessPointController> accessPointController)
+NetRemoteService::WifiAccessPointSetDot1xConfigurationImpl(std::string_view accessPointId, const Dot11Dot1xConfiguration& Dot11Dot1xConfiguration, std::shared_ptr<IAccessPointController> accessPointController)
 {
     WifiAccessPointOperationStatus wifiOperationStatus{};
 
     // Validate basic parameters in the request.
-    if (!dot118021xConfiguration.has_radius()) {
+    if (!Dot11Dot1xConfiguration.has_radius()) {
         wifiOperationStatus.set_code(WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
         wifiOperationStatus.set_message("No EAP (RADIUS) configuration provided");
         return wifiOperationStatus;

--- a/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
@@ -144,7 +144,7 @@ private:
      * @return grpc::Status
      */
     grpc::Status
-    WifiAccessPointSet8021xConfiguration(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointSet8021xConfigurationRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointSet8021xConfigurationResult* result) override;
+    WifiAccessPointSetDot1xConfiguration(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointSetDot1xConfigurationRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointSetDot1xConfigurationResult* result) override;
 
 protected:
     /**
@@ -296,12 +296,12 @@ protected:
      * @brief Set the IEEE 802.1x configuration for the access point.
      * 
      * @param accessPointId The access point identifier.
-     * @param dot11Network8021xConfiguration The new IEEE 802.1x configuration to set.
+     * @param dot11Dot1xConfiguration The new IEEE 802.1x configuration to set.
      * @param accessPointController  The access point controller for the specified access point (optional).
      * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus 
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
-    WifiAccessPointSet8021xConfigurationImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot118021xConfiguration& dot118021xConfiguration, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
+    WifiAccessPointSetDot1xConfigurationImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11Dot1xConfiguration& dot11Dot1xConfiguration, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
 private:
     std::shared_ptr<Microsoft::Net::NetworkManager> m_networkManager;

--- a/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
@@ -10,6 +10,7 @@
 #include <microsoft/net/NetworkManager.hxx>
 #include <microsoft/net/remote/protocol/NetRemoteService.grpc.pb.h>
 #include <microsoft/net/remote/protocol/NetRemoteWifi.pb.h>
+#include <microsoft/net/remote/protocol/Network8021x.pb.h>
 #include <microsoft/net/remote/protocol/NetworkCore.pb.h>
 #include <microsoft/net/remote/protocol/WifiCore.pb.h>
 #include <microsoft/net/remote/service/NetRemoteService.hxx>
@@ -114,11 +115,11 @@ private:
 
     /**
      * @brief Set the SSID of the access point.
-     * 
-     * @param context 
-     * @param request 
-     * @param result 
-     * @return grpc::Status 
+     *
+     * @param context
+     * @param request
+     * @param result
+     * @return grpc::Status
      */
     grpc::Status
     WifiAccessPointSetSsid(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointSetSsidRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointSetSsidResult* result) override;
@@ -133,6 +134,17 @@ private:
      */
     grpc::Status
     WifiAccessPointSetNetworkBridge(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointSetNetworkBridgeRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointSetNetworkBridgeResult* result) override;
+
+    /**
+     * @brief Set the IEEE 802.1x configuration for the access point.
+     *
+     * @param context
+     * @param request
+     * @param result
+     * @return grpc::Status
+     */
+    grpc::Status
+    WifiAccessPointSet8021xConfiguration(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointSet8021xConfigurationRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointSet8021xConfigurationResult* result) override;
 
 protected:
     /**
@@ -279,6 +291,17 @@ protected:
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
     WifiAccessPointSetSsidImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11Ssid& dot11Ssid, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
+
+    /**
+     * @brief Set the IEEE 802.1x configuration for the access point.
+     * 
+     * @param accessPointId The access point identifier.
+     * @param dot11Network8021xConfiguration The new IEEE 802.1x configuration to set.
+     * @param accessPointController  The access point controller for the specified access point (optional).
+     * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus 
+     */
+    Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+    WifiAccessPointSet8021xConfigurationImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot118021xConfiguration& dot118021xConfiguration, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
 private:
     std::shared_ptr<Microsoft::Net::NetworkManager> m_networkManager;

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -458,7 +458,7 @@ AccessPointControllerLinux::SetRadiusConfiguration(Ieee8021xRadiusConfiguration 
 
     // Allocate space for WPA RADIUS endpoint configurations.
     const bool hasPrimaryAccountingServer = radiusConfiguration.AccountingServer.has_value();
-    const std::size_t numRadiusServers = 1 + std::size(radiusConfiguration.AuthenticationServerFallbacks) + std::size(radiusConfiguration.AccountingServerFallbacks) + (hasPrimaryAccountingServer ? 1 : 0);
+    const std::size_t numRadiusServers = 1 + std::size(radiusConfiguration.ServerFallbacks) + (hasPrimaryAccountingServer ? 1 : 0);
     std::vector<Wpa::RadiusEndpointConfiguration> radiusEndpointConfigurations{ numRadiusServers };
 
     // First, convert the primary authentication server.
@@ -471,7 +471,7 @@ AccessPointControllerLinux::SetRadiusConfiguration(Ieee8021xRadiusConfiguration 
     }
 
     // Last, convert all secondary authentication and accounting servers.
-    std::ranges::transform(radiusConfiguration.AuthenticationServerFallbacks, radiusEndpointConfigurationsIter, Ieee8021xRadiusServerEndpointConfigurationToWpaRadiusEndpointConfiguration);
+    std::ranges::transform(radiusConfiguration.ServerFallbacks, radiusEndpointConfigurationsIter, Ieee8021xRadiusServerEndpointConfigurationToWpaRadiusEndpointConfiguration);
 
     // Attempt to add the WPA RADIUS endpoint configurations.
     try {

--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -458,7 +458,7 @@ AccessPointControllerLinux::SetRadiusConfiguration(Ieee8021xRadiusConfiguration 
 
     // Allocate space for WPA RADIUS endpoint configurations.
     const bool hasPrimaryAccountingServer = radiusConfiguration.AccountingServer.has_value();
-    const std::size_t numRadiusServers = 1 + std::size(radiusConfiguration.ServerFallbacks) + (hasPrimaryAccountingServer ? 1 : 0);
+    const std::size_t numRadiusServers = 1 + std::size(radiusConfiguration.FallbackServers) + (hasPrimaryAccountingServer ? 1 : 0);
     std::vector<Wpa::RadiusEndpointConfiguration> radiusEndpointConfigurations{ numRadiusServers };
 
     // First, convert the primary authentication server.
@@ -471,7 +471,7 @@ AccessPointControllerLinux::SetRadiusConfiguration(Ieee8021xRadiusConfiguration 
     }
 
     // Last, convert all secondary authentication and accounting servers.
-    std::ranges::transform(radiusConfiguration.ServerFallbacks, radiusEndpointConfigurationsIter, Ieee8021xRadiusServerEndpointConfigurationToWpaRadiusEndpointConfiguration);
+    std::ranges::transform(radiusConfiguration.FallbackServers, radiusEndpointConfigurationsIter, Ieee8021xRadiusServerEndpointConfigurationToWpaRadiusEndpointConfiguration);
 
     // Attempt to add the WPA RADIUS endpoint configurations.
     try {

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -908,6 +908,48 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
         REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
     }
 
+    SECTION("RADIUS: Fails with missing accounting server address")
+    {
+        WifiAccessPointSetDot1xConfigurationRequest request{};
+        request.set_accesspointid(InterfaceName);
+        auto& radiusConfiguration = *request.mutable_configuration()->mutable_radius();
+        auto& radiusAuthenticationServer = *radiusConfiguration.mutable_authenticationserver();
+        *radiusAuthenticationServer.mutable_address() = RadiusServerAddressValid;
+        *radiusAuthenticationServer.mutable_sharedsecret() = RadiusServerSharedSecretValid;
+        auto& radiusAccountingServer = *radiusConfiguration.mutable_accountingserver();
+        radiusAccountingServer.set_address("");
+        radiusAccountingServer.set_sharedsecret(RadiusServerSharedSecretValid);
+
+        WifiAccessPointSetDot1xConfigurationResult result{};
+        grpc::ClientContext clientContext{};
+
+        auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+        REQUIRE(status.ok());
+        REQUIRE(result.has_status());
+        REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+    }
+
+    SECTION("RADIUS: Fails with missing accounting server shared secret")
+    {
+        WifiAccessPointSetDot1xConfigurationRequest request{};
+        request.set_accesspointid(InterfaceName);
+        auto& radiusConfiguration = *request.mutable_configuration()->mutable_radius();
+        auto& radiusAuthenticationServer = *radiusConfiguration.mutable_authenticationserver();
+        *radiusAuthenticationServer.mutable_address() = RadiusServerAddressValid;
+        *radiusAuthenticationServer.mutable_sharedsecret() = RadiusServerSharedSecretValid;
+        auto& radiusAccountingServer = *radiusConfiguration.mutable_accountingserver();
+        radiusAccountingServer.set_address(RadiusServerAddressValid);
+        radiusAccountingServer.set_sharedsecret("");
+
+        WifiAccessPointSetDot1xConfigurationResult result{};
+        grpc::ClientContext clientContext{};
+
+        auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+        REQUIRE(status.ok());
+        REQUIRE(result.has_status());
+        REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
+    }
+
     SECTION("RADIUS: Succeeds with minimum configuration")
     {
         WifiAccessPointSetDot1xConfigurationRequest request{};
@@ -916,6 +958,26 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
         auto& radiusAuthenticationServer = *radiusConfiguration.mutable_authenticationserver();
         *radiusAuthenticationServer.mutable_address() = RadiusServerAddressValid;
         *radiusAuthenticationServer.mutable_sharedsecret() = RadiusServerSharedSecretValid;
+
+        WifiAccessPointSetDot1xConfigurationResult result{};
+        grpc::ClientContext clientContext{};
+        auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+        REQUIRE(status.ok());
+        REQUIRE(result.has_status());
+        REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
+    }
+
+    SECTION("RADIUS: Succeeds with primary authentication and accounting servers")
+    {
+        WifiAccessPointSetDot1xConfigurationRequest request{};
+        request.set_accesspointid(InterfaceName);
+        auto& radiusConfiguration = *request.mutable_configuration()->mutable_radius();
+        auto& radiusAuthenticationServer = *radiusConfiguration.mutable_authenticationserver();
+        *radiusAuthenticationServer.mutable_address() = RadiusServerAddressValid;
+        *radiusAuthenticationServer.mutable_sharedsecret() = RadiusServerSharedSecretValid;
+        auto& radiusAccountingServer = *radiusConfiguration.mutable_accountingserver();
+        radiusAccountingServer.set_address(RadiusServerAddressValid);
+        radiusAccountingServer.set_sharedsecret(RadiusServerSharedSecretValid);
 
         WifiAccessPointSetDot1xConfigurationResult result{};
         grpc::ClientContext clientContext{};


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow RADIUS settings to be configured for access points using enterprise AKMs.

### Technical Details

* Consolidate authentication and accounting servers into single collection field.
* Add `WifiAccessPointSetDot1xConfiguration` API to configure 802.1X settings, including RADIUS settings.
* Add unit tests for `WifiAccessPointSetDot1xConfiguration`.
* Add protobuf definitions for general 802.1X and RADIUS concepts.
* Add  `Dot11Dot1xConfiguration` for holding 802.1X configuration for 802.11 Wi-Fi access points.

### Test Results

* All unit tests pass.

### Reviewer Focus

* Consider whether the ``WifiAccessPointSetDot1xConfiguration` API is sufficient for testing enterprise AKM scenarios.

### Future Work

* Expand `WifiAccessPointEnable` API to include 802.1X settings.
* Extend `netremote-cli` to accept 802.1X settings.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
