### PR TITLE
Wrap and rename 802.1X authentication types

### DIFF
--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -19,5 +19,5 @@ service NetRemote
     rpc WifiAccessPointSetFrequencyBands (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetFrequencyBandsResult);
     rpc WifiAccessPointSetSsid (Microsoft.Net.Remote.Wifi.WifiAccessPointSetSsidRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetSsidResult);
     rpc WifiAccessPointSetNetworkBridge (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeResult);
-    rpc WifiAccessPointSetDot1xConfiguration (Microsoft.Net.Remote.Wifi.WifiAccessPointSetDot1xConfigurationRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetDot1xConfigurationResult);
+    rpc WifiAccessPointSetAuthenticationDot1x (Microsoft.Net.Remote.Wifi.WifiAccessPointSetAuthenticationDot1xRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetAuthenticationDot1xResult);
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -113,13 +113,13 @@ message WifiAccessPointSetSsidResult
     WifiAccessPointOperationStatus Status = 2;
 }
 
-message WifiAccessPointSetDot1xConfigurationRequest
+message WifiAccessPointSetAuthenticationDot1xRequest
 {
     string AccessPointId = 1;
-    Microsoft.Net.Wifi.Dot11Dot1xConfiguration Configuration = 2;
+    Microsoft.Net.Wifi.Dot11AuthenticationDot1x AuthenticationDot1x = 2;
 }
 
-message WifiAccessPointSetDot1xConfigurationResult
+message WifiAccessPointSetAuthenticationDot1xResult
 {
     string AccessPointId = 1;
     WifiAccessPointOperationStatus Status = 2;

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -190,15 +190,16 @@ message Dot11AuthenticationData
     Dot11AuthenticationDataSae Sae = 2;
 }
 
+// IEEE 802.1X EAP over LAN (EAPOL) configuration per IEEE 802.1X-2004.
+message Dot11AuthenticationDot1x
+{
+    Dot1xRadiusConfiguration Radius = 1;
+}
+
 message Dot11CipherSuiteConfiguration
 {
     Dot11SecurityProtocol SecurityProtocol = 1;
     repeated Dot11CipherSuite CipherSuites = 2;
-}
-
-message Dot11Dot1xConfiguration
-{
-    Dot1xRadiusConfiguration Radius = 1;
 }
 
 message Dot11AccessPointConfiguration
@@ -207,7 +208,7 @@ message Dot11AccessPointConfiguration
     Dot11MacAddress Bssid = 2;
     Dot11PhyType PhyType = 3;
     Dot11AuthenticationData AuthenticationData = 4;
-    Dot11Dot1xConfiguration Dot1xConfiguration = 9;
+    Dot11AuthenticationDot1x AuthenticationDot1x = 9;
     repeated Dot11AuthenticationAlgorithm AuthenticationAlgorithms = 5;
     repeated Dot11CipherSuiteConfiguration PairwiseCipherSuites = 6;
     repeated Dot11AkmSuite AkmSuites = 7;

--- a/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
@@ -144,7 +144,7 @@ private:
      * @return grpc::Status
      */
     grpc::Status
