### PR TITLE
Add ability to specify 802.1X RADIUS settings from netremote-cli

### DIFF
--- a/src/common/net/core/include/microsoft/net/NetworkIpAddress.hxx
+++ b/src/common/net/core/include/microsoft/net/NetworkIpAddress.hxx
@@ -37,6 +37,48 @@ struct NetworkIpAddress
 };
 
 /**
+ * @brief Categories of IP addresses.
+ */
+enum class IpAddressCategory {
+    Unknown,
+    Ipv4,
+    Ipv4Any,
+    Ipv6Any,
+};
+
+/**
+ * @brief Get the category of an IP address.
+ * 
+ * @param ipAddressView The view of the IP address to categorize.
+ * @return IpAddressCategory The category of the IP address.
+ */
+inline IpAddressCategory
+GetIpAddressCategory(std::string_view ipAddressView)
+{
+    const std::string ipAddress{ ipAddressView };
+
+    const std::regex RegexIpv4AnyAddressWithOptionalPort{ "^0.0.0.0(:\\d+)?$" };
+    if (std::regex_match(ipAddress, RegexIpv4AnyAddressWithOptionalPort))
+    {
+        return IpAddressCategory::Ipv4Any;
+    }
+
+    const std::regex RegexIpv6AnyAddressWithOptionalPort{ "^\\[?::\\]?(:\\d+)?$" };
+    if (std::regex_match(ipAddress, RegexIpv6AnyAddressWithOptionalPort))
+    {
+        return IpAddressCategory::Ipv6Any;
+    }
+
+    const std::regex RegexIpv4AddressWithOptionalPort(R"(^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?::(\d|[1-9]\d{1,3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5]))?$)");
+    if (std::regex_match(ipAddress, RegexIpv4AddressWithOptionalPort))
+    {
+        return IpAddressCategory::Ipv4;
+    }
+
+    return IpAddressCategory::Unknown;
+}
+
+/**
  * @brief Determine if a string contains an IPv4 or IPv6 "any" address. The port is optional for both forms, and square
  * brackets are optional for the IPv6 form.
  *
@@ -47,11 +89,8 @@ struct NetworkIpAddress
 inline bool
 IsAnyAddress(std::string_view ipAddressView) noexcept
 {
-    const std::regex RegexIpv4AnyAddressWithPort{ "^0.0.0.0(:\\d+)?$" };
-    const std::regex RegexIpv6AnyAddressWithPort{ "^\\[?::\\]?(:\\d+)?$" };
-    const std::string ipAddress(ipAddressView);
-
-    return std::regex_match(ipAddress, RegexIpv4AnyAddressWithPort) || std::regex_match(ipAddress, RegexIpv6AnyAddressWithPort);
+    const auto ipAddressCategory = GetIpAddressCategory(ipAddressView);
+    return ipAddressCategory == IpAddressCategory::Ipv4Any || ipAddressCategory == IpAddressCategory::Ipv6Any;
 }
 } // namespace Microsoft::Net
 

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -425,7 +425,7 @@ ToString(const Ieee8021xRadiusConfiguration& ieee8021xRadiusConfiguration) noexc
 /**
  * @brief Attempt to parse a vector of tokens into an Ieee8021xRadiusServerEndpointConfiguration.
  *
- * The expected format of the tokens is: [<type=[auth|acct]>,]<address>[:<port>],<sharedsecret>
+ * The expected format of the tokens is: [<[auth|acct]>,]<address>[:<port>],<sharedsecret>
  *
  * If the type is not specified, it defaults to 'auth' (authentication).
  * If the port is not specified, it defaults to 0, which will not set the 'Port' field.
@@ -588,9 +588,9 @@ NetRemoteCli::AddSubcommandWifiAccessPointSet8021xRadius(CLI::App* parent)
     });
 
     cliAppWifiAccessPointSetAuthenticationDot1x->add_option("id", m_cliData->WifiAccessPointId, "The identifier of the access point to set the 802.1X RADIUS configuration for")->required();
-    cliAppWifiAccessPointSetAuthenticationDot1x->add_option("--auth,--authServer,--authenticationServer", m_cliData->WifiAccessPointAuthentication8021x.Radius->AuthenticationServer, "The 802.1X RADIUS authentication server (format='<ipaddress>[:<port>],<sharedsecret>')")->required();
-    cliAppWifiAccessPointSetAuthenticationDot1x->add_option("--acct,--acctServer,--accountingServer", m_cliData->WifiAccessPointAuthentication8021x.Radius->AccountingServer, "The 802.1X RADIUS accounting server (format='<ipaddress>[:<port>],<sharedsecret>')");
-    cliAppWifiAccessPointSetAuthenticationDot1x->add_option("--fallback,--fallbackServer", m_cliData->WifiAccessPointAuthentication8021x.Radius->FallbackServers, "An 802.1X RADIUS fallback server (authentication and/or accounting) server (format='[<type=[auth|acct]>,]<ipaddress>[:<port>],<sharedsecret>')");
+    cliAppWifiAccessPointSetAuthenticationDot1x->add_option("auth,--auth,--authServer,--authenticationServer", m_cliData->WifiAccessPointAuthentication8021x.Radius->AuthenticationServer, "The 802.1X RADIUS authentication server (format='<ip>[:<port>],<sharedsecret>')")->required();
+    cliAppWifiAccessPointSetAuthenticationDot1x->add_option("--acct,--acctServer,--accountingServer", m_cliData->WifiAccessPointAuthentication8021x.Radius->AccountingServer, "The 802.1X RADIUS accounting server (format='<ip>[:<port>],<sharedsecret>')");
+    cliAppWifiAccessPointSetAuthenticationDot1x->add_option("--fallback,--fallbackServer", m_cliData->WifiAccessPointAuthentication8021x.Radius->FallbackServers, "An 802.1X RADIUS authentication or accounting fallback server (format='[<[auth|acct]>,]<ip>[:<port>],<sharedsecret>')");
 
     return cliAppWifiAccessPointSetAuthenticationDot1x;
 }

--- a/src/common/tools/cli/NetRemoteCli.cxx
+++ b/src/common/tools/cli/NetRemoteCli.cxx
@@ -1,8 +1,10 @@
 
 #include <format>
 #include <iostream>
+#include <istream>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -13,6 +15,7 @@
 #include <CLI/Error.hpp>
 #include <CLI/Validators.hpp>
 #include <microsoft/net/Ieee8021xRadiusAuthentication.hxx>
+#include <microsoft/net/NetworkIpAddress.hxx>
 #include <microsoft/net/remote/NetRemoteCli.hxx>
 #include <microsoft/net/remote/NetRemoteCliData.hxx>
 #include <microsoft/net/remote/NetRemoteCliHandler.hxx>
@@ -363,21 +366,231 @@ NetRemoteCli::AddSubcommandWifiAccessPointSetSsid(CLI::App* parent)
     return cliAppWifiAccessPointSetSsid;
 }
 
+namespace Microsoft::Net
+{
+/**
+ * @brief Convert an Ieee8021xRadiusServerEndpointType to a short string representation.
+ *
+ * @param ieee8021xRadiusServerEndpointType The Ieee8021xRadiusServerEndpointType to convert.
+ * @return constexpr std::string_view A short string representation of the Ieee8021xRadiusServerEndpointType.
+ */
+constexpr std::string_view
+ToString(Ieee8021xRadiusServerEndpointType ieee8021xRadiusServerEndpointType) noexcept
+{
+    switch (ieee8021xRadiusServerEndpointType) {
+    case Ieee8021xRadiusServerEndpointType::Authentication:
+        return "auth";
+    case Ieee8021xRadiusServerEndpointType::Accounting:
+        return "acct";
+    default:
+        return "????";
+    }
+}
+
+/**
+ * @brief Convert a Ieee8021xRadiusServerEndpointType to a human-readable string representation.
+ *
+ * @param ieee8021xRadiusServerEndpointConfiguration The Ieee8021xRadiusServerEndpointConfiguration to convert.
+ * @return std::string A human-readable string representation of the Ieee8021xRadiusServerEndpointConfiguration.
+ */
+std::string
+ToString(const Ieee8021xRadiusServerEndpointConfiguration& ieee8021xRadiusServerEndpointConfiguration) noexcept
+{
+    return std::format("[{}] {}:{} secret='{}'",
+        ToString(ieee8021xRadiusServerEndpointConfiguration.Type),
+        ieee8021xRadiusServerEndpointConfiguration.Address,
+        ieee8021xRadiusServerEndpointConfiguration.Port.value_or(0),
+        std::string(std::cbegin(ieee8021xRadiusServerEndpointConfiguration.SharedSecret), std::cend(ieee8021xRadiusServerEndpointConfiguration.SharedSecret)));
+}
+
+/**
+ * @brief Convert an Ieee8021xRadiusServerEndpointType to a string representation.
+ *
+ * @param ieee8021xRadiusConfiguration The Ieee8021xRadiusServerEndpointConfiguration to convert.
+ * @return std::string A multi-line string representation of the Ieee8021xRadiusServerEndpointConfiguration.
+ */
+std::string
+ToString(const Ieee8021xRadiusConfiguration& ieee8021xRadiusConfiguration) noexcept
+{
+    std::ostringstream output{};
+    output << " " << ToString(ieee8021xRadiusConfiguration.AuthenticationServer) << " (primary)\n"
+           << " " << (ieee8021xRadiusConfiguration.AccountingServer.has_value() ? ToString(ieee8021xRadiusConfiguration.AccountingServer.value()) : "[Accounting] <none>") << " (primary)\n";
+    for (const auto& fallbackServer : ieee8021xRadiusConfiguration.FallbackServers) {
+        output << " " << ToString(fallbackServer) << " (fallback)\n";
+    }
+
+    return output.str();
+}
+
+/**
+ * @brief Attempt to parse a vector of tokens into an Ieee8021xRadiusServerEndpointConfiguration.
+ *
+ * The expected format of the tokens is: [<type=[auth|acct]>,]<address>[:<port>],<sharedsecret>
+ *
+ * If the type is not specified, it defaults to 'auth' (authentication).
+ * If the port is not specified, it defaults to 0, which will not set the 'Port' field.
+ *
+ * @param ieee8021xRadiusServerEndpointConfigurationTokens The string tokens to parse into an Ieee8021xRadiusServerEndpointConfiguration.
+ * @param ieee8021xRadiusServerEndpointConfiguration The Ieee8021xRadiusServerEndpointConfiguration to populate with the parsed tokens.
+ * @return true A valid Ieee8021xRadiusServerEndpointConfiguration was successfully parsed and written to the output parameter.
+ * @return false No valid Ieee8021xRadiusServerEndpointConfiguration could be parsed from the input tokens.
+ */
+bool
+ParseIeee8021xRadiusServerEndpointConfiguration(const std::vector<std::string>& ieee8021xRadiusServerEndpointConfigurationTokens, Ieee8021xRadiusServerEndpointConfiguration& ieee8021xRadiusServerEndpointConfiguration) noexcept
+{
+    uint16_t port{ 0 };
+    std::string address{};
+    std::string sharedSecret{};
+    Ieee8021xRadiusServerEndpointType endpointType{ Ieee8021xRadiusServerEndpointType::Authentication };
+
+    // Check the tokens positionally for required arguments. [[fallthrough]]s are used to allow optional fields to be
+    // skipped, effectively shifting their positional index.
+    for (std::size_t numArgument = 0; numArgument < std::size(ieee8021xRadiusServerEndpointConfigurationTokens); ++numArgument) {
+        const auto& token = ieee8021xRadiusServerEndpointConfigurationTokens[numArgument];
+        switch (numArgument) {
+        // Parse the (optional) endpoint type. If not specified, defaults to 'Authentication'.
+        case 0: {
+            if (token == "acct" || token == "accounting") {
+                ieee8021xRadiusServerEndpointConfiguration.Type = Ieee8021xRadiusServerEndpointType::Accounting;
+                break;
+            } else if (token == "auth" || token == "authentication") {
+                ieee8021xRadiusServerEndpointConfiguration.Type = Ieee8021xRadiusServerEndpointType::Authentication;
+                break;
+            }
+            // No recognized endpoint type specified. Fall through to the next case to check if the token contains the
+            // 2nd expected field, an IP address.
+            [[fallthrough]];
+        }
+        // Parse the ip address with optional port.
+        case 1: {
+            // Check if this token specifies an IP address.
+            const auto ipAddressCategory = GetIpAddressCategory(token);
+            if (ipAddressCategory != IpAddressCategory::Unknown) {
+                // The address is valid; check if a port is specified.
+                address = std::move(token);
+                const auto portSeparatorIndex = address.find_last_of(':');
+                if (portSeparatorIndex == std::string::npos) {
+                    // The port is optional, so just take the address as-is.
+                    break;
+                }
+
+                // Attempt to parse the port. While it is optional, if one is specified, it must be valid. So, return
+                // false for all parsing errors.
+                const auto portToken = address.substr(portSeparatorIndex + 1);
+                try {
+                    static constexpr auto PortMaximumValue{ std::numeric_limits<decltype(port)>::max() };
+
+                    const auto portParsed = std::stoul(portToken);
+                    if (portParsed > PortMaximumValue) {
+                        LOGE << std::format("Port '{}' exceeds maximum value '{}' for RADIUS server endpoint configuration", portToken, PortMaximumValue);
+                        return false;
+                    }
+
+                    // Port is valid.
+                    port = static_cast<uint16_t>(portParsed);
+                    address = address.substr(0, portSeparatorIndex);
+                    break;
+                } catch (const std::exception& e) {
+                    LOGE << std::format("Failed to parse port '{}' for RADIUS server endpoint configuration: {}", portToken, e.what());
+                    return false;
+                }
+            }
+            // The token didn't contain an IP address. Fall through to the next case to process it as the shared secret.
+            [[fallthrough]];
+        }
+        // Parse the shared secret.
+        case 2: {
+            sharedSecret = std::move(token);
+            break;
+        }
+        default: {
+            LOGW << std::format("Ignoring unexpected extra argument '{}' for RADIUS server endpoint configuration", token);
+            break;
+        }
+        } // switch
+    } // for
+
+    // Ensure all required values were parsed.
+    if (std::empty(address)) {
+        LOGE << "Missing address for RADIUS server endpoint configuration";
+        return false;
+    }
+    if (std::empty(sharedSecret)) {
+        LOGE << "Missing shared secret for RADIUS server endpoint configuration";
+        return false;
+    }
+
+    // Assign parsed values.
+    ieee8021xRadiusServerEndpointConfiguration.Type = endpointType;
+    ieee8021xRadiusServerEndpointConfiguration.Address = std::move(address);
+    ieee8021xRadiusServerEndpointConfiguration.SharedSecret = { std::make_move_iterator(std::begin(sharedSecret)), std::make_move_iterator(std::end(sharedSecret)) };
+    if (port != 0) {
+        ieee8021xRadiusServerEndpointConfiguration.Port = port;
+    }
+
+    return true;
+}
+
+/**
+ * @brief Helper that will be invoked by CLI11 when parsing a string argument for a RADIUS server endpoint configuration
+ * of type Ieee8021xRadiusServerEndpointConfiguration.
+ *
+ * @param inputStream The input stream containing the arguments to parse a Ieee8021xRadiusServerEndpointConfiguration.
+ * @param ieee8021xRadiusConfiguration The Ieee8021xRadiusServerEndpointConfiguration to populate with the parsed arguments.
+ * @return std::istream&
+ */
+std::istream&
+operator>>(std::istream& inputStream, Ieee8021xRadiusServerEndpointConfiguration& ieee8021xRadiusConfiguration)
+{
+    std::string token{};
+    std::vector<std::string> tokens{};
+
+    // Tokenize the stream by comma, the expected delimeter for arguments specifying a Ieee8021xRadiusServerEndpointConfiguration.
+    while (std::getline(inputStream, token, ',')) {
+        tokens.push_back(std::move(token));
+    }
+
+    // Attempt to parse the tokenized arguments into a Ieee8021xRadiusServerEndpointConfiguration. If successful, clear
+    // the stream of the error/eof bits to signal to CLI11 that parsing was successful.
+    const bool parsingSucceeded = ParseIeee8021xRadiusServerEndpointConfiguration(tokens, ieee8021xRadiusConfiguration);
+    if (parsingSucceeded) {
+        inputStream.clear();
+    }
+
+    return inputStream;
+}
+} // namespace Microsoft::Net
+
 CLI::App*
 NetRemoteCli::AddSubcommandWifiAccessPointSet8021xRadius(CLI::App* parent)
 {
     auto* cliAppWifiAccessPointSetAuthenticationDot1x = parent->add_subcommand("access-point-set-radius", "Set the 802.1X RADIUS configuration for an access point");
     cliAppWifiAccessPointSetAuthenticationDot1x->alias("ap-set-radius")->alias("ap-radius")->alias("radius");
+    cliAppWifiAccessPointSetAuthenticationDot1x->preparse_callback([this]([[maybe_unused]] std::size_t numArguments) {
+        m_cliData->WifiAccessPointAuthentication8021x.Radius.emplace();
+    });
     cliAppWifiAccessPointSetAuthenticationDot1x->callback([this] {
-        const auto* ieee8021xRadiusConfiguration = m_cliData->WifiAccessPointAuthentication8021x.Radius.has_value()
-            ? &m_cliData->WifiAccessPointAuthentication8021x.Radius.value()
-            : nullptr;
+        Ieee8021xRadiusConfiguration* ieee8021xRadiusConfiguration{ nullptr };
+        if (m_cliData->WifiAccessPointAuthentication8021x.Radius.has_value()) {
+            ieee8021xRadiusConfiguration = &m_cliData->WifiAccessPointAuthentication8021x.Radius.value();
+
+            // Force the primary server type(s) in case they were explicitly specified otherwise on the command line.
+            ieee8021xRadiusConfiguration->AuthenticationServer.Type = Ieee8021xRadiusServerEndpointType::Authentication;
+            if (ieee8021xRadiusConfiguration->AccountingServer.has_value()) {
+                ieee8021xRadiusConfiguration->AccountingServer->Type = Ieee8021xRadiusServerEndpointType::Accounting;
+            }
+
+            LOGD << "Parsed 802.1X RADIUS configuration:\n"
+                 << ToString(*ieee8021xRadiusConfiguration);
+        }
+
         OnWifiAccessPointSet8021xRadius(m_cliData->WifiAccessPointId, ieee8021xRadiusConfiguration);
     });
 
     cliAppWifiAccessPointSetAuthenticationDot1x->add_option("id", m_cliData->WifiAccessPointId, "The identifier of the access point to set the 802.1X RADIUS configuration for")->required();
-
-    // TODO: add parsing for 802.1X RADIUS tsconfiguration argumen, vector of of [endpoint type, address, port, shared secret]
+    cliAppWifiAccessPointSetAuthenticationDot1x->add_option("--auth,--authServer,--authenticationServer", m_cliData->WifiAccessPointAuthentication8021x.Radius->AuthenticationServer, "The 802.1X RADIUS authentication server (format='<ipaddress>[:<port>],<sharedsecret>')")->required();
+    cliAppWifiAccessPointSetAuthenticationDot1x->add_option("--acct,--acctServer,--accountingServer", m_cliData->WifiAccessPointAuthentication8021x.Radius->AccountingServer, "The 802.1X RADIUS accounting server (format='<ipaddress>[:<port>],<sharedsecret>')");
+    cliAppWifiAccessPointSetAuthenticationDot1x->add_option("--fallback,--fallbackServer", m_cliData->WifiAccessPointAuthentication8021x.Radius->FallbackServers, "An 802.1X RADIUS fallback server (authentication and/or accounting) server (format='[<type=[auth|acct]>,]<ipaddress>[:<port>],<sharedsecret>')");
 
     return cliAppWifiAccessPointSetAuthenticationDot1x;
 }

