### PR TITLE
Omit reloading hostapd config after frequency band change

### DIFF
--- a/src/linux/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/wifi/core/AccessPointControllerLinux.cxx
@@ -262,15 +262,7 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
         }
     }
 
-    // Reload the hostapd configuration to pick up the changes.
-    try {
-        m_hostapd.Reload();
-    } catch (const HostapdException& ex) {
-        status.Code = AccessPointOperationStatusCode::InternalError;
-        status.Details = std::format("failed to reload hostapd configuration for frequency band change - {}", ex.what());
-        return status;
-    }
-
+    // Band changes do not require reloading configuration, so skip that step and mark the operation as successful.
     status.Code = AccessPointOperationStatusCode::Succeeded;
 
     return status;


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow frequency band changes without the AP toggling offline/online.

### Technical Details

* Remove explicit reload from implementations of `AccessPointControllerLinux::SetFrequencyBands` as hostapd doesn't require this for the change to take effect.

### Test Results

* All unit tests pass.
* Ad-hoc test done manually with hostapd_cli to change bands with `setband` command and observed change in band from other machine.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