-    WifiAccessPointSetDot1xConfiguration(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointSetDot1xConfigurationRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointSetDot1xConfigurationResult* result) override;
+    WifiAccessPointSetAuthenticationDot1x(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointSetAuthenticationDot1xRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointSetAuthenticationDot1xResult* result) override;
 
 protected:
     /**
@@ -296,12 +296,12 @@ protected:
      * @brief Set the IEEE 802.1x configuration for the access point.
      * 
      * @param accessPointId The access point identifier.
-     * @param dot11Dot1xConfiguration The new IEEE 802.1x configuration to set.
+     * @param dot11AuthenticationDot1x The new IEEE 802.1x configuration to set.
      * @param accessPointController  The access point controller for the specified access point (optional).
      * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus 
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
-    WifiAccessPointSetDot1xConfigurationImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11Dot1xConfiguration& dot11Dot1xConfiguration, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
+    WifiAccessPointSetAuthenticationDot1xImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11AuthenticationDot1x& dot11AuthenticationDot1x, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
 private:
     std::shared_ptr<Microsoft::Net::NetworkManager> m_networkManager;

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211Authentication.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211Authentication.hxx
@@ -10,6 +10,7 @@
 #include <variant>
 #include <vector>
 
+#include <microsoft/net/Ieee8021xRadiusAuthentication.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 
 namespace Microsoft::Net::Wifi
@@ -134,6 +135,11 @@ struct Ieee80211AuthenticationData
 {
     std::optional<Ieee80211AuthenticationDataPsk> Psk;
     std::optional<Ieee80211AuthenticationDataSae> Sae;
+};
+
+struct Ieee8021xAuthentication
+{
+    std::optional<Microsoft::Net::Ieee8021xRadiusConfiguration> Radius;
 };
 
 } // namespace Microsoft::Net::Wifi

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211Authentication.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211Authentication.hxx
@@ -137,7 +137,7 @@ struct Ieee80211AuthenticationData
     std::optional<Ieee80211AuthenticationDataSae> Sae;
 };
 
-struct Ieee8021xAuthentication
+struct Ieee80211Authentication8021x
 {
     std::optional<Microsoft::Net::Ieee8021xRadiusConfiguration> Radius;
 };

--- a/src/common/wifi/dot11/adapter/CMakeLists.txt
+++ b/src/common/wifi/dot11/adapter/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(wifi-core-adapter-dot11
 
 target_link_libraries(wifi-core-adapter-dot11
     PUBLIC
+        ${PROJECT_NAME}-net-adapter-service-api
         ${PROJECT_NAME}-protocol
         wifi-core
     PRIVATE

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <microsoft/net/ServiceApiNetworkDot1xAdapters.hxx>
 #include <microsoft/net/remote/protocol/NetRemoteWifi.pb.h>
 #include <microsoft/net/remote/protocol/WifiCore.pb.h>
 #include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
@@ -815,6 +816,34 @@ ToDot11AuthenticationData(const Ieee80211AuthenticationData& ieee80211Authentica
     }
 
     return dot11AuthenticationData;
+}
+
+Ieee8021xAuthentication
+FromDot11Dot1xConfiguration(const Dot11Dot1xConfiguration& dot11Dot1xConfiguration) noexcept
+{
+    Ieee8021xAuthentication ieee8021xAuthentication{};
+
+    // Convert RADIUS configuration, if present.
+    if (dot11Dot1xConfiguration.has_radius()) {
+        const auto& dot1xRadiusConfiguration = dot11Dot1xConfiguration.radius();
+        ieee8021xAuthentication.Radius = FromServiceDot1xRadiusConfiguration(dot1xRadiusConfiguration);
+    }
+
+    return ieee8021xAuthentication;
+}
+
+Dot11Dot1xConfiguration
+ToDot11Dot1xConfiguration(const Ieee8021xAuthentication& ieee8021xAuthentication) noexcept
+{
+    Dot11Dot1xConfiguration dot11Dot1xConfiguration{};
+
+    // Convert RADIUS configuration, if present.
+    if (ieee8021xAuthentication.Radius.has_value()) {
+        auto dot1xRadiusConfiguration = ToServiceDot1xRadiusConfiguration(ieee8021xAuthentication.Radius.value());
+        *dot11Dot1xConfiguration.mutable_radius() = std::move(dot1xRadiusConfiguration);
+    }
+
+    return dot11Dot1xConfiguration;
 }
 
 } // namespace Microsoft::Net::Wifi

--- a/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -818,32 +818,32 @@ ToDot11AuthenticationData(const Ieee80211AuthenticationData& ieee80211Authentica
     return dot11AuthenticationData;
 }
 
-Ieee8021xAuthentication
-FromDot11Dot1xConfiguration(const Dot11Dot1xConfiguration& dot11Dot1xConfiguration) noexcept
+Ieee80211Authentication8021x
+FromDot11AuthenticationDot1x(const Dot11AuthenticationDot1x& Dot11AuthenticationDot1x) noexcept
 {
-    Ieee8021xAuthentication ieee8021xAuthentication{};
+    Ieee80211Authentication8021x ieee8021xAuthentication{};
 
     // Convert RADIUS configuration, if present.
-    if (dot11Dot1xConfiguration.has_radius()) {
-        const auto& dot1xRadiusConfiguration = dot11Dot1xConfiguration.radius();
+    if (Dot11AuthenticationDot1x.has_radius()) {
+        const auto& dot1xRadiusConfiguration = Dot11AuthenticationDot1x.radius();
         ieee8021xAuthentication.Radius = FromServiceDot1xRadiusConfiguration(dot1xRadiusConfiguration);
     }
 
     return ieee8021xAuthentication;
 }
 
-Dot11Dot1xConfiguration
-ToDot11Dot1xConfiguration(const Ieee8021xAuthentication& ieee8021xAuthentication) noexcept
+Dot11AuthenticationDot1x
+ToDot11AuthenticationDot1x(const Ieee80211Authentication8021x& ieee8021xAuthentication) noexcept
 {
-    Dot11Dot1xConfiguration dot11Dot1xConfiguration{};
+    Dot11AuthenticationDot1x Dot11AuthenticationDot1x{};
 
     // Convert RADIUS configuration, if present.
     if (ieee8021xAuthentication.Radius.has_value()) {
         auto dot1xRadiusConfiguration = ToServiceDot1xRadiusConfiguration(ieee8021xAuthentication.Radius.value());
-        *dot11Dot1xConfiguration.mutable_radius() = std::move(dot1xRadiusConfiguration);
+        *Dot11AuthenticationDot1x.mutable_radius() = std::move(dot1xRadiusConfiguration);
     }
 
-    return dot11Dot1xConfiguration;
+    return Dot11AuthenticationDot1x;
 }
 
 } // namespace Microsoft::Net::Wifi

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include <microsoft/net/remote/protocol/NetRemoteWifi.pb.h>
+#include <microsoft/net/remote/protocol/Network8021x.pb.h>
 #include <microsoft/net/remote/protocol/WifiCore.pb.h>
 #include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
@@ -356,6 +357,24 @@ FromDot11AuthenticationData(const Dot11AuthenticationData& dot11AuthenticationDa
  */
 Dot11AuthenticationData
 ToDot11AuthenticationData(const Ieee80211AuthenticationData& ieee80211AuthenticationData) noexcept;
