### PR TITLE
Make hostapd WpaEventHandler available to upper layers

### DIFF
--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -43,7 +43,7 @@ Hostapd::Hostapd(std::string_view interfaceName) :
         throw HostapdException("Failed to create hostapd event handler control socket connection");
     }
 
-    auto eventHandler{ std::make_unique<WpaEventHandler>(std::move(controlSocketConnection), WpaType::Hostapd) };
+    auto eventHandler{ std::make_shared<WpaEventHandler>(std::move(controlSocketConnection), WpaType::Hostapd) };
     if (!eventHandler) {
         throw HostapdException("Failed to create hostapd event handler");
     }

--- a/src/linux/wpa-controller/Hostapd.cxx
+++ b/src/linux/wpa-controller/Hostapd.cxx
@@ -64,6 +64,12 @@ Hostapd::GetInterface()
     return m_interface;
 }
 
+std::shared_ptr<WpaEventHandler>
+Hostapd::GetEventHandler() const noexcept
+{
+    return m_eventHandler;
+}
+
 void
 Hostapd::Ping()
 {

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -94,6 +94,14 @@ struct Hostapd :
     GetInterface() override;
 
     /**
+     * @brief Obtain the event handler for the interface.
+     *
+     * @return std::shared_ptr<WpaEventHandler>
+     */
+    std::shared_ptr<WpaEventHandler>
+    GetEventHandler() const noexcept override;
+
+    /**
      * @brief Get the status for the interface.
      *
      * @return HostapdStatus

--- a/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/Hostapd.hxx
@@ -271,7 +271,7 @@ private:
     WpaController m_controller;
     std::unique_ptr<WpaControlSocketConnection> m_eventHandlerControlSocketConnection{ nullptr };
     std::shared_ptr<WpaEventListenerProxy> m_eventListenerProxy;
-    std::unique_ptr<WpaEventHandler> m_eventHandler{ nullptr };
+    std::shared_ptr<WpaEventHandler> m_eventHandler{ nullptr };
     WpaEventListenerRegistrationToken m_eventHandlerRegistrationToken{};
 };
 } // namespace Wpa

--- a/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
+++ b/src/linux/wpa-controller/include/Wpa/IHostapd.hxx
@@ -12,6 +12,7 @@
 
 #include <Wpa/ProtocolHostapd.hxx>
 #include <Wpa/ProtocolWpa.hxx>
+#include <Wpa/WpaEventHandler.hxx>
 
 namespace Wpa
 {
@@ -89,6 +90,14 @@ struct IHostapd
      */
     virtual std::string_view
     GetInterface() = 0;
+
+    /**
+     * @brief Obtain the event handler for the interface.
+     *
+     * @return std::shared_ptr<WpaEventHandler>
+     */
+    virtual std::shared_ptr<WpaEventHandler>
+    GetEventHandler() const noexcept = 0;
 
     /**
      * @brief Get the status for the interface.
@@ -217,7 +226,7 @@ struct IHostapd
      * @brief Add RADIUS server endpoints to the interface. This may contain multiple endpoints of various types. The
      * first endpoint configuration for each type is used as the primary server, and any following are used as fallbacks
      * in case the primary server is unreachable.
-     * 
+     *
      * @param endpointConfigurations The endpoint configurations to add.
      * @param enforceConfigurationChange When to enforce the configuration change. A value of 'Now' will trigger a
      * configuration reload.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow the middleware layers to access the hostapd event handler/producer.

### Technical Details

* Add `IHostapd::GetEventHandler` exposing a `shared_ptr<WpaEventHandler>` associated with the instance.
* Implement `IHostapd::GetEventHandler` in `Hostapd`.
* Convert `std::unique_ptr<WpaEventHandler>` to `std::shared_ptr` in `Hostapd`.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Register a listener on the handler in the `AccessPointControllerLinux` implementation.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
