### PR TITLE
Enable use of Ieee80211FrequencyBand literals _MHz and _GHz on Windows with MSVC

### DIFF
--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -32,7 +32,6 @@ enum class Ieee80211FrequencyBand {
 
 namespace Literals
 {
-#ifndef _MSC_VER
 /**
  * @brief User-defined literal operator for allowing use of _GHz to specify
  * frequency band enumeration values.
@@ -64,8 +63,6 @@ operator"" _GHz(long double value) noexcept
         return Microsoft::Net::Wifi::Ieee80211FrequencyBand::Unknown;
     }
 }
-
-#endif // _MSC_VER
 
 /**
  * @brief User-defined literal operator for allowing use of _MHz to specify

--- a/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -37,7 +37,7 @@ namespace Literals
  * @brief User-defined literal operator for allowing use of _GHz to specify
  * frequency band enumeration values.
  */
-inline constexpr Microsoft::Net::Wifi::Ieee80211FrequencyBand
+inline Microsoft::Net::Wifi::Ieee80211FrequencyBand
 operator"" _GHz(long double value) noexcept
 {
     /**

--- a/tests/unit/wifi/core/TestIeee80211.cxx
+++ b/tests/unit/wifi/core/TestIeee80211.cxx
@@ -37,7 +37,7 @@ TEST_CASE("IeeeDot11FrequencyBand GHz literals translate correctly", "[wifi][cor
             5.01_GHz,
             5.9999999999_GHz,
             6.01_GHz,
-            6.0000000000000001_GHz,
+            6.000000000000001_GHz,
             7.0_GHz,
             2000.00_GHz,
             2400.00_GHz,

--- a/tests/unit/wifi/core/TestIeee80211.cxx
+++ b/tests/unit/wifi/core/TestIeee80211.cxx
@@ -25,7 +25,7 @@ TEST_CASE("IeeeDot11FrequencyBand GHz literals translate correctly", "[wifi][cor
 
     SECTION("Invalid literal values translate to 'Unknown'")
     {
-        static constexpr std::initializer_list<Ieee80211FrequencyBand> InvalidBandValues{
+        static const std::initializer_list<Ieee80211FrequencyBand> InvalidBandValues{
             0.0_GHz,
             1.0_GHz,
             2.0_GHz,

--- a/tests/unit/wifi/core/TestIeee80211.cxx
+++ b/tests/unit/wifi/core/TestIeee80211.cxx
@@ -9,7 +9,6 @@
 // literal in the code. 
 // NOLINT(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
 
-#ifndef _MSC_VER 
 TEST_CASE("IeeeDot11FrequencyBand GHz literals translate correctly", "[wifi][core]")
 {
     using namespace Microsoft::Net::Wifi::Literals;
@@ -51,8 +50,6 @@ TEST_CASE("IeeeDot11FrequencyBand GHz literals translate correctly", "[wifi][cor
         }
     }
 }
-
-#endif // _MSC_VER
 
 TEST_CASE("Ieee80211FrequencyBand MHz literals translate correctly", "[wifi][core]")
 {


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals

* Allow the `_GHz` and `_MHz` literals for `Ieee80211FrequencyBand` to be used on Windows with MSVC.
* Resolve #91.

### Technical Details

* Drop the literal definitions from `constexpr` to `const`.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* It'd be nice to restore this to `constexpr`.

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