+
+/**
+ * @brief Convert the specified Dot11Dot1xConfiguration to the equivalent IEEE 802.1x authentication.
+ * 
+ * @param dot11Dot1xConfiguration The Dot11Dot1xConfiguration to convert.
+ * @return Ieee8021xAuthentication 
+ */
+Ieee8021xAuthentication
+FromDot11Dot1xConfiguration(const Dot11Dot1xConfiguration& dot11Dot1xConfiguration) noexcept;
+
+/**
+ * @brief Convert the specified IEEE 802.1x authentication to the equivalent Dot11Dot1xConfiguration.
+ * 
+ * @param ieee8021xAuthentication The IEEE 802.1x authentication to convert.
+ * @return Dot11Dot1xConfiguration 
+ */
+Dot11Dot1xConfiguration
+ToDot11Dot1xConfiguration(const Ieee8021xAuthentication& ieee8021xAuthentication) noexcept;
 
 } // namespace Microsoft::Net::Wifi
 

--- a/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -359,22 +359,22 @@ Dot11AuthenticationData
 ToDot11AuthenticationData(const Ieee80211AuthenticationData& ieee80211AuthenticationData) noexcept;
 
 /**
- * @brief Convert the specified Dot11Dot1xConfiguration to the equivalent IEEE 802.1x authentication.
+ * @brief Convert the specified Dot11AuthenticationDot1x to the equivalent IEEE 802.1x authentication.
  * 
- * @param dot11Dot1xConfiguration The Dot11Dot1xConfiguration to convert.
- * @return Ieee8021xAuthentication 
+ * @param dot11AuthenticationDot1x The Dot11AuthenticationDot1x to convert.
+ * @return Ieee80211Authentication8021x 
  */
-Ieee8021xAuthentication
-FromDot11Dot1xConfiguration(const Dot11Dot1xConfiguration& dot11Dot1xConfiguration) noexcept;
+Ieee80211Authentication8021x
+FromDot11AuthenticationDot1x(const Dot11AuthenticationDot1x& dot11AuthenticationDot1x) noexcept;
 
 /**
- * @brief Convert the specified IEEE 802.1x authentication to the equivalent Dot11Dot1xConfiguration.
+ * @brief Convert the specified IEEE 802.1x authentication to the equivalent Dot11AuthenticationDot1x.
  * 
  * @param ieee8021xAuthentication The IEEE 802.1x authentication to convert.
- * @return Dot11Dot1xConfiguration 
+ * @return Dot11AuthenticationDot1x 
  */
