### PR TITLE
Add WPA Event Parsing helpers

### DIFF
--- a/src/linux/wpa-controller/CMakeLists.txt
+++ b/src/linux/wpa-controller/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(wpa-controller
         WpaController.cxx
         WpaControlSocket.cxx
         WpaControlSocketConnection.cxx
+        WpaEvent.cxx
         WpaEventHandler.cxx
         WpaEventListenerProxy.cxx
         WpaKeyValuePair.cxx

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -530,5 +530,6 @@ Hostapd::GetIpAddress() const noexcept
 void
 Hostapd::OnWpaEvent(WpaEventSender* sender, const WpaEventArgs* eventArgs)
 {
-    LOGD << std::format("Hostapd event @ {}: {:#08x} {}", eventArgs->Timestamp, reinterpret_cast<uintptr_t>(sender), eventArgs->Event.ToString());
+    const auto& event{ eventArgs->Event };
+    LOGD << std::format("> [{}-Event|{}|{}|Sender={:#08x}] {}", magic_enum::enum_name(event.Source), magic_enum::enum_name(event.LogLevel), eventArgs->Timestamp, reinterpret_cast<uintptr_t>(sender), event.Payload);
 }

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -530,5 +530,5 @@ Hostapd::GetIpAddress() const noexcept
 void
 Hostapd::OnWpaEvent(WpaEventSender* sender, const WpaEventArgs* eventArgs)
 {
-    LOGD << std::format("Hostapd event @ {}: {:#08x} {}", eventArgs->Timestamp, reinterpret_cast<uintptr_t>(sender), eventArgs->Event.Payload);
+    LOGD << std::format("Hostapd event @ {}: {:#08x} {}", eventArgs->Timestamp, reinterpret_cast<uintptr_t>(sender), eventArgs->Event.ToString());
 }

--- a/src/linux/wpa-controller/WpaEvent.cxx
+++ b/src/linux/wpa-controller/WpaEvent.cxx
@@ -1,0 +1,60 @@
+
+#include <charconv>
+#include <format>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include <Wpa/ProtocolWpa.hxx>
+#include <Wpa/WpaCore.hxx>
+#include <Wpa/WpaEvent.hxx>
+#include <magic_enum.hpp>
+
+using namespace Wpa;
+
+/* static */
+std::optional<WpaEvent>
+WpaEvent::Parse(std::string_view eventPayload)
+{
+    WpaEvent event;
+
+    // Find the log level delimeters.
+    const std::size_t logLevelStart = eventPayload.find(ProtocolWpa::EventLogLevelDelimeterStart);
+    const std::size_t logLevelEnd = (logLevelStart != std::string::npos) ? eventPayload.find(ProtocolWpa::EventLogLevelDelimeterEnd, logLevelStart) : std::string::npos;
+    if (logLevelEnd == std::string::npos) {
+        return std::nullopt;
+    }
+
+    // Parse the log level.
+    std::underlying_type_t<WpaLogLevel> logLevelValue{};
+    const auto logLevel = eventPayload.substr(logLevelStart + 1, logLevelEnd - logLevelStart - 1);
+    const auto logLevelConversionResult = std::from_chars(std::data(logLevel), std::data(logLevel) + std::size(logLevel), logLevelValue);
+    if (logLevelConversionResult.ec != std::errc{}) {
+        return std::nullopt;
+    }
+
+    auto logLevelEnum = magic_enum::enum_cast<WpaLogLevel>(logLevelValue);
+    if (logLevelEnum.has_value()) {
+        event.LogLevel = logLevelEnum.value();
+    }
+
+    // Find the interface name prefix, if present (it's only present with messages from global control sockets).
+    const std::size_t interfaceStart = eventPayload.find(ProtocolWpa::EventInterfaceNamePrefix);
+    const std::size_t interfaceEnd = (interfaceStart != std::string::npos) ? eventPayload.find(' ', interfaceStart) : std::string::npos;
+    if (interfaceEnd != std::string::npos) {
+        event.Interface = eventPayload.substr(interfaceStart, interfaceEnd - interfaceStart);
+    }
+
+    // Find the payload.
+    const std::size_t payloadStart = (interfaceEnd != std::string::npos) ? interfaceEnd + 1 : logLevelEnd + 1;
+    event.Payload = eventPayload.substr(payloadStart);
+
+    return event;
+}
+
+std::string
+WpaEvent::ToString() const
+{
+    return std::format("[{}] {}{}{}", magic_enum::enum_name(LogLevel), magic_enum::enum_name(Source), Interface.value_or(""), Payload);
+}

--- a/src/linux/wpa-controller/WpaEvent.cxx
+++ b/src/linux/wpa-controller/WpaEvent.cxx
@@ -56,5 +56,5 @@ WpaEvent::Parse(std::string_view eventPayload)
 std::string
 WpaEvent::ToString() const
 {
-    return std::format("[{}] {}{}{}", magic_enum::enum_name(LogLevel), magic_enum::enum_name(Source), Interface.value_or(""), Payload);
+    return std::format("[{}|{}] {} {}", magic_enum::enum_name(Source), magic_enum::enum_name(LogLevel), Interface.value_or(""), Payload);
 }

--- a/src/linux/wpa-controller/include/Wpa/ProtocolWpa.hxx
+++ b/src/linux/wpa-controller/include/Wpa/ProtocolWpa.hxx
@@ -67,6 +67,13 @@ struct ProtocolWpa
     static constexpr auto EventSizeMax{ 4096 };
 
     /**
+     * @brief The prefix used to identify the interface name in an event payload.
+     */
+    static constexpr auto EventInterfaceNamePrefix{ "IFNAME=" };
+    static constexpr auto EventLogLevelDelimeterStart{ "<" };
+    static constexpr auto EventLogLevelDelimeterEnd{ ">" };
+
+    /**
      * @brief Determines if a response payload indicates success.
      *
      * @param response The response payload to check.

--- a/src/linux/wpa-controller/include/Wpa/WpaCore.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaCore.hxx
@@ -7,9 +7,23 @@
 namespace Wpa
 {
 /**
+ * @brief Log levels for WPA messages and events.
+ */
+enum class WpaLogLevel : int32_t {
+    Unknown = -1,
+    Excessive = 0,
+    MessageDump = 1,
+    Debug = 2,
+    Info = 3,
+    Warning = 4,
+    Error = 5,
+};
+
+/**
  * @brief The type of WPA daemon/service.
  */
 enum class WpaType {
+    Unknown,
     Hostapd,
     WpaSupplicant,
 };
@@ -28,6 +42,8 @@ GetWpaTypeDaemonBinaryName(WpaType type) noexcept
         return "hostapd";
     case WpaType::WpaSupplicant:
         return "wpa_supplicant";
+    case WpaType::Unknown:
+        [[fallthrough]];
     default:
         return "unknown";
     }

