### PR TITLE
Enable use of IEEE 802.1X AKM in hostapd adaption layer

### DIFF
--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -4,7 +4,6 @@ syntax = "proto3";
 package Microsoft.Net.Remote.Wifi;
 
 import "google/protobuf/any.proto";
-import "Network8021x.proto";
 import "WifiCore.proto";
 
 message WifiAccessPointsEnumerateResultItem

--- a/src/linux/external/hostap/hostapd/.config
+++ b/src/linux/external/hostap/hostapd/.config
@@ -183,6 +183,14 @@ CONFIG_SAE=y
 # Extra enabled
 CONFIG_SAE_PK=y
 
+# WPA3 Enterprise Suite B
+# [Manually enabled, not documented]
+CONFIG_SUITEB=y
+CONFIG_SUITEB192=y
+
+# Pre-Association Security Negotiation (PASN)
+# CONFIG_PASN=y
+
 # Remove debugging code that is printing out debug messages to stdout.
 # This can be used to reduce the size of the hostapd considerably if debugging
 # code is not needed.
@@ -405,7 +413,7 @@ CONFIG_FILS_SK_PFS=y
 
 # Include internal line edit mode in hostapd_cli. This can be used to provide
 # limited command line editing and history support.
-#CONFIG_WPA_CLI_EDIT=y
+CONFIG_WPA_CLI_EDIT=y
 
 # Opportunistic Wireless Encryption (OWE)
 # Experimental implementation of draft-harkins-owe-07.txt

--- a/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
+++ b/src/linux/wifi/core/Ieee80211WpaAdapters.cxx
@@ -107,7 +107,7 @@ Ieee80211AkmSuiteToWpaKeyManagement(Ieee80211AkmSuite ieee80211AkmSuite) noexcep
 {
     switch (ieee80211AkmSuite) {
     case Ieee80211AkmSuite::Ieee8021x:
-        return WpaKeyManagement::Ieee80211x;
+        return WpaKeyManagement::Ieee8021x;
     case Ieee80211AkmSuite::Psk:
         return WpaKeyManagement::Psk;
     case Ieee80211AkmSuite::Ft8021x:
@@ -123,9 +123,9 @@ Ieee80211AkmSuiteToWpaKeyManagement(Ieee80211AkmSuite ieee80211AkmSuite) noexcep
     case Ieee80211AkmSuite::FtSae:
         return WpaKeyManagement::FtSae;
     case Ieee80211AkmSuite::Ieee8021xSuiteB:
-        return WpaKeyManagement::Ieee80211xSuiteB;
+        return WpaKeyManagement::Ieee8021xSuiteB;
     case Ieee80211AkmSuite::Ieee8011xSuiteB192:
-        return WpaKeyManagement::Ieee80211xSuiteB192;
+        return WpaKeyManagement::Ieee8021xSuiteB192;
     case Ieee80211AkmSuite::Ft8021xSha384:
         return WpaKeyManagement::FtIeee8021xSha384;
     case Ieee80211AkmSuite::FilsSha256:

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -294,7 +294,9 @@ Hostapd::SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceC
             keyManagementPropertyValueBuilder << keyManagementValue << ' ';
         }
 
-        keyManagementPropertyValue = keyManagementPropertyValueBuilder.str();
+        auto keyManagementPropertyValueView = keyManagementPropertyValueBuilder.view();
+        keyManagementPropertyValueView.remove_suffix(1); // Remove the trailing space.
+        keyManagementPropertyValue = keyManagementPropertyValueView;
     }
 
     // If any key managements to set support fast-transition, set the network access server (NAS) identifier property to

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -303,6 +303,15 @@ Hostapd::SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceC
         SetNetworkAccessServerId();
     }
 
+    // If any key managements to set support IEEE 802.1X, set the IEEE 802.1X property to enabled.
+    if (std::ranges::any_of(keyManagements, IsKeyManagementIeee8021x)) {
+        try {
+            SetProperty(ProtocolHostapd::PropertyNameIeee8021X, ProtocolHostapd::PropertyEnabled, EnforceConfigurationChange::Defer);
+        } catch (const HostapdException& e) {
+            throw HostapdException(std::format("Failed to enable hostapd for IEEE 802.1X ({})", e.what()));
+        }
+    }
+
     try {
         SetProperty(ProtocolHostapd::PropertyNameWpaKeyManagement, keyManagementPropertyValue, enforceConfigurationChange);
     } catch (const HostapdException& e) {

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -498,3 +498,9 @@ Hostapd::SetNetworkAccessServerId(std::string_view networkAccessServiceId)
         throw HostapdException(std::format("Failed to set network access identifier ({})", e.what()));
     }
 }
