### PR TITLE
Fix use-after-free violation in NetlinkException

### DIFF
--- a/src/linux/libnl-helpers/NetlinkErrorCategory.cxx
+++ b/src/linux/libnl-helpers/NetlinkErrorCategory.cxx
@@ -31,7 +31,7 @@ NetlinkErrorCategory::default_error_condition(int error) const noexcept
 std::error_code
 make_netlink_error_code(int error)
 {
-    return std::error_code(error, NetlinkErrorCategory());
+    return std::error_code(error, GetNetlinkErrorCategory());
 }
 
 std::error_code
@@ -42,6 +42,13 @@ MakeNetlinkErrorCode(int error)
     }
 
     return make_netlink_error_code(error);
+}
+
+const NetlinkErrorCategory&
+GetNetlinkErrorCategory()
+{
+    static NetlinkErrorCategory instance;
+    return instance;
 }
 
 } // namespace Microsoft::Net::Netlink

--- a/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkErrorCategory.hxx
+++ b/src/linux/libnl-helpers/include/microsoft/net/netlink/NetlinkErrorCategory.hxx
@@ -42,25 +42,33 @@ struct NetlinkErrorCategory :
 
 /**
  * @brief Constructs a std::error_code from a netlink error code.
- * 
+ *
  * This function uses the std naming convention.
- * 
+ *
  * @param error The netlink error code. Must be positive.
- * @return std::error_code 
+ * @return std::error_code
  */
 [[nodiscard]] std::error_code
 make_netlink_error_code(int error);
 
 /**
  * @brief Alias for the make_netlink_error_code function.
- * 
+ *
  * This function uses the project naming convention.
- * 
- * @param error 
- * @return std::error_code 
+ *
+ * @param error
+ * @return std::error_code
  */
 [[nodiscard]] std::error_code
 MakeNetlinkErrorCode(int error);
+
+/**
+ * @brief Get the NetlinkErrorCategory object instance.
+ * 
+ * @return const NetlinkErrorCategory& 
+ */
+[[nodiscard]] const NetlinkErrorCategory&
+GetNetlinkErrorCategory();
 
 } // namespace Microsoft::Net::Netlink
 

--- a/tests/unit/linux/libnl-helpers/CMakeLists.txt
+++ b/tests/unit/linux/libnl-helpers/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(libnl-helpers-test-unit
         Main.cxx
         TestNetlink80211Interface.cxx
         TestNetlink80211ProtocolState.cxx
+        TestNetlinkException.cxx
         TestNetlinkRoute.cxx
 )
 

--- a/tests/unit/linux/libnl-helpers/TestNetlinkException.cxx
+++ b/tests/unit/linux/libnl-helpers/TestNetlinkException.cxx
@@ -1,0 +1,14 @@
+
+#include <catch2/catch_test_macros.hpp>
+#include <microsoft/net/netlink/NetlinkException.hxx>
+#include <netlink/errno.h>
+
+TEST_CASE("NetlinkException", "[linux][libnl-helpers]")
+{
+    using Microsoft::Net::Netlink::NetlinkException;
+
+    SECTION("Does not crash")
+    {
+        REQUIRE_THROWS_AS(throw NetlinkException(NLE_BAD_SOCK, "test"), NetlinkException);
+    }
+}


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Fix #294
* Ensure throwing a `NetlinkException` does not cause a crash or weird results when later reading the error category information from the `NetlinkException` instance.

### Technical Details

When creating an instance of `NetlinkException`, and temporary instance of `NetlinkErrorCategory` is passed to the `std::error_code` constructor. However, `std::error_code` expects a const reference and does not make a copy of it. Since we passed a temporary, this later results in a use-after-free bug which would cause either a crash (good case) or weird results when reading the error category information from the `NetlinkException` later. This is solved by using a singleton `NetlinkErrorCategory` and passing this instance to the `std::error_code` constructor.

* Add function to generate singleton instance of `NetlinkErrorCategory`.
* Pass valid, long-lived instance of `NetlinkErrorCategory` to `std:;error_code` constructor when creating a `NetlinkException`.
* Add unit test to ensure `NetlinkException` doesn't cause a crash or trigger AddressSanitizer.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
