### PR TITLE
Add ability to listen to WPA (hostapd, wpa_supplicant) events

### DIFF
--- a/src/linux/wpa-controller/CMakeLists.txt
+++ b/src/linux/wpa-controller/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(wpa-controller
         WpaController.cxx
         WpaControlSocket.cxx
         WpaControlSocketConnection.cxx
+        WpaEventHandler.cxx
         WpaKeyValuePair.cxx
         WpaParsingUtilities.cxx
         WpaParsingUtilities.hxx
@@ -29,6 +30,8 @@ target_sources(wpa-controller
     FILES
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/Hostapd.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/IHostapd.hxx
+        ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/IWpaEventListener.hxx
+        ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/IWpaEventProducer.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/ProtocolHostapd.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/ProtocolWpa.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/ProtocolWpaConfig.hxx
@@ -40,6 +43,8 @@ target_sources(wpa-controller
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaControlSocket.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaControlSocketConnection.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaCore.hxx
+        ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaEvent.hxx
+        ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaEventHandler.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaKeyValuePair.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaResponse.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaResponseParser.hxx

--- a/src/linux/wpa-controller/CMakeLists.txt
+++ b/src/linux/wpa-controller/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(wpa-controller
         WpaControlSocket.cxx
         WpaControlSocketConnection.cxx
         WpaEventHandler.cxx
+        WpaEventListenerProxy.cxx
         WpaKeyValuePair.cxx
         WpaParsingUtilities.cxx
         WpaParsingUtilities.hxx
@@ -31,7 +32,6 @@ target_sources(wpa-controller
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/Hostapd.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/IHostapd.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/IWpaEventListener.hxx
-        ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/IWpaEventProducer.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/ProtocolHostapd.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/ProtocolWpa.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/ProtocolWpaConfig.hxx
@@ -45,6 +45,7 @@ target_sources(wpa-controller
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaCore.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaEvent.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaEventHandler.hxx
+        ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaEventListenerProxy.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaKeyValuePair.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaResponse.hxx
         ${WPA_CONTROLLER_PUBLIC_INCLUDE_PREFIX}/WpaResponseParser.hxx

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -16,6 +16,7 @@
 #include <Wpa/WpaCommandSet.hxx>
 #include <Wpa/WpaCommandStatus.hxx>
 #include <Wpa/WpaControlSocket.hxx>
+#include <Wpa/WpaControlSocketConnection.hxx>
 #include <Wpa/WpaCore.hxx>
 #include <Wpa/WpaResponseStatus.hxx>
 #include <magic_enum.hpp>
@@ -34,8 +35,16 @@ Hostapd::IsManagingInterface(std::string_view interfaceName) noexcept
 
 Hostapd::Hostapd(std::string_view interfaceName) :
     m_interface(interfaceName),
-    m_controller(interfaceName, WpaType::Hostapd)
+    m_controller(interfaceName, WpaType::Hostapd),
+    m_eventListenerProxy(WpaEventListenerProxy::Create(*this)),
+    m_eventHandler(std::make_unique<WpaEventHandler>(WpaControlSocketConnection::TryCreate(interfaceName, m_controller.ControlSocketPath()))),
+    m_eventHandlerRegistrationToken(m_eventHandler->RegisterEventListener(m_eventListenerProxy->weak_from_this()))
 {
+}
+
+Hostapd::~Hostapd()
+{
+    m_eventHandler->UnregisterEventListener(m_eventHandlerRegistrationToken);
 }
 
 std::string_view
@@ -505,4 +514,10 @@ std::string_view
 Hostapd::GetIpAddress() const noexcept
 {
     return m_ownIpAddress;
+}
+
+void
+Hostapd::OnWpaEvent(WpaEventSender* sender, const WpaEventArgs* eventArgs)
+{
+    LOGD << std::format("Hostapd event @ {}: {:#08x} {}", eventArgs->Timestamp, reinterpret_cast<uintptr_t>(sender), eventArgs->Event.Payload);
 }

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -43,11 +43,11 @@ Hostapd::Hostapd(std::string_view interfaceName) :
         throw HostapdException("Failed to create hostapd event handler control socket connection");
     }
 
-    auto eventHandler{ std::make_unique<WpaEventHandler>(std::move(controlSocketConnection)) };
+    auto eventHandler{ std::make_unique<WpaEventHandler>(std::move(controlSocketConnection), WpaType::Hostapd) };
     if (!eventHandler) {
         throw HostapdException("Failed to create hostapd event handler");
     }
-    
+
     m_eventHandlerRegistrationToken = eventHandler->RegisterEventListener(m_eventListenerProxy->weak_from_this());
     m_eventHandler = std::move(eventHandler);
     m_eventHandler->StartListening();

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -50,6 +50,7 @@ Hostapd::Hostapd(std::string_view interfaceName) :
     
     m_eventHandlerRegistrationToken = eventHandler->RegisterEventListener(m_eventListenerProxy->weak_from_this());
     m_eventHandler = std::move(eventHandler);
+    m_eventHandler->StartListening();
 }
 
 Hostapd::~Hostapd()

--- a/src/linux/wpa-controller/WpaControlSocketConnection.cxx
+++ b/src/linux/wpa-controller/WpaControlSocketConnection.cxx
@@ -16,7 +16,8 @@ WpaControlSocketConnection::~WpaControlSocketConnection()
 }
 
 WpaControlSocketConnection::WpaControlSocketConnection(std::string_view interfaceName, std::filesystem::path controlSocketPathDir) :
-    m_controlSocketPath(std::move(controlSocketPathDir) / interfaceName)
+    m_controlSocketPath(std::move(controlSocketPathDir) / interfaceName),
+    m_interfaceName(interfaceName)
 {
 }
 
@@ -62,4 +63,10 @@ WpaControlSocketConnection::Disconnect() noexcept
         wpa_ctrl_close(m_controlSocket);
         m_controlSocket = nullptr;
     }
+}
+
+std::string_view
+WpaControlSocketConnection::GetInterfaceName() const noexcept
+{
+    return m_interfaceName;
 }

--- a/src/linux/wpa-controller/WpaEventHandler.cxx
+++ b/src/linux/wpa-controller/WpaEventHandler.cxx
@@ -1,0 +1,273 @@
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <format>
+#include <memory>
+#include <mutex>
+
+#include <Wpa/ProtocolWpa.hxx>
+#include <Wpa/WpaEventHandler.hxx>
+#include <notstd/Scope.hxx>
+#include <plog/Log.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <wpa_ctrl.h>
+
+using namespace Wpa;
+
+WpaEventHandler::WpaEventHandler(std::unique_ptr<WpaControlSocketConnection> wpaControlSocketConnection) :
+    m_wpaControlSocketConnection(std::move(wpaControlSocketConnection))
+{
+}
+
+WpaEventHandler::~WpaEventHandler()
+{
+    StopListening();
+}
+
+WpaEventListenerRegistrationToken
+WpaEventHandler::RegisterEventListener(std::weak_ptr<IWpaEventListener> wpaEventListener)
+{
+    std::unique_lock eventListenerWriteLock{ m_eventListenerStateGate };
+
+    auto wpaEventListenerRegistrationToken = m_eventListenerRegistrationTokenNext++;
+    m_eventListeners[wpaEventListenerRegistrationToken] = wpaEventListener;
+    LOGD << std::format("Registered WPA event listener with eventListenerRegistrationToken '{}' on interface '{}'", wpaEventListenerRegistrationToken, m_wpaControlSocketConnection->GetInterfaceName());
+
+    return wpaEventListenerRegistrationToken;
+}
+
+void
+WpaEventHandler::UnregisterEventListener(WpaEventListenerRegistrationToken wpaEventListenerRegistrationToken)
+{
+    std::unique_lock eventListenerWriteLock{ m_eventListenerStateGate };
+
+    const auto numRemoved = m_eventListeners.erase(wpaEventListenerRegistrationToken);
+    if (numRemoved == 0) {
+        LOGW << std::format("Attempted to unregister a WPA event listener that was not registered for interface '{}'.", m_wpaControlSocketConnection->GetInterfaceName());
+    } else {
+        LOGD << std::format("Unregistered WPA event listener with eventListenerRegistrationToken '{}' on interface '{}'", wpaEventListenerRegistrationToken, m_wpaControlSocketConnection->GetInterfaceName());
+    }
+}
+
+void
+WpaEventHandler::StartListening()
+{
+    std::unique_lock eventListenerWriteLock{ m_eventListenerStateGate };
+
+    m_eventListenerThread = std::jthread([this](std::stop_token stopToken) mutable {
+        ProcessEvents(*m_wpaControlSocketConnection, std::move(stopToken));
+    });
+}
+
+void
+WpaEventHandler::StopListening()
+{
+    // Check if the eventfd file descriptor for signaling thread stop has been created. If so, signal the thread to stop.
+    if (m_fdEventFdStop != -1) {
+        uint64_t value{ EventFdStopRequestValue };
+        ssize_t numWritten = write(m_fdEventFdStop, &value, sizeof value);
+        if (numWritten != sizeof value) {
+            LOGE << std::format("Failed to write to eventfd for interface '{}'.", m_wpaControlSocketConnection->GetInterfaceName());
+        }
+
+        close(m_fdEventFdStop);
+        m_fdEventFdStop = -1;
+    }
+
+    m_eventListenerThread.request_stop();
+    m_eventListenerThread.join();
+}
+
+void
+WpaEventHandler::ProcessNextEvent(WpaControlSocketConnection& wpaControlSocketConnection)
+{
+    const auto InterfaceName{ wpaControlSocketConnection.GetInterfaceName() };
+    LOGD << std::format("Processing pending WPA event on interface '{}'.", InterfaceName);
+
+    // Allocate a buffer for the event data, and subtract one to leave room for the null terminator.
+    std::array<char, ProtocolWpa::EventSizeMax + 1> wpaEventBuffer{};
+    std::size_t wpaEventBufferSize = std::size(wpaEventBuffer) - 1;
+
+    // Retrieve the next WPA event from the control socket.
+    int ret = wpa_ctrl_recv(*m_wpaControlSocketConnection, std::data(wpaEventBuffer), &wpaEventBufferSize);
+    if (ret < 0) {
+        LOGE << std::format("Failed to receive WPA event on interface '{}'.", InterfaceName);
+        return;
+    }
+
+    // Explicitly null-terminate the buffer in case bad data was provided.
+    wpaEventBuffer[wpaEventBufferSize] = '\0';
+
+    // Record the time this event was received.
+    const auto timestampNow{ std::chrono::system_clock::now() };
+    std::string wpaEventPayload{ std::data(wpaEventBuffer), wpaEventBufferSize };
+
+    // Create a WPA event args object to pass to the listeners.
+    WpaEventArgs wpaEventArgs{
+        .Timestamp = timestampNow,
+        .Event = {
+            .Source = WpaType::Hostapd, // TODO: determine true source of the event.
+            .Payload = { std::data(wpaEventBuffer), wpaEventBufferSize },
+        },
+    };
+
+    // Make a copy of the event listeners to minimuze the time we hold the state lock. This is safe since the event
+    // listeners are weak_ptrs which we later attempt to promote to a full shared_ptr before de-referencing them.
+    decltype(m_eventListeners) eventListeners{};
+    std::vector<decltype(m_eventListeners)::key_type> eventListenerRegistrationTokensExpired{};
+    {
+        std::shared_lock eventListenerReadLock{ m_eventListenerStateGate };
+        eventListeners = m_eventListeners;
+    }
+
+    // Invoke each registered event listener with the event args.
+    for (const auto& [eventListenerRegistrationToken, eventListenerWeak] : eventListeners) {
+        std::shared_ptr<IWpaEventListener> eventListener = eventListenerWeak.lock();
+        if (!eventListener) {
+            LOGW << std::format("WPA event listener with registration token '{}' on interface '{}' expired; removing it", eventListenerRegistrationToken, InterfaceName);
+            eventListenerRegistrationTokensExpired.push_back(eventListenerRegistrationToken);
+            continue;
+        }
+
+        // Fire the event on the listener.
+        eventListener->OnWpaEvent(this, &wpaEventArgs);
+    }
+
+    // Remove any expired listeners.
+    if (!std::empty(eventListenerRegistrationTokensExpired)) {
+        std::unique_lock eventListenerWriteLock{ m_eventListenerStateGate };
+        for (const auto& eventListenerRegistrationToken : eventListenerRegistrationTokensExpired) {
+            m_eventListeners.erase(eventListenerRegistrationToken);
+        }
+    }
+}
+
+void
+WpaEventHandler::ProcessEvents(WpaControlSocketConnection& wpaControlSocketConnection, std::stop_token stopToken)
+{
+    // One event for eventfd stop signaling, and one for WPA control socket event signaling.
+    static constexpr int EpollEventsMax{ 2 };
+
+    const auto InterfaceName{ wpaControlSocketConnection.GetInterfaceName() };
+
+    std::array<epoll_event, EpollEventsMax> epollEvents = {};
+    auto* eventEventFd = &epollEvents[0];
+    auto* eventWpa = &epollEvents[1];
+
+    // Create an epoll instance to listen for events on the eventfd file descriptor and WPA control socket.
+    int ret{ -1 };
+    int fdEpoll = epoll_create1(0);
+    if (fdEpoll < 0) {
+        ret = errno;
+        LOGE << std::format("Failed to create epoll instance for interface '{}': {}", InterfaceName, ret);
+        return;
+    }
+
+    auto closeEpollFileDescriptorOnExit = notstd::ScopeExit([&] {
+        close(fdEpoll);
+    });
+
+    // Configure eventfd descriptor for thread stop signaling via epoll.
+    int fdEventFdStop = eventfd(0, 0);
+    if (fdEventFdStop < 0) {
+        ret = errno;
+        LOGE << std::format("Failed to create eventfd for interface '{}': {}", InterfaceName, ret);
+        return;
+    }
+
+    auto closeEventFdStopFileDescriptorOnExit = notstd::ScopeExit([&] {
+        close(fdEventFdStop);
+    });
+
+    eventEventFd->events = EPOLLIN;
+    eventEventFd->data.fd = fdEventFdStop;
+
+    // Add the eventfd descriptor to the epoll instance.
+    ret = epoll_ctl(fdEpoll, EPOLL_CTL_ADD, fdEventFdStop, eventEventFd);
+    if (ret < 0) {
+        ret = errno;
+        LOGE << std::format("Failed to add eventfd to epoll instance for interface '{}': {}", InterfaceName, ret);
+        return;
+    }
+
+    struct wpa_ctrl* wpaControlSocket = wpaControlSocketConnection;
+
+    // Configure WPA control socket for event signaling via epoll.
+    int fdWpa = wpa_ctrl_get_fd(wpaControlSocket);
+    if (fdWpa < 0) {
+        ret = errno;
+        LOGE << std::format("Failed to get WPA control socket file descriptor for interface '{}': {}", InterfaceName, ret);
+        return;
+    }
+
+    eventWpa->events = EPOLLIN;
+    eventWpa->data.fd = fdWpa;
+
+    ret = epoll_ctl(fdEpoll, EPOLL_CTL_ADD, fdWpa, eventWpa);
+    if (ret < 0) {
+        ret = errno;
+        LOGE << std::format("Failed to add WPA control socket to epoll instance for interface '{}': {}", InterfaceName, ret);
+        return;
+    }
+
+    // Attach to WAP eventstream.
+    ret = wpa_ctrl_attach(wpaControlSocket);
+    if (ret < 0) {
+        ret = errno;
+        LOGE << std::format("Failed to attach to WPA control socket for interface '{}': {}", InterfaceName, ret);
+        return;
+    }
+
+    auto detachFromWpaControlSocketOnExit = notstd::ScopeExit([&] {
+        wpa_ctrl_detach(wpaControlSocket);
+    });
+
+    bool stopRequested{ false };
+    for (;;) {
+        if (stopToken.stop_requested() || stopRequested) {
+            LOGD << std::format("Stopping WPA event listener for interface '{}'.", InterfaceName);
+            break;
+        }
+
+        // Wait for at least one event file descriptor to be signaled.
+        const auto numEvents = epoll_wait(fdEpoll, std::data(epollEvents), std::size(epollEvents), -1);
+        if (numEvents < 0) {
+            ret = errno;
+            LOGE << std::format("Failed to wait for events on interface '{}': {}", InterfaceName, ret);
+            continue;
+        }
+        if (numEvents == 0) {
+            LOGW << std::format("No events received on interface '{}'.", InterfaceName);
+            continue;
+        }
+
+        // Determine which file descriptor was signaled, and handle it.
+        for (std::size_t i = 0; i < std::size(epollEvents); ++i) {
+            if (epollEvents[i].data.fd == fdEventFdStop) {
+                LOGD << "Eventfd was signaled; checking for pending event(s).";
+                uint64_t value{ ~EventFdStopRequestValue };
+                ssize_t numRead = read(fdEventFdStop, &value, sizeof value);
+                if (numRead != sizeof value) {
+                    ret = errno;
+                    LOGE << std::format("Failed to read from eventfd for interface '{}': {}", InterfaceName, ret);
+                    continue;
+                }
+                if (value == EventFdStopRequestValue) {
+                    LOGD << std::format("Received stop signal on interface '{}'.", InterfaceName);
+                    stopRequested = true;
+                    break;
+                }
+            }
+            if (epollEvents[i].data.fd == fdWpa) {
+                LOGD << "WPA control socket was signaled; checking for pending event(s).";
+                while (wpa_ctrl_pending(wpaControlSocket) > 0) {
+                    ProcessNextEvent(wpaControlSocketConnection);
+                }
+            }
+        }
+    }
+}

--- a/src/linux/wpa-controller/WpaEventHandler.cxx
+++ b/src/linux/wpa-controller/WpaEventHandler.cxx
@@ -78,8 +78,10 @@ WpaEventHandler::StopListening()
         m_fdEventFdStop = -1;
     }
 