--- a/src/common/tools/cli/NetRemoteCliHandler.cxx
+++ b/src/common/tools/cli/NetRemoteCliHandler.cxx
@@ -10,6 +10,7 @@
 #include <microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx>
 #include <plog/Log.h>
 
+using namespace Microsoft::Net;
 using namespace Microsoft::Net::Remote;
 using namespace Microsoft::Net::Wifi;
 
@@ -37,96 +38,92 @@ NetRemoteCliHandler::GetParentStrongRef() const
     return m_parent.lock();
 }
 
+std::tuple<std::shared_ptr<NetRemoteCli>, std::shared_ptr<INetRemoteCliHandlerOperations>>
+NetRemoteCliHandler::GetOperationsAndParentStrongRef() const
+{
+    auto parentStrong{ GetParentStrongRef() };
+    if (!parentStrong) {
+        LOGE << "Parent cli object is no longer valid, aborting command";
+        return {};
+    }
+
+    auto operations{ m_operations };
+    if (!operations) {
+        LOGE << "No operations instance available to handle command";
+        return {};
+    }
+
+    return { parentStrong, operations };
+}
+
 void
 NetRemoteCliHandler::HandleCommandNetworkInterfacesEnumerate()
 {
-    if (!m_operations) {
-        LOGE << "No operations instance available to handle command";
-        return;
-    }
-
-    auto parentStrong{ GetParentStrongRef() };
-    if (parentStrong == nullptr) {
-        LOGW << "Parent cli object is no longer valid, aborting command";
+    auto [parentStrong, operations] = GetOperationsAndParentStrongRef();
+    if (!parentStrong || !operations) {
         return;
     }
 
     LOGD << "Executing command NetworkInterfacesEnumerate";
-    m_operations->NetworkInterfacesEnumerate();
+    operations->NetworkInterfacesEnumerate();
 }
 
 void
 NetRemoteCliHandler::HandleCommandWifiAccessPointsEnumerate(bool detailedOutput)
 {
-    if (!m_operations) {
-        LOGE << "No operations instance available to handle command";
-        return;
-    }
-
-    auto parentStrong{ GetParentStrongRef() };
-    if (parentStrong == nullptr) {
-        LOGW << "Parent cli object is no longer valid, aborting command";
+    auto [parentStrong, operations] = GetOperationsAndParentStrongRef();
+    if (!parentStrong || !operations) {
         return;
     }
 
     LOGD << "Executing command WifiAccessPointsEnumerate";
-    m_operations->WifiAccessPointsEnumerate(detailedOutput);
+    operations->WifiAccessPointsEnumerate(detailedOutput);
 }
 
 void
 NetRemoteCliHandler::HandleCommandWifiAccessPointEnable(std::string_view accessPointId, const Ieee80211AccessPointConfiguration* ieee80211AccessPointConfiguration)
 {
-    if (!m_operations) {
-        LOGE << "No operations instance available to handle command";
-        return;
-    }
-
-    auto parentStrong{ GetParentStrongRef() };
-    if (parentStrong == nullptr) {
-        LOGW << "Parent cli object is no longer valid, aborting command";
+    auto [parentStrong, operations] = GetOperationsAndParentStrongRef();
+    if (!parentStrong || !operations) {
         return;
     }
 
     LOGD << "Executing command WifiAccessPointEnable";
-
-    m_operations->WifiAccessPointEnable(accessPointId, ieee80211AccessPointConfiguration);
+    operations->WifiAccessPointEnable(accessPointId, ieee80211AccessPointConfiguration);
 }
 
 void
 NetRemoteCliHandler::HandleCommandWifiAccessPointDisable(std::string_view accessPointId)
 {
-    if (!m_operations) {
-        LOGE << "No operations instance available to handle command";
-        return;
-    }
-
-    auto parentStrong{ GetParentStrongRef() };
-    if (parentStrong == nullptr) {
-        LOGW << "Parent cli object is no longer valid, aborting command";
+    auto [parentStrong, operations] = GetOperationsAndParentStrongRef();
+    if (!parentStrong || !operations) {
         return;
     }
 
     LOGD << "Executing command WifiAccessPointDisable";
-
-    m_operations->WifiAccessPointDisable(accessPointId);
+    operations->WifiAccessPointDisable(accessPointId);
 }
 
-    void
+void
 NetRemoteCliHandler::HandleCommandWifiAccessPointSetSsid(std::string_view accessPointId, std::string_view ssid)
 {
-    if (!m_operations) {
-        LOGE << "No operations instance available to handle command";
-        return;
-    }
-
-    auto parentStrong{ GetParentStrongRef() };
-    if (parentStrong == nullptr) {
-        LOGW << "Parent cli object is no longer valid, aborting command";
+    auto [parentStrong, operations] = GetOperationsAndParentStrongRef();
+    if (!parentStrong || !operations) {
         return;
     }
 
     LOGD << "Executing command WifiAccessPointSetSsid";
-
-    m_operations->WifiAccessPointSetSsid(accessPointId, ssid);
+    operations->WifiAccessPointSetSsid(accessPointId, ssid);
 }
 
+void
+NetRemoteCliHandler::HandleCommandWifiAccessPointSet8021xRadius(std::string_view accessPointId, const Ieee8021xRadiusConfiguration* ieee8021xRadiusConfiguration)
+{
+    auto [parentStrong, operations] = GetOperationsAndParentStrongRef();
+    if (!parentStrong || !operations) {
+        return;
+    }
+
+    LOGD << "Executing command WifiAccessPointSet8021xRadius";
+    operations->WifiAccessPointSet8021xRadius(accessPointId, ieee8021xRadiusConfiguration);
+}

--- a/src/common/tools/cli/include/microsoft/net/remote/INetRemoteCliHandlerOperations.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/INetRemoteCliHandlerOperations.hxx
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string_view>
 
+#include <microsoft/net/Ieee8021xRadiusAuthentication.hxx>
 #include <microsoft/net/remote/NetRemoteServerConnection.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx>
 
@@ -65,12 +66,21 @@ struct INetRemoteCliHandlerOperations
 
     /**
      * @brief Set the SSID of the specified WiFi access point.
-     * 
+     *
      * @param accessPointId The identifier of the access point to set the SSID for.
      * @param ssid The SSID to set.
      */
     virtual void
     WifiAccessPointSetSsid(std::string_view accessPointId, std::string_view ssid) = 0;
+
+    /**
+     * @brief Set the RADIUS configuration for the specified WiFi access point.
+     *
+     * @param accessPointId The identifier of the access point to set the RADIUS configuration for.
+     * @param ieee8021xRadiusConfiguration The RADIUS authentication configuration to set.
+     */
+    virtual void
+    WifiAccessPointSet8021xRadius(std::string_view accessPointId, const Microsoft::Net::Ieee8021xRadiusConfiguration* ieee8021xRadiusConfiguration) = 0;
 };
 
 /**

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCli.hxx
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include <CLI/CLI.hpp>
+#include <microsoft/net/Ieee8021xRadiusAuthentication.hxx>
 #include <microsoft/net/remote/NetRemoteCliData.hxx>
 #include <microsoft/net/remote/NetRemoteCliHandler.hxx>
 #include <microsoft/net/remote/NetRemoteServerConnection.hxx>
@@ -133,12 +134,21 @@ private:
 
     /**
      * @brief Add the 'wifi ap-set-ssid' sub-command.
-     * 
+     *
      * @param parent The parent app to add the sub-command to.
-     * @return CLI::App* 
+     * @return CLI::App*
      */
     CLI::App*
     AddSubcommandWifiAccessPointSetSsid(CLI::App* parent);
+
+    /**
+     * @brief Add the 'wifi ap-set-radius' sub-command.
+     *
+     * @param parent The parent app to add the sub-command to.
+     * @return CLI::App*
+     */
+    CLI::App*
+    AddSubcommandWifiAccessPointSet8021xRadius(CLI::App* parent);
 
     /**
      * @brief Handle the 'server' option.
@@ -179,12 +189,21 @@ private:
 
     /**
      * @brief Handle the 'wifi ap-set-ssid' command.
-     * 
+     *
      * @param accessPointId The identifier of the access point to set the SSID for.
      * @param ssid The SSID to set.
      */
     void
     OnWifiAccessPointSetSsid(std::string_view accessPointId, std::string_view ssid);
+
+    /**
+     * @brief Handle the 'wifi ap-set-radius' command.
+     *
+     * @param accessPointId The identifier of the access point to set the RADIUS configuration for.
+     * @param ieee8021xRadiusConfiguration The RADIUS authentication configuration to set.
+     */
+    void
+    OnWifiAccessPointSet8021xRadius(std::string_view accessPointId, const Microsoft::Net::Ieee8021xRadiusConfiguration* ieee8021xRadiusConfiguration);
 
     /**
      * @brief Handle the 'wifi ap-disable' command.
@@ -209,6 +228,7 @@ private:
     CLI::App* m_cliAppWifiAccessPointEnable{ nullptr };
     CLI::App* m_cliAppWifiAccessPointDisable{ nullptr };
     CLI::App* m_cliAppWifiAccessPointSetSsid{ nullptr };
+    CLI::App* m_cliAppWifiAccessPointSetAuthenticationDot1x{ nullptr };
 };
 } // namespace Microsoft::Net::Remote
 

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliData.hxx
@@ -33,6 +33,7 @@ struct NetRemoteCliData
     std::vector<Microsoft::Net::Wifi::Ieee80211AuthenticationAlgorithm> WifiAccessPointAuthenticationAlgorithms{};
     std::vector<Microsoft::Net::Wifi::Ieee80211AkmSuite> WifiAccessPointAkmSuites{};
     Microsoft::Net::Wifi::Ieee80211PhyType WifiAccessPointPhyType{ Microsoft::Net::Wifi::Ieee80211PhyType::Unknown };
+    Microsoft::Net::Wifi::Ieee80211Authentication8021x WifiAccessPointAuthentication8021x{};
 };
 } // namespace Microsoft::Net::Remote
 

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandler.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandler.hxx
@@ -4,7 +4,9 @@
 
 #include <memory>
 #include <string_view>
+#include <tuple>
 
+#include <microsoft/net/Ieee8021xRadiusAuthentication.hxx>
 #include <microsoft/net/remote/NetRemoteServerConnection.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx>
 
@@ -92,12 +94,21 @@ struct NetRemoteCliHandler
 
     /**
      * @brief Handle a command to set the SSID of a Wi-Fi access point.
-     * 
+     *
      * @param accessPointId The identifier of the access point to set the SSID for.
      * @param ssid The SSID to set.
      */
     void
     HandleCommandWifiAccessPointSetSsid(std::string_view accessPointId, std::string_view ssid);
+
+    /**
+     * @brief Handle a command to set the RADIUS configuration for a Wi-Fi access point.
+     *
+     * @param accessPointId The identifier of the access point to set the RADIUS configuration for.
+     * @param ieee8021xRadiusConfiguration The RADIUS authentication configuration to set.
+     */
+    void
+    HandleCommandWifiAccessPointSet8021xRadius(std::string_view accessPointId, const Microsoft::Net::Ieee8021xRadiusConfiguration* ieee8021xRadiusConfiguration);
 
 private:
     /**
@@ -108,6 +119,15 @@ private:
      */
     std::shared_ptr<NetRemoteCli>
     GetParentStrongRef() const;
+
+    /**
+     * @brief Obtain a strong reference to the parent NetRemoteCli object and the operations instance to use for
+     * handling commands.
+     * 
+     * @return std::tuple<std::shared_ptr<NetRemoteCli>, std::shared_ptr<INetRemoteCliHandlerOperations>> 
+     */
+    std::tuple<std::shared_ptr<NetRemoteCli>, std::shared_ptr<INetRemoteCliHandlerOperations>>
+    GetOperationsAndParentStrongRef() const;
 
 private:
     std::weak_ptr<NetRemoteCli> m_parent;

--- a/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandlerOperations.hxx
+++ b/src/common/tools/cli/include/microsoft/net/remote/NetRemoteCliHandlerOperations.hxx
@@ -4,6 +4,7 @@
 
 #include <memory>
 
+#include <microsoft/net/Ieee8021xRadiusAuthentication.hxx>
 #include <microsoft/net/remote/INetRemoteCliHandlerOperations.hxx>
 #include <microsoft/net/remote/NetRemoteServerConnection.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointConfiguration.hxx>
@@ -80,6 +81,15 @@ struct NetRemoteCliHandlerOperations :
      */
     void
     WifiAccessPointSetSsid(std::string_view accessPointId, std::string_view ssid) override;
+
+    /**
+     * @brief Set the RADIUS configuration for the specified WiFi access point.
+     *
+     * @param accessPointId The identifier of the access point to set the RADIUS configuration for.
+     * @param ieee8021xRadiusConfiguration The RADIUS authentication configuration to set.
+     */
+    void
+    WifiAccessPointSet8021xRadius(std::string_view accessPointId, const Microsoft::Net::Ieee8021xRadiusConfiguration* ieee8021xRadiusConfiguration) override;
 
 private:
     std::shared_ptr<NetRemoteServerConnection> m_connection;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow 802.1X RAIDUS settings to be configured via the command line tool `netremote-cli`.

### Technical Details

* Add new command `wifi radius <id> [--auth=]<ip[:port]>,<sharedsecret> [--acct=<ip:[:port]>,<sharedsecret>] [--fallback=[<[auth|acct]>,]<ip>[:<port>],<sharedsecret>]`
* Add helper to categorize an IP address string as IPv4, IPv4 "any address", IPv6, IPV6 "any address".
* Add helper in `NetRemoteCliHandler` to de-duplicate code that takes and checks a strong reference on the parent and validates the CLI handler operations vector.

### Test Results

* All unit tests pass.
* Validated specified configuration is properly encoded and converted to API types, and is received correctly by service following conversion:

<img width="1031" alt="image" src="https://github.com/microsoft/netremote/assets/2082148/21ae91b4-d587-443b-872b-0381e8c28e89">

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