+
+std::string_view
+Hostapd::GetIpAddress() const noexcept
+{
+    return m_ownIpAddress;
+}

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -297,13 +297,9 @@ Hostapd::SetKeyManagement(std::vector<WpaKeyManagement> keyManagements, EnforceC
         keyManagementPropertyValue = keyManagementPropertyValueBuilder.str();
     }
 
-    constexpr auto hasFtKeyManagement = [](const auto& keyManagement) {
-        return std::ranges::contains(WpaKeyManagementFt, keyManagement);
-    };
-
     // If any key managements to set support fast-transition, set the network access server (NAS) identifier property to
     // a default (random) value.
-    if (std::ranges::any_of(keyManagements, hasFtKeyManagement)) {
+    if (std::ranges::any_of(keyManagements, IsKeyManagementFastTransition)) {
         SetNetworkAccessServerId();
     }
 

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -235,8 +235,19 @@ struct Hostapd :
     void
     SetNetworkAccessServerId(std::string_view networkAccessServiceId = GenerateNetworkAccessServerId());
 
+    /**
+     * @brief Get the IP address of this access point. 
+     * 
+     * Currently, this is non-configurable and is always set to the loopback address (127.0.0.1).
+     * 
+     * @return std::string_view
+     */
+    std::string_view
+    GetIpAddress() const noexcept;
+
 private:
     const std::string m_interface;
+    std::string m_ownIpAddress{ "127.0.0.1" };
     WpaController m_controller;
 };
 } // namespace Wpa

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -326,6 +326,24 @@ static constexpr std::initializer_list<WpaKeyManagement> WpaKeyManagementFt = {
 };
 
 /**
+ * @brief All valid WpaKeyManagement values supporting IEEE 802.1X.
+ */
+static constexpr std::initializer_list<WpaKeyManagement> WpaKeyManagementIeee8021x = {
+    WpaKeyManagement::Ieee8021x,
+    WpaKeyManagement::FtIeee8021x,
+    WpaKeyManagement::FtIeee8021xSha384,
+    WpaKeyManagement::Cckm,
+    WpaKeyManagement::Osen,
+    WpaKeyManagement::Ieee8021xSha256,
+    WpaKeyManagement::Ieee8021xSuiteB,
+    WpaKeyManagement::Ieee8021xSuiteB192,
+    WpaKeyManagement::FilsSha256,
+    WpaKeyManagement::FilsSha384,
+    WpaKeyManagement::FtFilsSha256,
+    WpaKeyManagement::FtFilsSha384,
+};
+
+/**
  * @brief Determines if the specified key management value is part of the fast-transition (FT) class of authentication
  * and key management schemes.
  *
@@ -337,6 +355,20 @@ static constexpr bool
 IsKeyManagementFastTransition(WpaKeyManagement wpaKeyManagement)
 {
     return std::ranges::contains(WpaKeyManagementFt, wpaKeyManagement);
+}
+
+/**
+ * @brief Determines if the specified key management value is part of the IEEE 802.1X class of authentication and key
+ * management schemes.
+ *
+ * @param wpaKeyManagement The key management value to check.
+ * @return true The specified key management value supports IEEE 802.1X.
+ * @return false The specified key management value does not support IEEE 802.1X.
+ */
+static constexpr bool
+IsKeyManagementIeee8021x(WpaKeyManagement wpaKeyManagement)
+{
+    return std::ranges::contains(WpaKeyManagementIeee8021x, wpaKeyManagement);
 }
 
 /**
@@ -904,9 +936,9 @@ struct RadiusEndpointConfiguration
 
 /**
  * @brief Get the radius endpoint property names given a radius endpoint type.
- * 
+ *
  * @param type The type of radius endpoint.
- * @return constexpr std::tuple<std::string_view, std::string_view, std::string_view> 
+ * @return constexpr std::tuple<std::string_view, std::string_view, std::string_view>
  */
 constexpr std::tuple<std::string_view, std::string_view, std::string_view>
 GetRadiusEndpointPropertyNames(RadiusEndpointType type)

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -237,10 +237,10 @@ enum class WpaAlgorithm : uint32_t {
  */
 enum class WpaKeyManagement : uint32_t {
     Unknown = 0U,
-    Ieee80211x = (1U << 0U),
+    Ieee8021x = (1U << 0U),
     Psk = (1U << 1U),
     None = (1U << 2U),
-    Ieee80211xNoWpa = (1U << 3U),
+    Ieee8021xNoWpa = (1U << 3U),
     WpaNone = (1U << 4U),
     FtIeee8021x = (1U << 5U),
     FtPsk = (1U << 6U),
@@ -253,8 +253,8 @@ enum class WpaKeyManagement : uint32_t {
     WapiCert = (1U << 13U),
     Cckm = (1U << 14U),
     Osen = (1U << 15U),
-    Ieee80211xSuiteB = (1U << 16U),
-    Ieee80211xSuiteB192 = (1U << 17U),
+    Ieee8021xSuiteB = (1U << 16U),
+    Ieee8021xSuiteB192 = (1U << 17U),
     FilsSha256 = (1U << 18U),
     FilsSha384 = (1U << 19U),
     FtFilsSha256 = (1U << 20U),
@@ -272,10 +272,10 @@ enum class WpaKeyManagement : uint32_t {
  */
 inline constexpr std::array<WpaKeyManagement, 27> AllWpaKeyManagements = {
     WpaKeyManagement::Unknown,
-    WpaKeyManagement::Ieee80211x,
+    WpaKeyManagement::Ieee8021x,
     WpaKeyManagement::Psk,
     WpaKeyManagement::None,
-    WpaKeyManagement::Ieee80211xNoWpa,
+    WpaKeyManagement::Ieee8021xNoWpa,
     WpaKeyManagement::WpaNone,
     WpaKeyManagement::FtIeee8021x,
     WpaKeyManagement::FtPsk,
@@ -288,8 +288,8 @@ inline constexpr std::array<WpaKeyManagement, 27> AllWpaKeyManagements = {
     WpaKeyManagement::WapiCert,
     WpaKeyManagement::Cckm,
     WpaKeyManagement::Osen,
-    WpaKeyManagement::Ieee80211xSuiteB,
-    WpaKeyManagement::Ieee80211xSuiteB192,
+    WpaKeyManagement::Ieee8021xSuiteB,
+    WpaKeyManagement::Ieee8021xSuiteB192,
     WpaKeyManagement::FilsSha256,
     WpaKeyManagement::FilsSha384,
     WpaKeyManagement::FtFilsSha256,
@@ -304,7 +304,7 @@ inline constexpr std::array<WpaKeyManagement, 27> AllWpaKeyManagements = {
  * @brief A bitmask containing all valid WpaKeyManagement values supporting fast-transition (FT).
  */
 static constexpr std::underlying_type_t<WpaKeyManagement> WpaKeyManagementMaskFt =
-    std::to_underlying(WpaKeyManagement::Ieee80211x) |
+    std::to_underlying(WpaKeyManagement::Ieee8021x) |
     std::to_underlying(WpaKeyManagement::FtIeee8021x) |
     std::to_underlying(WpaKeyManagement::FtPsk) |
     std::to_underlying(WpaKeyManagement::FtIeee8021xSha384) |
@@ -316,7 +316,7 @@ static constexpr std::underlying_type_t<WpaKeyManagement> WpaKeyManagementMaskFt
  * @brief All valid WpaKeyManagement values supporting fast-transition (FT).
  */
 static constexpr std::initializer_list<WpaKeyManagement> WpaKeyManagementFt = {
-    WpaKeyManagement::Ieee80211x,
+    WpaKeyManagement::Ieee8021x,
     WpaKeyManagement::FtIeee8021x,
     WpaKeyManagement::FtPsk,
     WpaKeyManagement::FtIeee8021xSha384,
@@ -676,7 +676,7 @@ constexpr std::string_view
 WpaKeyManagementPropertyValue(WpaKeyManagement wpaKeyManagement) noexcept
 {
     switch (wpaKeyManagement) {
-    case WpaKeyManagement::Ieee80211x:
+    case WpaKeyManagement::Ieee8021x:
         return "WPA-EAP";
     case WpaKeyManagement::Psk:
         return "WPA-PSK";
@@ -694,9 +694,9 @@ WpaKeyManagementPropertyValue(WpaKeyManagement wpaKeyManagement) noexcept
         return "FT-SAE";
     case WpaKeyManagement::Osen:
         return "OSEN";
-    case WpaKeyManagement::Ieee80211xSuiteB:
+    case WpaKeyManagement::Ieee8021xSuiteB:
         return "WPA-EAP-SUITE-B";
-    case WpaKeyManagement::Ieee80211xSuiteB192:
+    case WpaKeyManagement::Ieee8021xSuiteB192:
         return "WPA-EAP-SUITE-B-192";
     case WpaKeyManagement::FilsSha256:
         return "FILS-SHA256";
@@ -717,7 +717,7 @@ WpaKeyManagementPropertyValue(WpaKeyManagement wpaKeyManagement) noexcept
     // Below values are not accepted for nor parsed from the configuration file.
     case WpaKeyManagement::None:
         [[fallthrough]];
-    case WpaKeyManagement::Ieee80211xNoWpa:
+    case WpaKeyManagement::Ieee8021xNoWpa:
         [[fallthrough]];
     case WpaKeyManagement::WpaNone:
         [[fallthrough]];

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -535,10 +535,15 @@ struct ProtocolHostapd :
     static constexpr auto PropertyValueIeee80211WOptional = "1";
     static constexpr auto PropertyValueIeee80211WRequired = "2";
 
-    static constexpr auto PropertyNameNasIdentifier = "nas_identifier";
     static constexpr auto PropertyNameBridgeInterface = "bridge";
 
+    // 802.1X/EAP properties.
+    static constexpr auto PropertyNameIeee8021X = "ieee8021x";
+    static constexpr auto PropertyNameEapServer = "eap_server";
+
+    // RADIUS properties.
     static constexpr auto PropertyNameOwnIpAddr = "own_ip_addr";
+    static constexpr auto PropertyNameNasIdentifier = "nas_identifier";
     static constexpr auto PropertyNameRadiusClientAddr = "radius_client_addr";
     static constexpr auto PropertyNameRadiusClientDev = "radius_client_dev";
 

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -445,7 +445,7 @@ TEST_CASE("Send SetKeyManagement() command (root)", "[wpa][hostapd][client][remo
 
     static constexpr std::initializer_list<WpaKeyManagement> KeyManagementInvalidValues = {
         WpaKeyManagement::None,
-        WpaKeyManagement::Ieee80211xNoWpa,
+        WpaKeyManagement::Ieee8021xNoWpa,
         WpaKeyManagement::WpaNone,
         WpaKeyManagement::Wps,
         WpaKeyManagement::WapiPsk,
@@ -454,7 +454,7 @@ TEST_CASE("Send SetKeyManagement() command (root)", "[wpa][hostapd][client][remo
     };
 
     static constexpr std::initializer_list<WpaKeyManagement> KeyManagementValidValues = {
-        WpaKeyManagement::Ieee80211x,
+        WpaKeyManagement::Ieee8021x,
         WpaKeyManagement::Psk,
         // WpaKeyManagement::FtIeee8021x,           // feature work not yet completed
         // WpaKeyManagement::FtPsk,                 // feature work not yet completed
@@ -463,8 +463,8 @@ TEST_CASE("Send SetKeyManagement() command (root)", "[wpa][hostapd][client][remo
         WpaKeyManagement::Sae,
         // WpaKeyManagement::FtSae,                 // feature work not yet completed
         // WpaKeyManagement::Osen,                  // feature work not yet completed
-        // WpaKeyManagement::Ieee80211xSuiteB,      // feature work not yet completed
-        // WpaKeyManagement::Ieee80211xSuiteB192,   // feature work not yet completed
+        // WpaKeyManagement::Ieee8021xSuiteB,      // feature work not yet completed
+        // WpaKeyManagement::Ieee8021xSuiteB192,   // feature work not yet completed
         // WpaKeyManagement::FilsSha256,            // feature work not yet completed
         // WpaKeyManagement::FilsSha384,            // feature work not yet completed
         // WpaKeyManagement::FtFilsSha256,          // feature work not yet completed


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow use of IEEE 802.1X AKMs in implementation layers.

### Technical Details

* Add hostapd compilation configuration flags to enable support for WPA3 Enterprise Suite B and cli edit mode and limited command history.
* Add hostapd property names for IEEE 802.1X AKMs and configuration.
* Remove unused proto import.
* Explicitly disable use of hostapd internal EAP server in favor of using externally configured ones (eg. FreeRADIUS).
* Explicitly set the (required) hostapd `own_ip_addr` property when configuring external RADIUS endpoints.
* Remove trailing space from hostapd AKM property values.
* Fix `Ieee80211x` -> `Ieee8021x` typo in neutral type enumeration.
* Enable all IEEE 802.1X AKMs in unit tests.
* Enable all FT-based AKMs in unit tests.

### Test Results

* All unit tests pass.
* Performed some ad-hoc tests to verify EAP AKM settings in hostapd directly using `hostapd_cli` and extra hostapd daemon logging (`-dddd`).

### Reviewer Focus

* None

### Future Work

* Possibly allow setting the `own_ip_addr` hostapd property, which is used to set the NAS IP address for RADIUS to a value other than the localhost (127.0.0.1), if necessary.
* Plumb any other required EAP-AKM based configuration knobs to the top of the stack.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