-    m_eventListenerThread.request_stop();
-    m_eventListenerThread.join();
+    if (m_eventListenerThread.joinable()) {
+        m_eventListenerThread.request_stop();
+        m_eventListenerThread.join();
+    }
 }
 
 void

--- a/src/linux/wpa-controller/WpaEventHandler.cxx
+++ b/src/linux/wpa-controller/WpaEventHandler.cxx
@@ -18,8 +18,9 @@
 
 using namespace Wpa;
 
-WpaEventHandler::WpaEventHandler(std::unique_ptr<WpaControlSocketConnection> wpaControlSocketConnection) :
-    m_wpaControlSocketConnection(std::move(wpaControlSocketConnection))
+WpaEventHandler::WpaEventHandler(std::unique_ptr<WpaControlSocketConnection> wpaControlSocketConnection, WpaType wpaType) :
+    m_wpaControlSocketConnection(std::move(wpaControlSocketConnection)),
+    m_wpaType(wpaType)
 {
 }
 
@@ -112,7 +113,7 @@ WpaEventHandler::ProcessNextEvent(WpaControlSocketConnection& wpaControlSocketCo
     WpaEventArgs wpaEventArgs{
         .Timestamp = timestampNow,
         .Event = {
-            .Source = WpaType::Hostapd, // TODO: determine true source of the event.
+            .Source = m_wpaType,
             .Payload = { std::data(wpaEventBuffer), wpaEventBufferSize },
         },
     };
@@ -153,7 +154,7 @@ WpaEventHandler::ProcessEvents(WpaControlSocketConnection& wpaControlSocketConne
 {
     const auto interfaceName{ wpaControlSocketConnection.GetInterfaceName() };
     LOGD << std::format("WPA event listener thread for interface '{}' started", interfaceName);
-    auto logOnExit = notstd::ScopeExit([&]{
+    auto logOnExit = notstd::ScopeExit([&] {
         LOGD << std::format("WPA event listener thread for interface '{}' stopped", interfaceName);
     });
 

--- a/src/linux/wpa-controller/WpaEventListenerProxy.cxx
+++ b/src/linux/wpa-controller/WpaEventListenerProxy.cxx
@@ -1,0 +1,26 @@
+
+#include <memory>
+
+#include <Wpa/IWpaEventListener.hxx>
+#include <Wpa/WpaEventListenerProxy.hxx>
+#include <notstd/Memory.hxx>
+
+using namespace Wpa;
+
+WpaEventListenerProxy::WpaEventListenerProxy(IWpaEventListener &wpaEventListenerProxy) :
+    m_wpaEventListenerProxy(wpaEventListenerProxy)
+{
+}
+
+/* static */
+std::shared_ptr<WpaEventListenerProxy>
+WpaEventListenerProxy::Create(IWpaEventListener &wpaEventListenerProxy)
+{
+    return std::make_shared<notstd::enable_make_protected<WpaEventListenerProxy>>(wpaEventListenerProxy);
+}
+
+void
+WpaEventListenerProxy::OnWpaEvent(WpaEventSender *sender, const WpaEventArgs *eventArgs)
+{
+    m_wpaEventListenerProxy.OnWpaEvent(sender, eventArgs);
+}

--- a/src/linux/wpa-controller/include/Wpa/IWpaEventListener.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IWpaEventListener.hxx
@@ -19,6 +19,8 @@ struct WpaEventSender
  */
 struct IWpaEventListener
 {
+    virtual ~IWpaEventListener() = default;
+
     /**
      * @brief Invoked when a WPA event is received.
      *

--- a/src/linux/wpa-controller/include/Wpa/IWpaEventListener.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IWpaEventListener.hxx
@@ -1,0 +1,33 @@
+
+#ifndef I_WPA_EVENT_HANDLER_HXX
+#define I_WPA_EVENT_HANDLER_HXX
+
+#include <Wpa/WpaEventArgs.hxx>
+
+namespace Wpa
+{
+/**
+ * @brief Represents the sender or source of a WPA event.
+ */
+struct WpaEventSender
+{
+    virtual ~WpaEventSender() = default;
+};
+
+/**
+ * @brief Interface for WPA event consumers.
+ */
+struct IWpaEventListener
+{
+    /**
+     * @brief Invoked when a WPA event is received.
+     *
+     * @param sender The sender or source of the event.
+     * @param eventArgs The event arguments.
+     */
+    virtual void
+    OnWpaEvent(WpaEventSender *sender, const WpaEventArgs *eventArgs) = 0;
+};
+} // namespace Wpa
+
+#endif // I_WPA_EVENT_HANDLER_HXX

--- a/src/linux/wpa-controller/include/Wpa/ProtocolWpa.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolWpa.hxx
@@ -61,6 +61,12 @@ struct ProtocolWpa
     static constexpr auto ResponsePayloadPing = "PONG";
 
     /**
+     * @brief Maximum size of a WPA event. This value is used by the wpa_cli and hostapd_cli tools as an upper bound, so
+     * is used similarly here.
+     */
+    static constexpr auto EventSizeMax{ 4096 };
+
+    /**
      * @brief Determines if a response payload indicates success.
      *
      * @param response The response payload to check.

--- a/src/linux/wpa-controller/include/Wpa/WpaControlSocketConnection.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaControlSocketConnection.hxx
@@ -4,6 +4,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <string>
 #include <string_view>
 
 #include <wpa_ctrl.h>
@@ -56,6 +57,14 @@ public:
     void
     Disconnect() noexcept;
 
+    /**
+     * @brief Get the interface name for this connection.
+     * 
+     * @return std::string_view
+     */
+    std::string_view
+    GetInterfaceName() const noexcept;
+
 protected:
     /**
      * @brief Construct a new WpaControlSocketConnection object.
@@ -67,6 +76,7 @@ protected:
 
 private:
     std::filesystem::path m_controlSocketPath;
+    std::string m_interfaceName;
     struct wpa_ctrl* m_controlSocket{ nullptr };
 };
 } // namespace Wpa

--- a/src/linux/wpa-controller/include/Wpa/WpaEvent.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaEvent.hxx
@@ -1,0 +1,22 @@
+
+#ifndef WPA_EVENT_HXX
+#define WPA_EVENT_HXX
+
+#include <string>
+
+#include <Wpa/WpaCore.hxx>
+
+namespace Wpa
+{
+/**
+ * @brief Represents an event from a WPA daemon/service.
+ */
+struct WpaEvent
+{
+    WpaType Source;
+    std::string Payload;
+};
+
+} // namespace Wpa
+
+#endif // WPA_EVENT_HXX

--- a/src/linux/wpa-controller/include/Wpa/WpaEventArgs.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaEventArgs.hxx
@@ -1,0 +1,21 @@
+
+#ifndef WPA_EVENT_ARGS_HXX
+#define WPA_EVENT_ARGS_HXX
+
+#include <chrono>
+
+#include <Wpa/WpaEvent.hxx>
+
+namespace Wpa
+{
+/**
+ * @brief The event arguments for the WPA event.
+ */
+struct WpaEventArgs
+{
+    std::chrono::time_point<std::chrono::system_clock> Timestamp;
+    WpaEvent Event;
+};
+} // namespace Wpa
+
+#endif // WPA_EVENT_ARGS_HXX

--- a/src/linux/wpa-controller/include/Wpa/WpaEventHandler.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaEventHandler.hxx
@@ -1,6 +1,6 @@
 
-#ifndef WPA_EVENT_LISTENER_HXX
-#define WPA_EVENT_LISTENER_HXX
+#ifndef WPA_EVENT_HANDLER_HXX
+#define WPA_EVENT_HANDLER_HXX
 
 #include <cstdint>
 #include <filesystem>
@@ -99,4 +99,4 @@ private:
 };
 } // namespace Wpa
 
-#endif // WPA_EVENT_LISTENER_HXX
+#endif // WPA_EVENT_HANDLER_HXX

--- a/src/linux/wpa-controller/include/Wpa/WpaEventHandler.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaEventHandler.hxx
@@ -13,6 +13,7 @@
 
 #include <Wpa/IWpaEventListener.hxx>
 #include <Wpa/WpaControlSocketConnection.hxx>
+#include <Wpa/WpaCore.hxx>
 
 namespace Wpa
 {
@@ -29,7 +30,7 @@ struct WpaEventHandler :
      *
      * @param wpaControlSocketConnection
      */
-    WpaEventHandler(std::unique_ptr<WpaControlSocketConnection> wpaControlSocketConnection);
+    WpaEventHandler(std::unique_ptr<WpaControlSocketConnection> wpaControlSocketConnection, WpaType wpaType);
 
     /**
      * @brief Destroy the WpaEventHandler object.
@@ -85,6 +86,7 @@ private:
 
 private:
     std::unique_ptr<WpaControlSocketConnection> m_wpaControlSocketConnection{ nullptr };
+    WpaType m_wpaType;
 
     // The below m_eventListenerStateGate mutex protects m_eventListeners, m_eventListenerRegistrationTokenNext, and
     // m_eventListenerThread.

--- a/src/linux/wpa-controller/include/Wpa/WpaEventHandler.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaEventHandler.hxx
@@ -1,0 +1,102 @@
+
+#ifndef WPA_EVENT_LISTENER_HXX
+#define WPA_EVENT_LISTENER_HXX
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <shared_mutex>
+#include <stop_token>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+
+#include <Wpa/IWpaEventListener.hxx>
+#include <Wpa/WpaControlSocketConnection.hxx>
+
+namespace Wpa
+{
+using WpaEventListenerRegistrationToken = uint32_t;
+
+/**
+ * @brief Class that processes WPA events and distributes them to registered listeners.
+ */
+struct WpaEventHandler :
+    public WpaEventSender
+{
+    /**
+     * @brief Create a new WpaEventHandler.
+     *
+     * @param wpaControlSocketConnection
+     */
+    WpaEventHandler(std::unique_ptr<WpaControlSocketConnection> wpaControlSocketConnection);
+
+    /**
+     * @brief Destroy the WpaEventHandler object.
+     */
+    ~WpaEventHandler();
+
+    /**
+     * @brief Register a listener for WPA events.
+     *
+     * @param wpaEventListener The listener to register.
+     * @return WpaEventListenerRegistrationToken A token that can be used to unregister the listener.
+     */
+    WpaEventListenerRegistrationToken
+    RegisterEventListener(std::weak_ptr<IWpaEventListener> wpaEventListener);
+
+    /**
+     * @brief Unregister a listener for WPA events.
+     *
+     * @param wpaEventListenerRegistrationToken The token returned by RegisterEventListener.
+     */
+    void
+    UnregisterEventListener(WpaEventListenerRegistrationToken wpaEventListenerRegistrationToken);
+
+    /**
+     * @brief Start listening for WPA events.
+     */
+    void
+    StartListening();
+
+    /**
+     * @brief Stop listening for WPA events.
+     */
+    void
+    StopListening();
+
+private:
+    /**
+     * @brief Process the next WPA event.
+     *
+     * @param WpaControlSocketConnection The WPA control socket connection to use.
+     */
+    void
+    ProcessNextEvent(WpaControlSocketConnection& wpaControlSocketConnection);
+
+    /**
+     * @brief Listen for and process WPA events.
+     *
+     * @param wpaControlSocketConnection The WPA control socket connection to listen on.
+     * @param stopToken The stop token to use to stop listening.
+     */
+    void
+    ProcessEvents(WpaControlSocketConnection& wpaControlSocketConnection, std::stop_token stopToken);
+
+private:
+    std::unique_ptr<WpaControlSocketConnection> m_wpaControlSocketConnection{ nullptr };
+
+    // The below m_eventListenerStateGate mutex protects m_eventListeners, m_eventListenerRegistrationTokenNext, and
+    // m_eventListenerThread.
+    std::shared_mutex m_eventListenerStateGate;
+    std::unordered_map<WpaEventListenerRegistrationToken, std::weak_ptr<IWpaEventListener>> m_eventListeners;
+    WpaEventListenerRegistrationToken m_eventListenerRegistrationTokenNext{ 0 };
+    std::jthread m_eventListenerThread;
+
+    // Signal value to stop the event listener thread.
+    static constexpr std::uint64_t EventFdStopRequestValue{ 1 };
+    int m_fdEventFdStop{ -1 };
+};
+} // namespace Wpa
+
+#endif // WPA_EVENT_LISTENER_HXX

--- a/src/linux/wpa-controller/include/Wpa/WpaEventListenerProxy.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaEventListenerProxy.hxx
@@ -1,0 +1,58 @@
+
+#ifndef WPA_EVENT_LISTENER_PROXY_HXX
+#define WPA_EVENT_LISTENER_PROXY_HXX
+
+#include <memory>
+
+#include <Wpa/IWpaEventListener.hxx>
+
+namespace Wpa
+{
+/**
+ * @brief Helper to allow use of classes that implement IWpaEventListener without providing a std::weak_ptr<> of itself
+ * to WpaEventHandler.
+ *
+ * The implemenation simply forwards the OnWpaEvent() call to the IWpaEventListener instance provided in the
+ * constructor. The caller is responsible for ensuring that the IWpaEventListener instance outlives the
+ * WpaEventListenerProxy instance.
+ */
+struct WpaEventListenerProxy :
+    public IWpaEventListener,
+    public std::enable_shared_from_this<WpaEventListenerProxy>
+{
+    virtual ~WpaEventListenerProxy() = default;
+
+    /**
+     * @brief Create a new WpaEventListenerProxy instance that forwards OnWpaEvent() calls to the provided
+     * IWpaEventListener.
+     *
+     * @param wpaEventListenerProxy The IWpaEventListener instance to forward OnWpaEvent() calls to.
+     * @return std::shared_ptr<WpaEventListenerProxy>
+     */
+    static std::shared_ptr<WpaEventListenerProxy>
+    Create(IWpaEventListener &wpaEventListenerProxy);
+
+    /**
+     * @brief Invoked when a WPA event is received.
+     *
+     * @param sender The sender or source of the event.
+     * @param eventArgs The event arguments.
+     */
+    void
+    OnWpaEvent(WpaEventSender *sender, const WpaEventArgs *eventArgs) override;
+
+protected:
+    /**
+     * @brief Construct a new WpaEventListenerProxy instance that forwards OnWpaEvent() calls to the provided
+     * IWpaEventListener.
+     *
+     * @param wpaEventListenerProxy The IWpaEventListener instance to forward OnWpaEvent() calls to.
+     */
+    WpaEventListenerProxy(IWpaEventListener &wpaEventListenerProxy);
+
+private:
+    IWpaEventListener &m_wpaEventListenerProxy;
+};
+} // namespace Wpa
+
+#endif // WPA_EVENT_LISTENER_PROXY_HXX

--- a/tests/unit/linux/wpa-controller/TestHostapd.cxx
+++ b/tests/unit/linux/wpa-controller/TestHostapd.cxx
@@ -49,10 +49,10 @@ TEST_CASE("Create a Hostapd instance (root)", "[wpa][hostapd][client][remote]")
         REQUIRE_NOTHROW(hostapd2.emplace(WpaDaemonManager::InterfaceNameDefault));
     }
 
-    SECTION("Sending command on invalid interface fails")
+    SECTION("Create with invalid interface name fails")
     {
-        Hostapd hostapd("invalid");
-        REQUIRE_THROWS_AS(hostapd.Ping(), HostapdException);
+        std::optional<Hostapd> hostapd;
+        REQUIRE_THROWS_AS(hostapd.emplace("invalid"), HostapdException);
     }
 
     SECTION("Create reflects correct interface name")


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [x] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Enable consuming events generated from WPA daemons including `hostapd` and `wpa_supplicant`.

### Technical Details

* Add `IWpaEventListener` interface for WPA event consumption.
* Add `WpaEventListenerProxy` for proxying events to implementations that don't produce `std::weak_ptr`s.
* Add `WpaEvent` for describing raw WPA events.
* Ad `WpaEventHandler` for processing WPA events.
* Expose interface name from `WpaControlSocketConnection` to aid logging.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Consider whether to create statically typed events on top of the string payload/content as was done in the `wifi-telemetry` project.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
