### PR TITLE
Setup skeleton audit log

### DIFF
--- a/src/common/shared/logging/include/logging/LogUtils.hxx
+++ b/src/common/shared/logging/include/logging/LogUtils.hxx
@@ -15,13 +15,13 @@ enum class LogInstanceId : int {
     Audit = 3,
 };
 
-#define AUDIT_LOGN LOG_(static_cast<int>(LogInstanceId::Audit), plog::none)
-#define AUDIT_LOGF LOG_(static_cast<int>(LogInstanceId::Audit), plog::fatal)
-#define AUDIT_LOGE LOG_(static_cast<int>(LogInstanceId::Audit), plog::error)
-#define AUDIT_LOGW LOG_(static_cast<int>(LogInstanceId::Audit), plog::warning)
-#define AUDIT_LOGI LOG_(static_cast<int>(LogInstanceId::Audit), plog::info)
-#define AUDIT_LOGD LOG_(static_cast<int>(LogInstanceId::Audit), plog::debug)
-#define AUDIT_LOGV LOG_(static_cast<int>(LogInstanceId::Audit), plog::verbose)
+#define AUDITN LOG_(static_cast<int>(LogInstanceId::Audit), plog::none)
+#define AUDITF LOG_(static_cast<int>(LogInstanceId::Audit), plog::fatal)
+#define AUDITE LOG_(static_cast<int>(LogInstanceId::Audit), plog::error)
+#define AUDITW LOG_(static_cast<int>(LogInstanceId::Audit), plog::warning)
+#define AUDITI LOG_(static_cast<int>(LogInstanceId::Audit), plog::info)
+#define AUDITD LOG_(static_cast<int>(LogInstanceId::Audit), plog::debug)
+#define AUDITV LOG_(static_cast<int>(LogInstanceId::Audit), plog::verbose)
 
 namespace logging
 {

--- a/src/common/shared/logging/include/logging/LogUtils.hxx
+++ b/src/common/shared/logging/include/logging/LogUtils.hxx
@@ -8,6 +8,21 @@
 
 #include <plog/Severity.h>
 
+enum class LogInstanceId : int {
+    // Default logger is 0 and is omitted from this enumeration.
+    Console = 1,
+    File = 2,
+    Audit = 3,
+};
+
+#define AUDIT_LOGN LOG_(static_cast<int>(LogInstanceId::Audit), plog::none)
+#define AUDIT_LOGF LOG_(static_cast<int>(LogInstanceId::Audit), plog::fatal)
+#define AUDIT_LOGE LOG_(static_cast<int>(LogInstanceId::Audit), plog::error)
+#define AUDIT_LOGW LOG_(static_cast<int>(LogInstanceId::Audit), plog::warning)
+#define AUDIT_LOGI LOG_(static_cast<int>(LogInstanceId::Audit), plog::info)
+#define AUDIT_LOGD LOG_(static_cast<int>(LogInstanceId::Audit), plog::debug)
+#define AUDIT_LOGV LOG_(static_cast<int>(LogInstanceId::Audit), plog::verbose)
+
 namespace logging
 {
 /**

--- a/src/linux/server/Main.cxx
+++ b/src/linux/server/Main.cxx
@@ -35,21 +35,6 @@ using namespace Microsoft::Net::Remote;
 using namespace Microsoft::Net::Remote::Service;
 using namespace Microsoft::Net::Wifi;
 
-enum class LogInstanceId : int {
-    // Default logger is 0 and is omitted from this enumeration.
-    Console = 1,
-    File = 2,
-    Audit = 3,
-};
-
-#define AUDIT_LOGN LOG_(static_cast<int>(LogInstanceId::Audit), plog::none)
-#define AUDIT_LOGF LOG_(static_cast<int>(LogInstanceId::Audit), plog::fatal)
-#define AUDIT_LOGE LOG_(static_cast<int>(LogInstanceId::Audit), plog::error)
-#define AUDIT_LOGW LOG_(static_cast<int>(LogInstanceId::Audit), plog::warning)
-#define AUDIT_LOGI LOG_(static_cast<int>(LogInstanceId::Audit), plog::info)
-#define AUDIT_LOGD LOG_(static_cast<int>(LogInstanceId::Audit), plog::debug)
-#define AUDIT_LOGV LOG_(static_cast<int>(LogInstanceId::Audit), plog::verbose)
-
 namespace
 {
 /**

--- a/src/linux/server/Main.cxx
+++ b/src/linux/server/Main.cxx
@@ -83,12 +83,12 @@ main(int argc, char *argv[])
 
     // Create file and console log appenders.
     static plog::ColorConsoleAppender<plog::MessageOnlyFormatter> colorConsoleAppender{};
-    std::string logFilePath = "/usr/local/";
+    std::string logFilePath = "/var/log/";
     logFilePath += logging::GetLogName("server");
     static plog::RollingFileAppender<plog::TxtFormatter> rollingFileAppender(logFilePath.c_str());
 
     // Create the audit log file appender.
-    std::string auditLogFilePath = "/usr/local/";
+    std::string auditLogFilePath = "/var/log/";
     auditLogFilePath += logging::GetLogName("audit");
     static plog::RollingFileAppender<plog::TxtFormatter> auditLogRollingFileAppender(auditLogFilePath.c_str());
 
@@ -106,7 +106,7 @@ main(int argc, char *argv[])
     plog::init<std::to_underlying(LogInstanceId::Audit)>(logSeverity, &auditLogRollingFileAppender);
 
     LOGN << std::format("Netremote server starting (log level={})", magic_enum::enum_name(logSeverity));
-    AUDIT_LOGN << std::format("Netremote server starting (log level={})", magic_enum::enum_name(logSeverity));
+    AUDITN << std::format("Netremote server starting (log level={})", magic_enum::enum_name(logSeverity));
 
     // Create an access point manager and discovery agent.
     auto accessPointManager = AccessPointManager::Create();


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [X] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

This PR sets up the foundation for the Wi-Fi state audit log.

### Technical Details

* Added a PLOG RollingFileAppender separate from the existing logging to be used for writing to the audit log file.
* Added audit log macros in the form of `AUDIT_LOG*`.
* Ensured that log files are actually present by specifying the path to `/usr/local/`.

### Test Results

Verified that the `AUDIT_LOGN` line added to `Main` shows up in `/usr/local/202407-LogNetRemote-audit.txt`.

### Reviewer Focus

I'm not sure if `/usr/local` is the best place, but omitting that and just using what is returned by `GetLogName` doesn't seem to create a log file anywhere.

### Future Work

Write Wi-Fi state and events to the audit log.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