-Dot11Dot1xConfiguration
-ToDot11Dot1xConfiguration(const Ieee8021xAuthentication& ieee8021xAuthentication) noexcept;
+Dot11AuthenticationDot1x
+ToDot11AuthenticationDot1x(const Ieee80211Authentication8021x& ieee8021xAuthentication) noexcept;
 
 } // namespace Microsoft::Net::Wifi
 

--- a/tests/unit/TestNetRemoteServiceClient.cxx
+++ b/tests/unit/TestNetRemoteServiceClient.cxx
@@ -142,8 +142,8 @@ TEST_CASE("WifiAccessPointEnable API", "[basic][rpc][client][remote]")
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand2_4GHz);
         apConfiguration.mutable_frequencybands()->Add(Dot11FrequencyBand::Dot11FrequencyBand5_0GHz);
         apConfiguration.mutable_authenticationdata()->mutable_sae()->mutable_passwords()->Add(std::move(dot11RsnaPassword));
-        apConfiguration.mutable_dot1xconfiguration()->mutable_radius()->mutable_authenticationserver()->set_address("127.0.0.1");
-        apConfiguration.mutable_dot1xconfiguration()->mutable_radius()->mutable_authenticationserver()->set_sharedsecret("shared-secret");
+        apConfiguration.mutable_authenticationdot1x()->mutable_radius()->mutable_authenticationserver()->set_address("127.0.0.1");
+        apConfiguration.mutable_authenticationdot1x()->mutable_radius()->mutable_authenticationserver()->set_sharedsecret("shared-secret");
         *apConfiguration.mutable_authenticationdata()->mutable_psk()->mutable_psk()->mutable_passphrase() = AsciiPassword;
 
         WifiAccessPointEnableRequest request{};
@@ -794,7 +794,7 @@ TEST_CASE("NetworkInterfacesEnumerate API", "[basic][rpc][client][remote]")
     }
 }
 
-TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remote]")
+TEST_CASE("WifiAccessPointSetAuthenticationDot1x API", "[basic][rpc][client][remote]")
 {
     using namespace Microsoft::Net;
     using namespace Microsoft::Net::Remote;
@@ -804,7 +804,7 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
     using namespace Microsoft::Net::Wifi;
     using namespace Microsoft::Net::Wifi::Test;
 
-    constexpr auto InterfaceName{ "TestWifiAccessPointSetDot1xConfiguration" };
+    constexpr auto InterfaceName{ "TestWifiAccessPointSetAuthenticationDot1x" };
     constexpr auto RadiusServerAddressValid{ "127.0.0.1" };
     constexpr auto RadiusServerSharedSecretValid{ "shared-secret" };
     constexpr auto RadiusServerPortValid{ 1234 };
@@ -825,22 +825,22 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
 
     SECTION("Can be called")
     {
-        WifiAccessPointSetDot1xConfigurationRequest request{};
-        WifiAccessPointSetDot1xConfigurationResult result{};
+        WifiAccessPointSetAuthenticationDot1xRequest request{};
+        WifiAccessPointSetAuthenticationDot1xResult result{};
         grpc::ClientContext clientContext{};
 
-        auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+        auto status = client->WifiAccessPointSetAuthenticationDot1x(&clientContext, request, &result);
         REQUIRE(status.ok());
         REQUIRE(result.has_status());
     }
 
     SECTION("Fails with missing configuration")
     {
-        WifiAccessPointSetDot1xConfigurationRequest request{};
-        WifiAccessPointSetDot1xConfigurationResult result{};
+        WifiAccessPointSetAuthenticationDot1xRequest request{};
+        WifiAccessPointSetAuthenticationDot1xResult result{};
         grpc::ClientContext clientContext{};
 
-        auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+        auto status = client->WifiAccessPointSetAuthenticationDot1x(&clientContext, request, &result);
         REQUIRE(status.ok());
         REQUIRE(result.has_status());
         REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
@@ -848,14 +848,14 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
 
     SECTION("Fails with invalid access point id")
     {
-        WifiAccessPointSetDot1xConfigurationRequest request{};
+        WifiAccessPointSetAuthenticationDot1xRequest request{};
         request.set_accesspointid("InvalidAccessPointId");
-        *request.mutable_configuration()->mutable_radius() = {};
+        *request.mutable_authenticationdot1x()->mutable_radius() = {};
 
-        WifiAccessPointSetDot1xConfigurationResult result{};
+        WifiAccessPointSetAuthenticationDot1xResult result{};
         grpc::ClientContext clientContext{};
 
-        auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+        auto status = client->WifiAccessPointSetAuthenticationDot1x(&clientContext, request, &result);
         REQUIRE(status.ok());
         REQUIRE(result.has_status());
         REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeAccessPointInvalid);
@@ -863,14 +863,14 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
 
     SECTION("RADIUS: Fails with missing authentication server")
     {
-        WifiAccessPointSetDot1xConfigurationRequest request{};
+        WifiAccessPointSetAuthenticationDot1xRequest request{};
         request.set_accesspointid(InterfaceName);
-        *request.mutable_configuration()->mutable_radius() = {};
+        *request.mutable_authenticationdot1x()->mutable_radius() = {};
 
-        WifiAccessPointSetDot1xConfigurationResult result{};
+        WifiAccessPointSetAuthenticationDot1xResult result{};
         grpc::ClientContext clientContext{};
 
-        auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+        auto status = client->WifiAccessPointSetAuthenticationDot1x(&clientContext, request, &result);
         REQUIRE(status.ok());
         REQUIRE(result.has_status());
         REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
@@ -878,17 +878,17 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
 
     SECTION("RADIUS: Fails with missing authentication server address")
     {
-        WifiAccessPointSetDot1xConfigurationRequest request{};
+        WifiAccessPointSetAuthenticationDot1xRequest request{};
         request.set_accesspointid(InterfaceName);
-        auto& radiusConfiguration = *request.mutable_configuration()->mutable_radius();
+        auto& radiusConfiguration = *request.mutable_authenticationdot1x()->mutable_radius();
         auto& radiusAuthenticationServer = *radiusConfiguration.mutable_authenticationserver();
         *radiusAuthenticationServer.mutable_address() = "";
         *radiusAuthenticationServer.mutable_sharedsecret() = RadiusServerSharedSecretValid;
 
-        WifiAccessPointSetDot1xConfigurationResult result{};
+        WifiAccessPointSetAuthenticationDot1xResult result{};
         grpc::ClientContext clientContext{};
 
-        auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+        auto status = client->WifiAccessPointSetAuthenticationDot1x(&clientContext, request, &result);
         REQUIRE(status.ok());
         REQUIRE(result.has_status());
         REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
@@ -896,17 +896,17 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
 
     SECTION("RADIUS: Fails with missing authentication server shared secret")
     {
-        WifiAccessPointSetDot1xConfigurationRequest request{};
+        WifiAccessPointSetAuthenticationDot1xRequest request{};
         request.set_accesspointid(InterfaceName);
-        auto& radiusConfiguration = *request.mutable_configuration()->mutable_radius();
+        auto& radiusConfiguration = *request.mutable_authenticationdot1x()->mutable_radius();
         auto& radiusAuthenticationServer = *radiusConfiguration.mutable_authenticationserver();
         *radiusAuthenticationServer.mutable_address() = RadiusServerAddressValid;
         *radiusAuthenticationServer.mutable_sharedsecret() = "";
 
-        WifiAccessPointSetDot1xConfigurationResult result{};
+        WifiAccessPointSetAuthenticationDot1xResult result{};
         grpc::ClientContext clientContext{};
 
-        auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+        auto status = client->WifiAccessPointSetAuthenticationDot1x(&clientContext, request, &result);
         REQUIRE(status.ok());
         REQUIRE(result.has_status());
         REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
@@ -914,9 +914,9 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
 
     SECTION("RADIUS: Fails with missing accounting server address")
     {
-        WifiAccessPointSetDot1xConfigurationRequest request{};
+        WifiAccessPointSetAuthenticationDot1xRequest request{};
         request.set_accesspointid(InterfaceName);
-        auto& radiusConfiguration = *request.mutable_configuration()->mutable_radius();
+        auto& radiusConfiguration = *request.mutable_authenticationdot1x()->mutable_radius();
         auto& radiusAuthenticationServer = *radiusConfiguration.mutable_authenticationserver();
         *radiusAuthenticationServer.mutable_address() = RadiusServerAddressValid;
         *radiusAuthenticationServer.mutable_sharedsecret() = RadiusServerSharedSecretValid;
@@ -924,10 +924,10 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
         radiusAccountingServer.set_address("");
         radiusAccountingServer.set_sharedsecret(RadiusServerSharedSecretValid);
 
-        WifiAccessPointSetDot1xConfigurationResult result{};
+        WifiAccessPointSetAuthenticationDot1xResult result{};
         grpc::ClientContext clientContext{};
 
-        auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+        auto status = client->WifiAccessPointSetAuthenticationDot1x(&clientContext, request, &result);
         REQUIRE(status.ok());
         REQUIRE(result.has_status());
         REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
@@ -935,9 +935,9 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
 
     SECTION("RADIUS: Fails with missing accounting server shared secret")
     {
-        WifiAccessPointSetDot1xConfigurationRequest request{};
+        WifiAccessPointSetAuthenticationDot1xRequest request{};
         request.set_accesspointid(InterfaceName);
-        auto& radiusConfiguration = *request.mutable_configuration()->mutable_radius();
+        auto& radiusConfiguration = *request.mutable_authenticationdot1x()->mutable_radius();
         auto& radiusAuthenticationServer = *radiusConfiguration.mutable_authenticationserver();
         *radiusAuthenticationServer.mutable_address() = RadiusServerAddressValid;
         *radiusAuthenticationServer.mutable_sharedsecret() = RadiusServerSharedSecretValid;
@@ -945,10 +945,10 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
         radiusAccountingServer.set_address(RadiusServerAddressValid);
         radiusAccountingServer.set_sharedsecret("");
 
-        WifiAccessPointSetDot1xConfigurationResult result{};
+        WifiAccessPointSetAuthenticationDot1xResult result{};
         grpc::ClientContext clientContext{};
 
-        auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+        auto status = client->WifiAccessPointSetAuthenticationDot1x(&clientContext, request, &result);
         REQUIRE(status.ok());
         REQUIRE(result.has_status());
         REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
@@ -957,9 +957,9 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
     SECTION("RADIUS: Fails with fallback server missing address")
     {
         for (const auto dot1xRadiusServerEndpoint : { Dot1xRadiusServerEndpoint::Dot1xRadiusServerEndpointAuthentication, Dot1xRadiusServerEndpoint::Dot1xRadiusServerEndpointAccounting }) {
-            WifiAccessPointSetDot1xConfigurationRequest request{};
+            WifiAccessPointSetAuthenticationDot1xRequest request{};
             request.set_accesspointid(InterfaceName);
-            auto& radiusConfiguration = *request.mutable_configuration()->mutable_radius();
+            auto& radiusConfiguration = *request.mutable_authenticationdot1x()->mutable_radius();
             auto& radiusAuthenticationServer = *radiusConfiguration.mutable_authenticationserver();
             *radiusAuthenticationServer.mutable_address() = RadiusServerAddressValid;
             *radiusAuthenticationServer.mutable_sharedsecret() = RadiusServerSharedSecretValid;
@@ -982,10 +982,10 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
                 };
             }
 
-            WifiAccessPointSetDot1xConfigurationResult result{};
+            WifiAccessPointSetAuthenticationDot1xResult result{};
             grpc::ClientContext clientContext{};
 
-            auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+            auto status = client->WifiAccessPointSetAuthenticationDot1x(&clientContext, request, &result);
             REQUIRE(status.ok());
             REQUIRE(result.has_status());
             REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
@@ -995,9 +995,9 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
     SECTION("RADIUS: Fails with fallback server missing shared secret")
     {
         for (const auto dot1xRadiusServerEndpoint : { Dot1xRadiusServerEndpoint::Dot1xRadiusServerEndpointAuthentication, Dot1xRadiusServerEndpoint::Dot1xRadiusServerEndpointAccounting }) {
-            WifiAccessPointSetDot1xConfigurationRequest request{};
+            WifiAccessPointSetAuthenticationDot1xRequest request{};
             request.set_accesspointid(InterfaceName);
-            auto& radiusConfiguration = *request.mutable_configuration()->mutable_radius();
+            auto& radiusConfiguration = *request.mutable_authenticationdot1x()->mutable_radius();
             auto& radiusAuthenticationServer = *radiusConfiguration.mutable_authenticationserver();
             *radiusAuthenticationServer.mutable_address() = RadiusServerAddressValid;
             *radiusAuthenticationServer.mutable_sharedsecret() = RadiusServerSharedSecretValid;
@@ -1020,10 +1020,10 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
                 };
             }
 
-            WifiAccessPointSetDot1xConfigurationResult result{};
+            WifiAccessPointSetAuthenticationDot1xResult result{};
             grpc::ClientContext clientContext{};
 
-            auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+            auto status = client->WifiAccessPointSetAuthenticationDot1x(&clientContext, request, &result);
             REQUIRE(status.ok());
             REQUIRE(result.has_status());
             REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeInvalidParameter);
@@ -1032,16 +1032,16 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
 
     SECTION("RADIUS: Succeeds with minimum configuration")
     {
-        WifiAccessPointSetDot1xConfigurationRequest request{};
+        WifiAccessPointSetAuthenticationDot1xRequest request{};
         request.set_accesspointid(InterfaceName);
-        auto& radiusConfiguration = *request.mutable_configuration()->mutable_radius();
+        auto& radiusConfiguration = *request.mutable_authenticationdot1x()->mutable_radius();
         auto& radiusAuthenticationServer = *radiusConfiguration.mutable_authenticationserver();
         *radiusAuthenticationServer.mutable_address() = RadiusServerAddressValid;
         *radiusAuthenticationServer.mutable_sharedsecret() = RadiusServerSharedSecretValid;
 
-        WifiAccessPointSetDot1xConfigurationResult result{};
+        WifiAccessPointSetAuthenticationDot1xResult result{};
         grpc::ClientContext clientContext{};
-        auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+        auto status = client->WifiAccessPointSetAuthenticationDot1x(&clientContext, request, &result);
         REQUIRE(status.ok());
         REQUIRE(result.has_status());
         REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
@@ -1049,9 +1049,9 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
 
     SECTION("RADIUS: Succeeds with primary authentication and accounting servers")
     {
-        WifiAccessPointSetDot1xConfigurationRequest request{};
+        WifiAccessPointSetAuthenticationDot1xRequest request{};
         request.set_accesspointid(InterfaceName);
-        auto& radiusConfiguration = *request.mutable_configuration()->mutable_radius();
+        auto& radiusConfiguration = *request.mutable_authenticationdot1x()->mutable_radius();
         auto& radiusAuthenticationServer = *radiusConfiguration.mutable_authenticationserver();
         *radiusAuthenticationServer.mutable_address() = RadiusServerAddressValid;
         *radiusAuthenticationServer.mutable_sharedsecret() = RadiusServerSharedSecretValid;
@@ -1059,9 +1059,9 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
         radiusAccountingServer.set_address(RadiusServerAddressValid);
         radiusAccountingServer.set_sharedsecret(RadiusServerSharedSecretValid);
 
-        WifiAccessPointSetDot1xConfigurationResult result{};
+        WifiAccessPointSetAuthenticationDot1xResult result{};
         grpc::ClientContext clientContext{};
-        auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+        auto status = client->WifiAccessPointSetAuthenticationDot1x(&clientContext, request, &result);
         REQUIRE(status.ok());
         REQUIRE(result.has_status());
         REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);
@@ -1070,9 +1070,9 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
     SECTION("RADIUS: Succeeds with primary authentication, primary accounting server, and fallback servers")
     {
         for (const auto dot1xRadiusServerEndpoint : { Dot1xRadiusServerEndpoint::Dot1xRadiusServerEndpointAuthentication, Dot1xRadiusServerEndpoint::Dot1xRadiusServerEndpointAccounting }) {
-            WifiAccessPointSetDot1xConfigurationRequest request{};
+            WifiAccessPointSetAuthenticationDot1xRequest request{};
             request.set_accesspointid(InterfaceName);
-            auto& radiusConfiguration = *request.mutable_configuration()->mutable_radius();
+            auto& radiusConfiguration = *request.mutable_authenticationdot1x()->mutable_radius();
             auto& radiusAuthenticationServer = *radiusConfiguration.mutable_authenticationserver();
             *radiusAuthenticationServer.mutable_address() = RadiusServerAddressValid;
             *radiusAuthenticationServer.mutable_sharedsecret() = RadiusServerSharedSecretValid;
@@ -1115,9 +1115,9 @@ TEST_CASE("WifiAccessPointSetDot1xConfiguration API", "[basic][rpc][client][remo
                 };
             }
 
-            WifiAccessPointSetDot1xConfigurationResult result{};
+            WifiAccessPointSetAuthenticationDot1xResult result{};
             grpc::ClientContext clientContext{};
-            auto status = client->WifiAccessPointSetDot1xConfiguration(&clientContext, request, &result);
+            auto status = client->WifiAccessPointSetAuthenticationDot1x(&clientContext, request, &result);
             REQUIRE(status.ok());
             REQUIRE(result.has_status());
             REQUIRE(result.status().code() == WifiAccessPointOperationStatusCode::WifiAccessPointOperationStatusCodeSucceeded);

--- a/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
+++ b/tests/unit/wifi/helpers/AccessPointControllerTest.cxx
@@ -199,7 +199,7 @@ AccessPointControllerTest::SetRadiusConfiguration(Ieee8021xRadiusConfiguration r
         return AccessPointOperationStatus::InvalidAccessPoint("null AccessPoint");
     }
 
-    AccessPoint->RadiusConfiguration = std::move(radiusConfiguration);
+    AccessPoint->Authentication8021x.Radius = std::move(radiusConfiguration);
     return AccessPointOperationStatus::MakeSucceeded(AccessPoint->InterfaceName);
 }
 

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -33,7 +33,7 @@ struct AccessPointTest final :
     Microsoft::Net::Wifi::Ieee80211MacAddress MacAddress{};
     Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities Capabilities;
     Microsoft::Net::Wifi::Ieee80211PhyType PhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
-    Microsoft::Net::Wifi::Ieee8021xAuthentication Authentication8021x;
+    Microsoft::Net::Wifi::Ieee80211Authentication8021x Authentication8021x;
     Microsoft::Net::Wifi::Ieee80211AuthenticationData AuthenticationData;
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> FrequencyBands;
     std::vector<Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm> AuthenticationAlgorithms;

--- a/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -33,13 +33,13 @@ struct AccessPointTest final :
     Microsoft::Net::Wifi::Ieee80211MacAddress MacAddress{};
     Microsoft::Net::Wifi::Ieee80211AccessPointCapabilities Capabilities;
     Microsoft::Net::Wifi::Ieee80211PhyType PhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
+    Microsoft::Net::Wifi::Ieee8021xAuthentication Authentication8021x;
     Microsoft::Net::Wifi::Ieee80211AuthenticationData AuthenticationData;
     std::vector<Microsoft::Net::Wifi::Ieee80211FrequencyBand> FrequencyBands;
     std::vector<Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm> AuthenticationAlgorithms;
     std::vector<Microsoft::Net::Wifi::Ieee80211AkmSuite> AkmSuites;
     std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> CipherSuites;
     AccessPointOperationalState OperationalState{ AccessPointOperationalState::Disabled };
-    std::optional<Microsoft::Net::Ieee8021xRadiusConfiguration> RadiusConfiguration;
 
     /**
      * @brief Construct a new AccessPointTest object with the given interface name and default capabilities.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Allow easier management of 802.1X types.
* Ensure authentication related concepts are referred to with consistent naming.

### Technical Details

* Add `Ieee80211Authentication8021x` type, wrap `Ieee8021xRadiusConfiguration` in it, and replace such instance with top-level type.
* Rename identifiers from using `Dot11Dot1xConfiguration` to `Dot11AuthenticationDot1x` for consistency.
* Replace direct 

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