--- a/src/linux/wpa-controller/include/Wpa/WpaEvent.hxx
+++ b/src/linux/wpa-controller/include/Wpa/WpaEvent.hxx
@@ -2,7 +2,9 @@
 #ifndef WPA_EVENT_HXX
 #define WPA_EVENT_HXX
 
+#include <optional>
 #include <string>
+#include <string_view>
 
 #include <Wpa/WpaCore.hxx>
 
@@ -13,8 +15,27 @@ namespace Wpa
  */
 struct WpaEvent
 {
-    WpaType Source;
-    std::string Payload;
+    WpaType Source{ WpaType::Unknown };
+    WpaLogLevel LogLevel{ WpaLogLevel::Unknown };
+    std::string Payload{};
+    std::optional<std::string> Interface{ std::nullopt };
+
+    /**
+     * @brief Parse a string into a WpaEvent.
+     *
+     * @param eventPayload The string to parse.
+     * @return std::optional<WpaEvent>
+     */
+    static std::optional<WpaEvent>
+    Parse(std::string_view eventPayload);
+
+    /**
+     * @brief Convert the event to a string.
+     *
+     * @return std::string
+     */
+    std::string
+    ToString() const;
 };
 
 } // namespace Wpa


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Enable parsing of WPA event payloads.
* Allow future extension of static typing of WPA events.

### Technical Details

* Add `static` function `WpaEvent::Parse` to parse string payloads from WPA events.
* Add `WpaEvent::ToString` helper for outputting a string representation of WPA events.

### Test Results

* All unit tests pass.
* Validated expected output per below:

<img width="535" alt="image" src="https://github.com/microsoft/netremote/assets/2082148/e02b3c2a-f8a4-4cbb-858e-a2918ab351e3">

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
