### PR TITLE
Extend WifiAccessPointEnable API to allow configuring IEEE 802.1X

### DIFF
--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -207,6 +207,7 @@ message Dot11AccessPointConfiguration
     Dot11MacAddress Bssid = 2;
     Dot11PhyType PhyType = 3;
     Dot11AuthenticationData AuthenticationData = 4;
+    Dot11Dot1xConfiguration Dot1xConfiguration = 9;
     repeated Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 5;
     repeated Dot11CipherSuiteConfiguration PairwiseCipherSuites = 6;
     repeated Dot11AkmSuite AkmSuites = 7;

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -502,6 +502,13 @@ NetRemoteService::WifiAccessPointEnableImpl(std::string_view accessPointId, cons
             }
         }
 
+        if (dot11AccessPointConfiguration->has_dot1xconfiguration()) {
+            wifiOperationStatus = WifiAccessPointSetDot1xConfigurationImpl(accessPointId, dot11AccessPointConfiguration->dot1xconfiguration(), accessPointController);
+            if (wifiOperationStatus.code() != WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded) {
+                return wifiOperationStatus;
+            }
+        }
+
         if (dot11AccessPointConfiguration->authenticationalgorithms_size() > 0) {
             auto dot11AuthenticationAlgorithms = ToDot11AuthenticationAlgorithms(*dot11AccessPointConfiguration);
             wifiOperationStatus = WifiAccessPointSetAuthenticationAlgorithsmImpl(accessPointId, dot11AuthenticationAlgorithms, accessPointController);

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -142,6 +142,8 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
         apConfiguration.mutable_authenticationdata()->mutable_sae()->mutable_passwords()->Add(std::move(dot11RsnaPassword));
+        apConfiguration.mutable_dot1xconfiguration()->mutable_radius()->mutable_authenticationserver()->set_address("127.0.0.1");
+        apConfiguration.mutable_dot1xconfiguration()->mutable_radius()->mutable_authenticationserver()->set_sharedsecret("shared-secret");
         *apConfiguration.mutable_authenticationdata()->mutable_psk()->mutable_psk()->mutable_passphrase() = AsciiPassword;
 
         WifiAccessPointEnableRequest request{};


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow IEEE 802.1X settings to be configured using the `WifiAccessPointEnable` API.

### Technical Details

* Add `Dot11Dot1xConfiguration` field to `Dot11AccessPointConfiguration` message.
* Check for presence of dot1x configuration and proxy to impl function in service impl.
* Expand `WifiAccessPointEnable` unit tests to include basic IEEE 802.1X settings for santiy.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Expand `netremote-cli` to include support for IEEE 802.1X configuration.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
