### PR TITLE
Initialize all struct members explicitly.

### DIFF
--- a/src/common/server/include/microsoft/net/remote/service/NetRemoteServerConfiguration.hxx
+++ b/src/common/server/include/microsoft/net/remote/service/NetRemoteServerConfiguration.hxx
@@ -67,12 +67,12 @@ struct NetRemoteServerConfiguration
     /**
      * @brief Object to use when performing network operations.
      */
-    std::shared_ptr<Microsoft::Net::NetworkManager> NetworkManager;
+    std::shared_ptr<Microsoft::Net::NetworkManager> NetworkManager{};
 
     /**
      * @brief Factory to use to create the discovery service.
      */
-    std::shared_ptr<INetRemoteDiscoveryServiceFactory> DiscoveryServiceFactory;
+    std::shared_ptr<INetRemoteDiscoveryServiceFactory> DiscoveryServiceFactory{};
 };
 
 } // namespace Microsoft::Net::Remote::Service

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx
@@ -14,11 +14,11 @@ namespace Microsoft::Net::Wifi
  */
 struct Ieee80211AccessPointCapabilities
 {
-    std::vector<Ieee80211SecurityProtocol> SecurityProtocols;
-    std::vector<Ieee80211PhyType> PhyTypes;
-    std::vector<Ieee80211FrequencyBand> FrequencyBands;
-    std::vector<Ieee80211AkmSuite> AkmSuites;
-    std::vector<Ieee80211CipherSuite> CipherSuites;
+    std::vector<Ieee80211SecurityProtocol> SecurityProtocols{};
+    std::vector<Ieee80211PhyType> PhyTypes{};
+    std::vector<Ieee80211FrequencyBand> FrequencyBands{};
+    std::vector<Ieee80211AkmSuite> AkmSuites{};
+    std::vector<Ieee80211CipherSuite> CipherSuites{};
 
     /**
      * @brief Get a string representation of the capabilities.

--- a/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -929,9 +929,9 @@ static constexpr uint16_t RadiusAccountingPortDefault = 1813;
 struct RadiusEndpointConfiguration
 {
     RadiusEndpointType Type{ RadiusEndpointType::Unknown };
-    std::string Address;
-    std::optional<uint16_t> Port;
-    std::string SharedSecret;
+    std::string Address{};
+    std::optional<uint16_t> Port{};
+    std::string SharedSecret{};
 };
 
 /**


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Ensure structs explicitly initialize all of their field members to allow aggregate initialization to skip initializing some and receive the default value.

### Technical Details

* Default-initialize (`{}`) all struct field members that weren't previously explicitly initialized.

### Test Results

* All unit tests pass.
* Compiling with LLVM-18 which has stricter checks, does not emit any `-Wmissing-field-initializers` warnings.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
