### PR TITLE
Log Wi-Fi state changes to the audit log

### DIFF
--- a/src/common/net/wifi/core/Ieee80211.cxx
+++ b/src/common/net/wifi/core/Ieee80211.cxx
@@ -11,37 +11,7 @@
 
 namespace Microsoft::Net::Wifi
 {
-std::string
-Ieee80211SecurityProtocolToString(const Ieee80211SecurityProtocol& securityProtocol)
-{
-    switch (securityProtocol) {
-    case Ieee80211SecurityProtocol::Wpa:
-        return "Wpa";
-    case Ieee80211SecurityProtocol::Wpa2:
-        return "Wpa2";
-    case Ieee80211SecurityProtocol::Wpa3:
-        return "Wpa3";
-    default:
-        return "Unknown";
-    }
-}
-
-std::string
-Ieee80211FrequencyBandToString(const Ieee80211FrequencyBand& frequencyBand)
-{
-    switch (frequencyBand) {
-    case Ieee80211FrequencyBand::TwoPointFourGHz:
-        return "TwoPointFourGHz";
-    case Ieee80211FrequencyBand::FiveGHz:
-        return "FiveGHz";
-    case Ieee80211FrequencyBand::SixGHz:
-        return "SixGHz";
-    default:
-        return "Unknown"; 
-    }
-}
-
-std::string
+std::string_view
 Ieee80211AuthenticationAlgorithmToString(const Ieee80211AuthenticationAlgorithm& authenticationAlgorithm)
 {
     switch (authenticationAlgorithm) {
@@ -61,94 +31,6 @@ Ieee80211AuthenticationAlgorithmToString(const Ieee80211AuthenticationAlgorithm&
         return "FilsPublicKey";
     case Ieee80211AuthenticationAlgorithm::VendorSpecific:
         return "VendorSpecific";
-    default:
-        return "Unknown";
-    }
-}
-
-std::string
-Ieee80211AkmSuiteToString(const Ieee80211AkmSuite& akmSuite)
-{
-    switch (akmSuite) {
-    case Ieee80211AkmSuite::Reserved0:
-        return "Reserved0";
-    case Ieee80211AkmSuite::Ieee8021x:
-        return "Ieee8021x";
-    case Ieee80211AkmSuite::Psk:
-        return "Psk";
-    case Ieee80211AkmSuite::Ft8021x:
-        return "Ft8021x";
-    case Ieee80211AkmSuite::FtPsk:
-        return "FtPsk";
-    case Ieee80211AkmSuite::Ieee8021xSha256:
-        return "Ieee8021xSha256";
-    case Ieee80211AkmSuite::PskSha256:
-        return "PskSha256";
-    case Ieee80211AkmSuite::Tdls:
-        return "Tdls";
-    case Ieee80211AkmSuite::Sae:
-        return "Sae";
-    case Ieee80211AkmSuite::FtSae:
-        return "FtSae";
-    case Ieee80211AkmSuite::ApPeerKey:
-        return "ApPeerKey";
-    case Ieee80211AkmSuite::Ieee8021xSuiteB:
-        return "Ieee8021xSuiteB";
-    case Ieee80211AkmSuite::Ieee8011xSuiteB192:
-        return "Ieee8021xSuiteB192";
-    case Ieee80211AkmSuite::Ft8021xSha384:
-        return "Ft8021xSha384";
-    case Ieee80211AkmSuite::FilsSha256:
-        return "FilsSha256";
-    case Ieee80211AkmSuite::FilsSha384:
-        return "FilsSha384";
-    case Ieee80211AkmSuite::FtFilsSha256:
-        return "FtFilsSha256";
-    case Ieee80211AkmSuite::FtFilsSha384:
-        return "FtFilsSha384";
-    case Ieee80211AkmSuite::Owe:
-        return "Owe";
-    case Ieee80211AkmSuite::FtPskSha384:
-        return "FtPskSha384";
-    case Ieee80211AkmSuite::PskSha384:
-        return "PskSha384";
-    case Ieee80211AkmSuite::Pasn:
-        return "Pasn";
-    default:
-        return "Unknown";
-    }
-}
-
-std::string
-Ieee80211CipherSuiteToString(const Ieee80211CipherSuite& cipherSuite)
-{
-    switch (cipherSuite) {
-    case Ieee80211CipherSuite::BipCmac128:
-        return "BipCmac128";
-    case Ieee80211CipherSuite::BipCmac256:
-        return "BipCmac256";
-    case Ieee80211CipherSuite::BipGmac128:
-        return "BipGmac128";
-    case Ieee80211CipherSuite::BipGmac256:
-        return "BipGmac256";
-    case Ieee80211CipherSuite::Ccmp128:
-        return "Ccmp128";
-    case Ieee80211CipherSuite::Ccmp256:
-        return "Ccmp256";
-    case Ieee80211CipherSuite::Gcmp128:
-        return "Gcmp128";
-    case Ieee80211CipherSuite::Gcmp256:
-        return "Gcmp256";
-    case Ieee80211CipherSuite::GroupAddressesTrafficNotAllowed:
-        return "GroupAddressesTrafficNotAllowed";
-    case Ieee80211CipherSuite::Tkip:
-        return "Tkip";
-    case Ieee80211CipherSuite::UseGroup:
-        return "UseGroup";
-    case Ieee80211CipherSuite::Wep104:
-        return "Wep104";
-    case Ieee80211CipherSuite::Wep40:
-        return "Wep40";
     default:
         return "Unknown";
     }

--- a/src/common/net/wifi/core/Ieee80211.cxx
+++ b/src/common/net/wifi/core/Ieee80211.cxx
@@ -12,6 +12,149 @@
 namespace Microsoft::Net::Wifi
 {
 std::string
+Ieee80211SecurityProtocolToString(const Ieee80211SecurityProtocol& securityProtocol)
+{
+    switch (securityProtocol) {
+    case Ieee80211SecurityProtocol::Wpa:
+        return "Wpa";
+    case Ieee80211SecurityProtocol::Wpa2:
+        return "Wpa2";
+    case Ieee80211SecurityProtocol::Wpa3:
+        return "Wpa3";
+    default:
+        return "Unknown";
+    }
+}
+
+std::string
+Ieee80211FrequencyBandToString(const Ieee80211FrequencyBand& frequencyBand)
+{
+    switch (frequencyBand) {
+    case Ieee80211FrequencyBand::TwoPointFourGHz:
+        return "TwoPointFourGHz";
+    case Ieee80211FrequencyBand::FiveGHz:
+        return "FiveGHz";
+    case Ieee80211FrequencyBand::SixGHz:
+        return "SixGHz";
+    default:
+        return "Unknown"; 
+    }
+}
+
+std::string
+Ieee80211AuthenticationAlgorithmToString(const Ieee80211AuthenticationAlgorithm& authenticationAlgorithm)
+{
+    switch (authenticationAlgorithm) {
+    case Ieee80211AuthenticationAlgorithm::OpenSystem:
+        return "OpenSystem";
+    case Ieee80211AuthenticationAlgorithm::SharedKey:
+        return "SharedKey";
+    case Ieee80211AuthenticationAlgorithm::FastBssTransition:
+        return "FastBssTransition";
+    case Ieee80211AuthenticationAlgorithm::Sae:
+        return "Sae";
+    case Ieee80211AuthenticationAlgorithm::Fils:
+        return "Fils";
+    case Ieee80211AuthenticationAlgorithm::FilsPfs:
+        return "FilsPfs";
+    case Ieee80211AuthenticationAlgorithm::FilsPublicKey:
+        return "FilsPublicKey";
+    case Ieee80211AuthenticationAlgorithm::VendorSpecific:
+        return "VendorSpecific";
+    default:
+        return "Unknown";
+    }
+}
+
+std::string
+Ieee80211AkmSuiteToString(const Ieee80211AkmSuite& akmSuite)
+{
+    switch (akmSuite) {
+    case Ieee80211AkmSuite::Reserved0:
+        return "Reserved0";
+    case Ieee80211AkmSuite::Ieee8021x:
+        return "Ieee8021x";
+    case Ieee80211AkmSuite::Psk:
+        return "Psk";
+    case Ieee80211AkmSuite::Ft8021x:
+        return "Ft8021x";
+    case Ieee80211AkmSuite::FtPsk:
+        return "FtPsk";
+    case Ieee80211AkmSuite::Ieee8021xSha256:
+        return "Ieee8021xSha256";
+    case Ieee80211AkmSuite::PskSha256:
+        return "PskSha256";
+    case Ieee80211AkmSuite::Tdls:
+        return "Tdls";
+    case Ieee80211AkmSuite::Sae:
+        return "Sae";
+    case Ieee80211AkmSuite::FtSae:
+        return "FtSae";
+    case Ieee80211AkmSuite::ApPeerKey:
+        return "ApPeerKey";
+    case Ieee80211AkmSuite::Ieee8021xSuiteB:
+        return "Ieee8021xSuiteB";
+    case Ieee80211AkmSuite::Ieee8011xSuiteB192:
+        return "Ieee8021xSuiteB192";
+    case Ieee80211AkmSuite::Ft8021xSha384:
+        return "Ft8021xSha384";
+    case Ieee80211AkmSuite::FilsSha256:
+        return "FilsSha256";
+    case Ieee80211AkmSuite::FilsSha384:
+        return "FilsSha384";
+    case Ieee80211AkmSuite::FtFilsSha256:
+        return "FtFilsSha256";
+    case Ieee80211AkmSuite::FtFilsSha384:
+        return "FtFilsSha384";
+    case Ieee80211AkmSuite::Owe:
+        return "Owe";
+    case Ieee80211AkmSuite::FtPskSha384:
+        return "FtPskSha384";
+    case Ieee80211AkmSuite::PskSha384:
+        return "PskSha384";
+    case Ieee80211AkmSuite::Pasn:
+        return "Pasn";
+    default:
+        return "Unknown";
+    }
+}
+
+std::string
+Ieee80211CipherSuiteToString(const Ieee80211CipherSuite& cipherSuite)
+{
+    switch (cipherSuite) {
+    case Ieee80211CipherSuite::BipCmac128:
+        return "BipCmac128";
+    case Ieee80211CipherSuite::BipCmac256:
+        return "BipCmac256";
+    case Ieee80211CipherSuite::BipGmac128:
+        return "BipGmac128";
+    case Ieee80211CipherSuite::BipGmac256:
+        return "BipGmac256";
+    case Ieee80211CipherSuite::Ccmp128:
+        return "Ccmp128";
+    case Ieee80211CipherSuite::Ccmp256:
+        return "Ccmp256";
+    case Ieee80211CipherSuite::Gcmp128:
+        return "Gcmp128";
+    case Ieee80211CipherSuite::Gcmp256:
+        return "Gcmp256";
+    case Ieee80211CipherSuite::GroupAddressesTrafficNotAllowed:
+        return "GroupAddressesTrafficNotAllowed";
+    case Ieee80211CipherSuite::Tkip:
+        return "Tkip";
+    case Ieee80211CipherSuite::UseGroup:
+        return "UseGroup";
+    case Ieee80211CipherSuite::Wep104:
+        return "Wep104";
+    case Ieee80211CipherSuite::Wep40:
+        return "Wep40";
+    default:
+        return "Unknown";
+    }
+}
+
+std::string
 Ieee80211MacAddressToString(const Ieee80211MacAddress& macAddress)
 {
     return std::format("{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}", macAddress[0], macAddress[1], macAddress[2], macAddress[3], macAddress[4], macAddress[5]);

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -23,12 +23,30 @@ enum class Ieee80211SecurityProtocol {
     Wpa3,
 };
 
+/**
+ * @brief Convert an Ieee80211SecurityProtocol to a string.
+ * 
+ * @param securityProtocol The security protocol to convert.
+ * @return std::string
+ */
+std::string
+Ieee80211SecurityProtocolToString(const Ieee80211SecurityProtocol& securityProtocol);
+
 enum class Ieee80211FrequencyBand {
     Unknown,
     TwoPointFourGHz,
     FiveGHz,
     SixGHz,
 };
+
+/**
+ * @brief Convert an Ieee80211FrequencyBand to a string.
+ * 
+ * @param frequencyBand The frequency band to convert.
+ * @return std::string
+ */
+std::string
+Ieee80211FrequencyBandToString(const Ieee80211FrequencyBand& frequencyBand);
 
 namespace Literals
 {
@@ -151,6 +169,15 @@ enum class Ieee80211AuthenticationAlgorithm : uint16_t {
     FilsPublicKey = 0x0007,
     VendorSpecific = 0xFFFF,
 };
+
+/**
+ * @brief Convert an Ieee80211AuthenticationAlgorithm to a string.
+ * 
+ * @param authenticationAlgorithm The authentication algorithm to convert.
+ * @return std::string
+ */
+std::string
+Ieee80211AuthenticationAlgorithmToString(const Ieee80211AuthenticationAlgorithm& authenticationAlgorithm);
 
 /**
  * @brief AKM suite identifiers or "selectors".
@@ -292,6 +319,15 @@ WpaAkmSuites(const Ieee80211SecurityProtocol& securityProtocol)
 }
 
 /**
+ * @brief Convert an Ieee80211AkmSuite to a string.
+ * 
+ * @param akmSuite The AKM suite to convert.
+ * @return std::string
+ */
+std::string
+Ieee80211AkmSuiteToString(const Ieee80211AkmSuite& akmSuite);
+
+/**
  * @brief Cipher suite identifiers or "selectors".
  *
  * Defined in IEEE 802.11-2020, Section 9.4.2.24.2, Table 9-149.
@@ -379,6 +415,15 @@ WpaCipherSuites(const Ieee80211SecurityProtocol& securityProtocol)
         return {};
     }
 }
+
+/**
+ * @brief Convert an Ieee80211CipherSuite to a string.
+ * 
+ * @param cipherSuite The cipher suite to convert.
+ * @return std::string
+ */
+std::string
+Ieee80211CipherSuiteToString(const Ieee80211CipherSuite& cipherSuite);
 
 /**
  * @brief IEEE 802.11 BSS Types.

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/Ieee80211.hxx
@@ -9,6 +9,7 @@
 #include <initializer_list>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 
 namespace Microsoft::Net::Wifi
@@ -23,30 +24,12 @@ enum class Ieee80211SecurityProtocol {
     Wpa3,
 };
 
-/**
- * @brief Convert an Ieee80211SecurityProtocol to a string.
- * 
- * @param securityProtocol The security protocol to convert.
- * @return std::string
- */
-std::string
-Ieee80211SecurityProtocolToString(const Ieee80211SecurityProtocol& securityProtocol);
-
 enum class Ieee80211FrequencyBand {
     Unknown,
     TwoPointFourGHz,
     FiveGHz,
     SixGHz,
 };
-
-/**
- * @brief Convert an Ieee80211FrequencyBand to a string.
- * 
- * @param frequencyBand The frequency band to convert.
- * @return std::string
- */
-std::string
-Ieee80211FrequencyBandToString(const Ieee80211FrequencyBand& frequencyBand);
 
 namespace Literals
 {
@@ -174,9 +157,9 @@ enum class Ieee80211AuthenticationAlgorithm : uint16_t {
  * @brief Convert an Ieee80211AuthenticationAlgorithm to a string.
  * 
  * @param authenticationAlgorithm The authentication algorithm to convert.
- * @return std::string
+ * @return std::string_view
  */
-std::string
+std::string_view
 Ieee80211AuthenticationAlgorithmToString(const Ieee80211AuthenticationAlgorithm& authenticationAlgorithm);
 
 /**
@@ -319,15 +302,6 @@ WpaAkmSuites(const Ieee80211SecurityProtocol& securityProtocol)
 }
 
 /**
- * @brief Convert an Ieee80211AkmSuite to a string.
- * 
- * @param akmSuite The AKM suite to convert.
- * @return std::string
- */
-std::string
-Ieee80211AkmSuiteToString(const Ieee80211AkmSuite& akmSuite);
-
-/**
  * @brief Cipher suite identifiers or "selectors".
  *
  * Defined in IEEE 802.11-2020, Section 9.4.2.24.2, Table 9-149.
@@ -415,15 +389,6 @@ WpaCipherSuites(const Ieee80211SecurityProtocol& securityProtocol)
         return {};
     }
 }
-
-/**
- * @brief Convert an Ieee80211CipherSuite to a string.
- * 
- * @param cipherSuite The cipher suite to convert.
- * @return std::string
- */
-std::string
-Ieee80211CipherSuiteToString(const Ieee80211CipherSuite& cipherSuite);
 
 /**
  * @brief IEEE 802.11 BSS Types.

--- a/src/linux/net/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/net/wifi/core/AccessPointControllerLinux.cxx
@@ -124,7 +124,7 @@ AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState oper
 
     switch (operationalState) {
     case AccessPointOperationalState::Enabled: {
-        AUDIT_LOGD << std::format("Attempting to set operational state of AP {} to 'enabled'", status.AccessPointId);
+        AUDITD << std::format("Attempting to set operational state of AP {} to 'enabled'", status.AccessPointId);
         try {
             m_hostapd.Enable();
             status.Code = AccessPointOperationStatusCode::Succeeded;
@@ -133,7 +133,7 @@ AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState oper
             AccessPointOperationalState actualOperationalState{};
             auto getOperationalStateStatus = GetOperationalState(actualOperationalState);
             if (getOperationalStateStatus.Code == AccessPointOperationStatusCode::Succeeded && actualOperationalState == AccessPointOperationalState::Enabled) {
-                AUDIT_LOGI << std::format("Operational state of AP {} set to 'enabled'", status.AccessPointId);
+                AUDITI << std::format("Operational state of AP {} set to 'enabled'", status.AccessPointId);
             }
         } catch (const Wpa::HostapdException& ex) {
             status.Code = AccessPointOperationStatusCode::InternalError;
@@ -142,7 +142,7 @@ AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState oper
         break;
     }
     case AccessPointOperationalState::Disabled: {
-        AUDIT_LOGD << std::format("Attempting to set operational state of AP {} to 'disabled'", status.AccessPointId);
+        AUDITD << std::format("Attempting to set operational state of AP {} to 'disabled'", status.AccessPointId);
         try {
             m_hostapd.Disable();
             status.Code = AccessPointOperationStatusCode::Succeeded;
@@ -151,7 +151,7 @@ AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState oper
             AccessPointOperationalState actualOperationalState{};
             auto getOperationalStateStatus = GetOperationalState(actualOperationalState);
             if (getOperationalStateStatus.Code == AccessPointOperationStatusCode::Succeeded && actualOperationalState == AccessPointOperationalState::Disabled) {
-                AUDIT_LOGI << std::format("Operational state of AP {} set to 'disabled'", status.AccessPointId);
+                AUDITI << std::format("Operational state of AP {} set to 'disabled'", status.AccessPointId);
             }
         } catch (const Wpa::HostapdException& ex) {
             status.Code = AccessPointOperationStatusCode::InternalError;
@@ -176,7 +176,7 @@ AccessPointControllerLinux::SetPhyType(Ieee80211PhyType ieeePhyType) noexcept
     AccessPointOperationStatus status{ GetInterfaceName(), std::format("SetPhyType {}", ieeePhyTypeName) };
     const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
 
-    AUDIT_LOGD << std::format("Attempting to set PHY type of AP {} to {}", status.AccessPointId, ieeePhyTypeName);
+    AUDITD << std::format("Attempting to set PHY type of AP {} to {}", status.AccessPointId, ieeePhyTypeName);
 
     // Populate a list of required properties to set.
     std::vector<std::pair<std::string_view, std::string_view>> propertiesToSet{};
@@ -237,20 +237,20 @@ AccessPointControllerLinux::SetPhyType(Ieee80211PhyType ieeePhyType) noexcept
         if (hostapdStatus.Ieee80211ax == 1 && hostapdStatus.Disable11ax == 0 &&
             hostapdStatus.Ieee80211ac == 1 && hostapdStatus.Disable11ac == 0 &&
             hostapdStatus.Ieee80211n == 1 && hostapdStatus.Disable11n == 0) {
-            AUDIT_LOGI << std::format("PHY type of AP {} set to 'AX' (HE)", status.AccessPointId);
+            AUDITI << std::format("PHY type of AP {} set to 'AX' (HE)", status.AccessPointId);
         }
         break;
     // PHY type AC requires AC and N to be enabled.
     case Ieee80211PhyType::AC:
         if (hostapdStatus.Ieee80211ac == 1 && hostapdStatus.Disable11ac == 0 &&
             hostapdStatus.Ieee80211n == 1 && hostapdStatus.Disable11n == 0) {
-            AUDIT_LOGI << std::format("PHY type of AP {} set to 'AC' (VHT)", status.AccessPointId);
+            AUDITI << std::format("PHY type of AP {} set to 'AC' (VHT)", status.AccessPointId);
         }
         break;
     // PHY type N only requires N to be enabled.
     case Ieee80211PhyType::N:
         if (hostapdStatus.Ieee80211n == 1 && hostapdStatus.Disable11n == 0) {
-            AUDIT_LOGI << std::format("PHY type of AP {} set to 'N' (HT)", status.AccessPointId);
+            AUDITI << std::format("PHY type of AP {} set to 'N' (HT)", status.AccessPointId);
         }
         break;
     default:
@@ -279,7 +279,7 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
     std::string bands = std::accumulate(std::next(std::begin(frequencyBands)), std::end(frequencyBands), Ieee80211FrequencyBandToString(frequencyBands[0]), [](std::string concatenatedBands, Ieee80211FrequencyBand band) {
         return concatenatedBands + ',' + Ieee80211FrequencyBandToString(band);
     });
-    AUDIT_LOGD << std::format("Attempting to set frequency bands of AP {} to {}", status.AccessPointId, bands);
+    AUDITD << std::format("Attempting to set frequency bands of AP {} to {}", status.AccessPointId, bands);
 
     // Generate the argument for the hostapd "setband" command, which accepts a comma separated list of bands.
     std::ostringstream setBandArgumentBuilder;
@@ -321,13 +321,13 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
     /*
     auto hostapdStatus = m_hostapd.GetStatus();
     if (std::ranges::contains(frequencyBands, Ieee80211FrequencyBand::TwoPointFourGHz) && hostapdStatus.Frequency >= 2400 && hostapdStatus.Frequency < 5000) {
-        AUDIT_LOGI << std::format("AP {} is operating on frequency band 2.4GHz with frequency {}", status.AccessPointId, hostapdStatus.Frequency);
+        AUDITI << std::format("AP {} is operating on frequency band 2.4GHz with frequency {}", status.AccessPointId, hostapdStatus.Frequency);
     } else if (std::ranges::contains(frequencyBands, Ieee80211FrequencyBand::FiveGHz) && hostapdStatus.Frequency >= 5000 && hostapdStatus.Frequency < 6000) {
-        AUDIT_LOGI << std::format("AP {} is operating on frequency band 5GHz with frequency {}", status.AccessPointId, hostapdStatus.Frequency);
+        AUDITI << std::format("AP {} is operating on frequency band 5GHz with frequency {}", status.AccessPointId, hostapdStatus.Frequency);
     } else if (std::ranges::contains(frequencyBands, Ieee80211FrequencyBand::SixGHz) && hostapdStatus.Frequency >= 6000 && hostapdStatus.Frequency < 7000) {
-        AUDIT_LOGI << std::format("AP {} is operating on frequency band 6GHz with frequency {}", status.AccessPointId, hostapdStatus.Frequency);
+        AUDITI << std::format("AP {} is operating on frequency band 6GHz with frequency {}", status.AccessPointId, hostapdStatus.Frequency);
     } else {
-        AUDIT_LOGD << std::format("Frequency bands of AP {} were not set. Current frequency: {}", hostapdStatus.Frequency);
+        AUDITD << std::format("Frequency bands of AP {} were not set. Current frequency: {}", hostapdStatus.Frequency);
     }
     */
 
@@ -353,7 +353,7 @@ AccessPointControllerLinux::SetAuthenticationAlgorithms(std::vector<Ieee80211Aut
     std::string algorithms = std::accumulate(std::next(std::begin(authenticationAlgorithms)), std::end(authenticationAlgorithms), Ieee80211AuthenticationAlgorithmToString(authenticationAlgorithms[0]), [](std::string concatenatedAlgorithms, Ieee80211AuthenticationAlgorithm algorithm) {
         return concatenatedAlgorithms + ',' + Ieee80211AuthenticationAlgorithmToString(algorithm);
     });
-    AUDIT_LOGD << std::format("Attempting to set authentication algorithms of AP {} to {}", status.AccessPointId, algorithms);
+    AUDITD << std::format("Attempting to set authentication algorithms of AP {} to {}", status.AccessPointId, algorithms);
 
     std::vector<Wpa::WpaAuthenticationAlgorithm> authenticationAlgorithmsHostapd(std::size(authenticationAlgorithms));
     std::ranges::transform(authenticationAlgorithms, std::begin(authenticationAlgorithmsHostapd), Ieee80211AuthenticationAlgorithmToWpaAuthenticationAlgorithm);
@@ -435,7 +435,7 @@ AccessPointControllerLinux::SetAkmSuites(std::vector<Ieee80211AkmSuite> akmSuite
     std::string akms = std::accumulate(std::next(std::begin(akmSuites)), std::end(akmSuites), Ieee80211AkmSuiteToString(akmSuites[0]), [](std::string concatenatedAkms, Ieee80211AkmSuite akm) {
         return concatenatedAkms + ',' + Ieee80211AkmSuiteToString(akm);
     });
-    AUDIT_LOGD << std::format("Attempting to set AKM suites of AP {} to {}", status.AccessPointId, akms);
+    AUDITD << std::format("Attempting to set AKM suites of AP {} to {}", status.AccessPointId, akms);
 
     std::vector<Wpa::WpaKeyManagement> wpaKeyManagements(std::size(akmSuites));
     std::ranges::transform(akmSuites, std::begin(wpaKeyManagements), Ieee80211AkmSuiteToWpaKeyManagement);
@@ -452,11 +452,11 @@ AccessPointControllerLinux::SetAkmSuites(std::vector<Ieee80211AkmSuite> akmSuite
     auto hostapdBssConfiguration = m_hostapd.GetConfiguration();
     auto actualKeyManagements = hostapdBssConfiguration.WpaKeyMgmt;
     if (std::equal(std::begin(wpaKeyManagements), std::end(wpaKeyManagements), std::begin(actualKeyManagements))) {
-        AUDIT_LOGI << std::format("AKM suites of AP {} set to {}", status.AccessPointId, akms);
+        AUDITI << std::format("AKM suites of AP {} set to {}", status.AccessPointId, akms);
     } else {
-        AUDIT_LOGD << std::format("AKM suites of AP {} were not set. Current key_mgmt values:", status.AccessPointId);
+        AUDITD << std::format("AKM suites of AP {} were not set. Current key_mgmt values:", status.AccessPointId);
         for (const auto& actualKeyManagement : actualKeyManagements) {
-            AUDIT_LOGD << std::format("key_mgmt: {}", std::to_underlying(actualKeyManagement));
+            AUDITD << std::format("key_mgmt: {}", std::to_underlying(actualKeyManagement));
         }
     }
 
@@ -490,7 +490,7 @@ AccessPointControllerLinux::SetPairwiseCipherSuites(std::unordered_map<Ieee80211
         pairwiseCiphers += ";";
     }
     pairwiseCiphers.pop_back(); // Remove trailing semicolon
-    AUDIT_LOGD << std::format("Attempting to set pairwise cipher suites of AP {} to {}", status.AccessPointId, pairwiseCiphers);
+    AUDITD << std::format("Attempting to set pairwise cipher suites of AP {} to {}", status.AccessPointId, pairwiseCiphers);
 
     auto pairwiseCipherSuitesHostapd = Ieee80211CipherSuitesToWpaCipherSuites(pairwiseCipherSuites);
 
@@ -509,9 +509,9 @@ AccessPointControllerLinux::SetPairwiseCipherSuites(std::unordered_map<Ieee80211
         return wpaCipher.first;
     });
     if (isWpaSecurityProtocolSet) {
-        AUDIT_LOGI << std::format("WPA security protocol for AP {} set to {}", status.AccessPointId, std::to_underlying(wpaSecurityProtocol));
+        AUDITI << std::format("WPA security protocol for AP {} set to {}", status.AccessPointId, std::to_underlying(wpaSecurityProtocol));
     } else {
-        AUDIT_LOGD << std::format("WPA security protocol for AP {} was not set. Current wpa value: {}", status.AccessPointId, std::to_underlying(wpaSecurityProtocol));
+        AUDITD << std::format("WPA security protocol for AP {} was not set. Current wpa value: {}", status.AccessPointId, std::to_underlying(wpaSecurityProtocol));
     }
 
     // TODO: Update HostapdBssConfiguration to accept a vector of wpa_pairwise_cipher and rsn_pairwise_cipher, as well as the following code.
@@ -522,16 +522,16 @@ AccessPointControllerLinux::SetPairwiseCipherSuites(std::unordered_map<Ieee80211
     switch (wpaSecurityProtocol) {
     case Wpa::WpaSecurityProtocol::Wpa:
         if (iter != std::end(pairwiseCipherSuitesHostapd) && std::ranges::contains(iter->second, wpaPairwiseCipher)) {
-            AUDIT_LOGI << std::format("WPA pairwise cipher for AP {} set to {}", status.AccessPointId, std::to_underlying(wpaPairwiseCipher));
+            AUDITI << std::format("WPA pairwise cipher for AP {} set to {}", status.AccessPointId, std::to_underlying(wpaPairwiseCipher));
         } else {
-            AUDIT_LOGD << std::format("WPA pairwise cipher for AP {} was not set. Current wpa_pairwise_cipher value: {}", status.AccessPointId, std::to_underlying(wpaPairwiseCipher));
+            AUDITD << std::format("WPA pairwise cipher for AP {} was not set. Current wpa_pairwise_cipher value: {}", status.AccessPointId, std::to_underlying(wpaPairwiseCipher));
         }
         break;
     case Wpa::WpaSecurityProtocol::Wpa2: // Also applies to Wpa3 since they have the same value in the enum class.
         if (iter != std::end(pairwiseCipherSuitesHostapd) && std::ranges::contains(iter->second, rsnPairwiseCipher)) {
-            AUDIT_LOGI << std::format("RSN pairwise cipher for AP {} set to {}", status.AccessPointId, std::to_underlying(rsnPairwiseCipher));
+            AUDITI << std::format("RSN pairwise cipher for AP {} set to {}", status.AccessPointId, std::to_underlying(rsnPairwiseCipher));
         } else {
-            AUDIT_LOGD << std::format("RSN pairwise cipher for AP {} not set. Current rsn_pairwise_cipher value: {}", status.AccessPointId, std::to_underlying(rsnPairwiseCipher));
+            AUDITD << std::format("RSN pairwise cipher for AP {} not set. Current rsn_pairwise_cipher value: {}", status.AccessPointId, std::to_underlying(rsnPairwiseCipher));
         }
         break;
     default:
@@ -555,7 +555,7 @@ AccessPointControllerLinux::SetSsid(std::string_view ssid) noexcept
         return status;
     }
 
-    AUDIT_LOGD << std::format("Attempting to set SSID for AP {} to {}", status.AccessPointId, ssid);
+    AUDITD << std::format("Attempting to set SSID for AP {} to {}", status.AccessPointId, ssid);
 
     // Attempt to set the SSID.
     try {
@@ -569,9 +569,9 @@ AccessPointControllerLinux::SetSsid(std::string_view ssid) noexcept
     // Validate that the SSID was successfully set by hostapd.
     auto hostapdBssConfiguration = m_hostapd.GetConfiguration();
     if (hostapdBssConfiguration.Ssid == ssid) {
-        AUDIT_LOGI << std::format("SSID for AP {} set to {}", status.AccessPointId, hostapdBssConfiguration.Ssid);
+        AUDITI << std::format("SSID for AP {} set to {}", status.AccessPointId, hostapdBssConfiguration.Ssid);
     } else {
-        AUDIT_LOGD << std::format("SSID for AP {} was not set. Current ssid value: {}", status.AccessPointId, hostapdBssConfiguration.Ssid);
+        AUDITD << std::format("SSID for AP {} was not set. Current ssid value: {}", status.AccessPointId, hostapdBssConfiguration.Ssid);
     }
 
     status.Code = AccessPointOperationStatusCode::Succeeded;

--- a/src/linux/net/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/net/wifi/core/AccessPointControllerLinux.cxx
@@ -458,7 +458,7 @@ AccessPointControllerLinux::SetAkmSuites(std::vector<Ieee80211AkmSuite> akmSuite
     } else {
         std::string keyMgmtDebugLog = std::format("AKM suites of AP {} were not set. Current key_mgmt values: ", status.AccessPointId);
         for (const auto& actualKeyManagement : actualKeyManagements) {
-            keyMgmtDebugLog += std::format("{} ", std::to_underlying(actualKeyManagement));
+            keyMgmtDebugLog += std::format("{} ", magic_enum::enum_name(actualKeyManagement));
         }
         AUDITD << keyMgmtDebugLog;
     }
@@ -511,9 +511,9 @@ AccessPointControllerLinux::SetPairwiseCipherSuites(std::unordered_map<Ieee80211
         return wpaCipher.first;
     });
     if (isWpaSecurityProtocolSet) {
-        AUDITI << std::format("WPA security protocol for AP {} set to {}", status.AccessPointId, std::to_underlying(wpaSecurityProtocol));
+        AUDITI << std::format("WPA security protocol for AP {} set to {}", status.AccessPointId, magic_enum::enum_name(wpaSecurityProtocol));
     } else {
-        AUDITD << std::format("WPA security protocol for AP {} was not set. Current wpa value: {}", status.AccessPointId, std::to_underlying(wpaSecurityProtocol));
+        AUDITD << std::format("WPA security protocol for AP {} was not set. Current wpa value: {}", status.AccessPointId, magic_enum::enum_name(wpaSecurityProtocol));
     }
 
     // TODO: Update HostapdBssConfiguration to accept a vector of wpa_pairwise_cipher and rsn_pairwise_cipher, as well as the following code.
@@ -524,16 +524,16 @@ AccessPointControllerLinux::SetPairwiseCipherSuites(std::unordered_map<Ieee80211
     switch (wpaSecurityProtocol) {
     case Wpa::WpaSecurityProtocol::Wpa:
         if (iter != std::end(pairwiseCipherSuitesHostapd) && std::ranges::contains(iter->second, wpaPairwiseCipher)) {
-            AUDITI << std::format("WPA pairwise cipher for AP {} set to {}", status.AccessPointId, std::to_underlying(wpaPairwiseCipher));
+            AUDITI << std::format("WPA pairwise cipher for AP {} set to {}", status.AccessPointId, magic_enum::enum_name(wpaPairwiseCipher));
         } else {
-            AUDITD << std::format("WPA pairwise cipher for AP {} was not set. Current wpa_pairwise_cipher value: {}", status.AccessPointId, std::to_underlying(wpaPairwiseCipher));
+            AUDITD << std::format("WPA pairwise cipher for AP {} was not set. Current wpa_pairwise_cipher value: {}", status.AccessPointId, magic_enum::enum_name(wpaPairwiseCipher));
         }
         break;
     case Wpa::WpaSecurityProtocol::Wpa2: // Also applies to Wpa3 since they have the same value in the enum class.
         if (iter != std::end(pairwiseCipherSuitesHostapd) && std::ranges::contains(iter->second, rsnPairwiseCipher)) {
-            AUDITI << std::format("RSN pairwise cipher for AP {} set to {}", status.AccessPointId, std::to_underlying(rsnPairwiseCipher));
+            AUDITI << std::format("RSN pairwise cipher for AP {} set to {}", status.AccessPointId, magic_enum::enum_name(rsnPairwiseCipher));
         } else {
-            AUDITD << std::format("RSN pairwise cipher for AP {} not set. Current rsn_pairwise_cipher value: {}", status.AccessPointId, std::to_underlying(rsnPairwiseCipher));
+            AUDITD << std::format("RSN pairwise cipher for AP {} not set. Current rsn_pairwise_cipher value: {}", status.AccessPointId, magic_enum::enum_name(rsnPairwiseCipher));
         }
         break;
     default:

--- a/src/linux/net/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/net/wifi/core/AccessPointControllerLinux.cxx
@@ -3,6 +3,7 @@
 #include <format>
 #include <iterator>
 #include <memory>
+#include <numeric>
 #include <ranges>
 #include <sstream>
 #include <string>
@@ -15,6 +16,7 @@
 #include <Wpa/Hostapd.hxx>
 #include <Wpa/IHostapd.hxx>
 #include <Wpa/ProtocolHostapd.hxx>
+#include <logging/LogUtils.hxx>
 #include <magic_enum.hpp>
 #include <microsoft/net/Ieee8021xRadiusAuthentication.hxx>
 #include <microsoft/net/netlink/nl80211/Ieee80211Nl80211Adapters.hxx>
@@ -26,6 +28,7 @@
 #include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
+#include <plog/Log.h>
 #include <plog/Severity.h>
 
 #include "Ieee80211WpaAdapters.hxx"
@@ -121,9 +124,17 @@ AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState oper
 
     switch (operationalState) {
     case AccessPointOperationalState::Enabled: {
+        AUDIT_LOGD << std::format("Attempting to set operational state of AP {} to 'enabled'", status.AccessPointId);
         try {
             m_hostapd.Enable();
             status.Code = AccessPointOperationStatusCode::Succeeded;
+
+            // Validate that enabling the operational state succeeds.
+            AccessPointOperationalState actualOperationalState{};
+            auto getOperationalStateStatus = GetOperationalState(actualOperationalState);
+            if (getOperationalStateStatus.Code == AccessPointOperationStatusCode::Succeeded && actualOperationalState == AccessPointOperationalState::Enabled) {
+                AUDIT_LOGI << std::format("Operational state of AP {} set to 'enabled'", status.AccessPointId);
+            }
         } catch (const Wpa::HostapdException& ex) {
             status.Code = AccessPointOperationStatusCode::InternalError;
             status.Details = std::format("failed to set operational state to 'enabled' ({})", ex.what());
@@ -131,9 +142,17 @@ AccessPointControllerLinux::SetOperationalState(AccessPointOperationalState oper
         break;
     }
     case AccessPointOperationalState::Disabled: {
+        AUDIT_LOGD << std::format("Attempting to set operational state of AP {} to 'disabled'", status.AccessPointId);
         try {
             m_hostapd.Disable();
             status.Code = AccessPointOperationStatusCode::Succeeded;
+
+            // Validate that disabling the operational state succeeds.
+            AccessPointOperationalState actualOperationalState{};
+            auto getOperationalStateStatus = GetOperationalState(actualOperationalState);
+            if (getOperationalStateStatus.Code == AccessPointOperationStatusCode::Succeeded && actualOperationalState == AccessPointOperationalState::Disabled) {
+                AUDIT_LOGI << std::format("Operational state of AP {} set to 'disabled'", status.AccessPointId);
+            }
         } catch (const Wpa::HostapdException& ex) {
             status.Code = AccessPointOperationStatusCode::InternalError;
             status.Details = std::format("failed to set operational state to 'disabled' ({})", ex.what());
@@ -156,6 +175,8 @@ AccessPointControllerLinux::SetPhyType(Ieee80211PhyType ieeePhyType) noexcept
     const auto ieeePhyTypeName = std::format("802.11 {}", magic_enum::enum_name(ieeePhyType));
     AccessPointOperationStatus status{ GetInterfaceName(), std::format("SetPhyType {}", ieeePhyTypeName) };
     const AccessPointOperationStatusLogOnExit logStatusOnExit(&status);
+
+    AUDIT_LOGD << std::format("Attempting to set PHY type of AP {} to {}", status.AccessPointId, ieeePhyTypeName);
 
     // Populate a list of required properties to set.
     std::vector<std::pair<std::string_view, std::string_view>> propertiesToSet{};
@@ -208,6 +229,34 @@ AccessPointControllerLinux::SetPhyType(Ieee80211PhyType ieeePhyType) noexcept
         return status;
     }
 
+    // There is no way to validate the PHY type that was set, except for AX, AC, and N, which are available from the 'STATUS' command.
+    auto hostapdStatus = m_hostapd.GetStatus();
+    switch (ieeePhyType) {
+    // PHY type AX requires AX, AC, and N to be enabled.
+    case Ieee80211PhyType::AX:
+        if (hostapdStatus.Ieee80211ax == 1 && hostapdStatus.Disable11ax == 0 &&
+            hostapdStatus.Ieee80211ac == 1 && hostapdStatus.Disable11ac == 0 &&
+            hostapdStatus.Ieee80211n == 1 && hostapdStatus.Disable11n == 0) {
+            AUDIT_LOGI << std::format("PHY type of AP {} set to 'AX' (HE)", status.AccessPointId);
+        }
+        break;
+    // PHY type AC requires AC and N to be enabled.
+    case Ieee80211PhyType::AC:
+        if (hostapdStatus.Ieee80211ac == 1 && hostapdStatus.Disable11ac == 0 &&
+            hostapdStatus.Ieee80211n == 1 && hostapdStatus.Disable11n == 0) {
+            AUDIT_LOGI << std::format("PHY type of AP {} set to 'AC' (VHT)", status.AccessPointId);
+        }
+        break;
+    // PHY type N only requires N to be enabled.
+    case Ieee80211PhyType::N:
+        if (hostapdStatus.Ieee80211n == 1 && hostapdStatus.Disable11n == 0) {
+            AUDIT_LOGI << std::format("PHY type of AP {} set to 'N' (HT)", status.AccessPointId);
+        }
+        break;
+    default:
+        break;
+    }
+
     status.Code = AccessPointOperationStatusCode::Succeeded;
 
     return status;
@@ -226,6 +275,11 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
         logStatusOnExit.SeverityOnError = plog::Severity::warning;
         return status;
     }
+
+    std::string bands = std::accumulate(std::next(std::begin(frequencyBands)), std::end(frequencyBands), Ieee80211FrequencyBandToString(frequencyBands[0]), [](std::string concatenatedBands, Ieee80211FrequencyBand band) {
+        return concatenatedBands + ',' + Ieee80211FrequencyBandToString(band);
+    });
+    AUDIT_LOGD << std::format("Attempting to set frequency bands of AP {} to {}", status.AccessPointId, bands);
 
     // Generate the argument for the hostapd "setband" command, which accepts a comma separated list of bands.
     std::ostringstream setBandArgumentBuilder;
@@ -262,6 +316,21 @@ AccessPointControllerLinux::SetFrequencyBands(std::vector<Ieee80211FrequencyBand
         }
     }
 
+    // Validate that the AP is operating on a frequency band that was set by hostapd.
+    // TODO: Add parsing code for HostapdStatus::Frequency in ProtocolHostapd.*xx
+    /*
+    auto hostapdStatus = m_hostapd.GetStatus();
+    if (std::ranges::contains(frequencyBands, Ieee80211FrequencyBand::TwoPointFourGHz) && hostapdStatus.Frequency >= 2400 && hostapdStatus.Frequency < 5000) {
+        AUDIT_LOGI << std::format("AP {} is operating on frequency band 2.4GHz with frequency {}", status.AccessPointId, hostapdStatus.Frequency);
+    } else if (std::ranges::contains(frequencyBands, Ieee80211FrequencyBand::FiveGHz) && hostapdStatus.Frequency >= 5000 && hostapdStatus.Frequency < 6000) {
+        AUDIT_LOGI << std::format("AP {} is operating on frequency band 5GHz with frequency {}", status.AccessPointId, hostapdStatus.Frequency);
+    } else if (std::ranges::contains(frequencyBands, Ieee80211FrequencyBand::SixGHz) && hostapdStatus.Frequency >= 6000 && hostapdStatus.Frequency < 7000) {
+        AUDIT_LOGI << std::format("AP {} is operating on frequency band 6GHz with frequency {}", status.AccessPointId, hostapdStatus.Frequency);
+    } else {
+        AUDIT_LOGD << std::format("Frequency bands of AP {} were not set. Current frequency: {}", hostapdStatus.Frequency);
+    }
+    */
+
     // Band changes do not require reloading configuration, so skip that step and mark the operation as successful.
     status.Code = AccessPointOperationStatusCode::Succeeded;
 
@@ -281,6 +350,11 @@ AccessPointControllerLinux::SetAuthenticationAlgorithms(std::vector<Ieee80211Aut
         return status;
     }
 
+    std::string algorithms = std::accumulate(std::next(std::begin(authenticationAlgorithms)), std::end(authenticationAlgorithms), Ieee80211AuthenticationAlgorithmToString(authenticationAlgorithms[0]), [](std::string concatenatedAlgorithms, Ieee80211AuthenticationAlgorithm algorithm) {
+        return concatenatedAlgorithms + ',' + Ieee80211AuthenticationAlgorithmToString(algorithm);
+    });
+    AUDIT_LOGD << std::format("Attempting to set authentication algorithms of AP {} to {}", status.AccessPointId, algorithms);
+
     std::vector<Wpa::WpaAuthenticationAlgorithm> authenticationAlgorithmsHostapd(std::size(authenticationAlgorithms));
     std::ranges::transform(authenticationAlgorithms, std::begin(authenticationAlgorithmsHostapd), Ieee80211AuthenticationAlgorithmToWpaAuthenticationAlgorithm);
 
@@ -291,6 +365,9 @@ AccessPointControllerLinux::SetAuthenticationAlgorithms(std::vector<Ieee80211Aut
         status.Details = std::format("failed to set authentication algorithms - {}", ex.what());
         return status;
     }
+
+    // TODO: Validate that the AP is using one of the authentication algorithms that were set.
+    // Note: This is currently not possible to check in hostapd. Update this in the future if hostapd gets updated.
 
     status.Code = AccessPointOperationStatusCode::Succeeded;
 
@@ -355,6 +432,11 @@ AccessPointControllerLinux::SetAkmSuites(std::vector<Ieee80211AkmSuite> akmSuite
         return status;
     }
 
+    std::string akms = std::accumulate(std::next(std::begin(akmSuites)), std::end(akmSuites), Ieee80211AkmSuiteToString(akmSuites[0]), [](std::string concatenatedAkms, Ieee80211AkmSuite akm) {
+        return concatenatedAkms + ',' + Ieee80211AkmSuiteToString(akm);
+    });
+    AUDIT_LOGD << std::format("Attempting to set AKM suites of AP {} to {}", status.AccessPointId, akms);
+
     std::vector<Wpa::WpaKeyManagement> wpaKeyManagements(std::size(akmSuites));
     std::ranges::transform(akmSuites, std::begin(wpaKeyManagements), Ieee80211AkmSuiteToWpaKeyManagement);
 
@@ -364,6 +446,18 @@ AccessPointControllerLinux::SetAkmSuites(std::vector<Ieee80211AkmSuite> akmSuite
         status.Code = AccessPointOperationStatusCode::InternalError;
         status.Details = std::format("failed to set akm suites - {}", ex.what());
         return status;
+    }
+
+    // Validate that the AKM suites are successfully set by hostapd.
+    auto hostapdBssConfiguration = m_hostapd.GetConfiguration();
+    auto actualKeyManagements = hostapdBssConfiguration.WpaKeyMgmt;
+    if (std::equal(std::begin(wpaKeyManagements), std::end(wpaKeyManagements), std::begin(actualKeyManagements))) {
+        AUDIT_LOGI << std::format("AKM suites of AP {} set to {}", status.AccessPointId, akms);
+    } else {
+        AUDIT_LOGD << std::format("AKM suites of AP {} were not set. Current key_mgmt values:", status.AccessPointId);
+        for (const auto& actualKeyManagement : actualKeyManagements) {
+            AUDIT_LOGD << std::format("key_mgmt: {}", std::to_underlying(actualKeyManagement));
+        }
     }
 
     status.Code = AccessPointOperationStatusCode::Succeeded;
@@ -384,6 +478,20 @@ AccessPointControllerLinux::SetPairwiseCipherSuites(std::unordered_map<Ieee80211
         return status;
     }
 
+    std::string pairwiseCiphers{};
+    for (const auto& [securityProtocol, cipherSuites] : pairwiseCipherSuites) {
+        pairwiseCiphers += Ieee80211SecurityProtocolToString(securityProtocol);
+        pairwiseCiphers += ": ";
+        for (const auto& cipherSuite : cipherSuites) {
+            pairwiseCiphers += Ieee80211CipherSuiteToString(cipherSuite);
+            pairwiseCiphers += ",";
+        }
+        pairwiseCiphers.pop_back(); // Remove trailing comma
+        pairwiseCiphers += ";";
+    }
+    pairwiseCiphers.pop_back(); // Remove trailing semicolon
+    AUDIT_LOGD << std::format("Attempting to set pairwise cipher suites of AP {} to {}", status.AccessPointId, pairwiseCiphers);
+
     auto pairwiseCipherSuitesHostapd = Ieee80211CipherSuitesToWpaCipherSuites(pairwiseCipherSuites);
 
     try {
@@ -392,6 +500,42 @@ AccessPointControllerLinux::SetPairwiseCipherSuites(std::unordered_map<Ieee80211
         status.Code = AccessPointOperationStatusCode::InternalError;
         status.Details = std::format("failed to set pairwise cipher suites - {}", e.what());
         return status;
+    }
+
+    // Validate that the pairwise cipher suites were successfully set by hostapd.
+    auto hostapdBssConfiguration = m_hostapd.GetConfiguration();
+    auto wpaSecurityProtocol = hostapdBssConfiguration.Wpa;
+    bool isWpaSecurityProtocolSet = std::ranges::contains(pairwiseCipherSuitesHostapd, wpaSecurityProtocol, [](const auto& wpaCipher) {
+        return wpaCipher.first;
+    });
+    if (isWpaSecurityProtocolSet) {
+        AUDIT_LOGI << std::format("WPA security protocol for AP {} set to {}", status.AccessPointId, std::to_underlying(wpaSecurityProtocol));
+    } else {
+        AUDIT_LOGD << std::format("WPA security protocol for AP {} was not set. Current wpa value: {}", status.AccessPointId, std::to_underlying(wpaSecurityProtocol));
+    }
+
+    // TODO: Update HostapdBssConfiguration to accept a vector of wpa_pairwise_cipher and rsn_pairwise_cipher, as well as the following code.
+    auto wpaPairwiseCipher = hostapdBssConfiguration.WpaPairwiseCipher;
+    auto rsnPairwiseCipher = hostapdBssConfiguration.RsnPairwiseCipher;
+
+    auto iter = pairwiseCipherSuitesHostapd.find(wpaSecurityProtocol);
+    switch (wpaSecurityProtocol) {
+    case Wpa::WpaSecurityProtocol::Wpa:
+        if (iter != std::end(pairwiseCipherSuitesHostapd) && std::ranges::contains(iter->second, wpaPairwiseCipher)) {
+            AUDIT_LOGI << std::format("WPA pairwise cipher for AP {} set to {}", status.AccessPointId, std::to_underlying(wpaPairwiseCipher));
+        } else {
+            AUDIT_LOGD << std::format("WPA pairwise cipher for AP {} was not set. Current wpa_pairwise_cipher value: {}", status.AccessPointId, std::to_underlying(wpaPairwiseCipher));
+        }
+        break;
+    case Wpa::WpaSecurityProtocol::Wpa2: // Also applies to Wpa3 since they have the same value in the enum class.
+        if (iter != std::end(pairwiseCipherSuitesHostapd) && std::ranges::contains(iter->second, rsnPairwiseCipher)) {
+            AUDIT_LOGI << std::format("RSN pairwise cipher for AP {} set to {}", status.AccessPointId, std::to_underlying(rsnPairwiseCipher));
+        } else {
+            AUDIT_LOGD << std::format("RSN pairwise cipher for AP {} not set. Current rsn_pairwise_cipher value: {}", status.AccessPointId, std::to_underlying(rsnPairwiseCipher));
+        }
+        break;
+    default:
+        break;
     }
 
     status.Code = AccessPointOperationStatusCode::Succeeded;
@@ -411,6 +555,8 @@ AccessPointControllerLinux::SetSsid(std::string_view ssid) noexcept
         return status;
     }
 
+    AUDIT_LOGD << std::format("Attempting to set SSID for AP {} to {}", status.AccessPointId, ssid);
+
     // Attempt to set the SSID.
     try {
         m_hostapd.SetProperty(Wpa::ProtocolHostapd::PropertyNameSsid, ssid, EnforceConfigurationChange::Now);
@@ -418,6 +564,14 @@ AccessPointControllerLinux::SetSsid(std::string_view ssid) noexcept
         status.Code = AccessPointOperationStatusCode::InternalError;
         status.Details = std::format("failed to set 'ssid' property to {} - {}", ssid, ex.what());
         return status;
+    }
+
+    // Validate that the SSID was successfully set by hostapd.
+    auto hostapdBssConfiguration = m_hostapd.GetConfiguration();
+    if (hostapdBssConfiguration.Ssid == ssid) {
+        AUDIT_LOGI << std::format("SSID for AP {} set to {}", status.AccessPointId, hostapdBssConfiguration.Ssid);
+    } else {
+        AUDIT_LOGD << std::format("SSID for AP {} was not set. Current ssid value: {}", status.AccessPointId, hostapdBssConfiguration.Ssid);
     }
 
     status.Code = AccessPointOperationStatusCode::Succeeded;

--- a/src/linux/net/wifi/core/CMakeLists.txt
+++ b/src/linux/net/wifi/core/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(wifi-core-linux
     PUBLIC
         ${PROJECT_NAME}-net
         libnl-helpers
+        logging-utils
         wifi-core
         wpa-controller
 )


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

To log Wi-Fi state changes to the audit log. This is done at the neutral `Ieee80211*` layer in `AccessPointControllerLinux` for most of the `Set*` functions.

A debug ( `AUDITD` ) line is added to log which neutral type values will be attempted to be set, then after the values are set, the updated changes are validated. If successful, an info ( `AUDITI` ) line is added to log the successful changes. If unsuccessful (usually meaning the value retrieved by hostapd is not what was set), then a debug line is added to log the value that was retrieved.

### Technical Details

* Added several `AUDITD` and `AUDITI` lines in `AccessPointControllerLinux.cxx` as described above.
* Added various `Ieee80211*ToString()` functions to `Ieee80211.*xx`.

### Test Results

Verified that the following changes show up in the audit log:
* Setting operational state
* Setting PHY type
* Setting SSID

Have not been able to verify that setting AKM suites and pairwise cipher suites works.

Tested these changes with `netremote-cli wifi ap-enable wlo1 --phy 3 --akms 1027080 --sae password`, `netremote-cli wifi ap-disable wlo1`, and `netremote-cli wifi set-ssid wlo1 netremote2-ap-wlo1`.

### Reviewer Focus

None.

### Future Work

* Add WPA events to audit log (via `OnWpaEvent` callback).
* Add access point events (such as AP added, removed, etc.) to audit log (via `AccessPointManager`).
* Need to update `HostapdBssConfiguration` to use `std::vector<WpaCipher` for `WpaPairwiseCipher` and `RsnPairwiseCipher`. Currently, there is only a single `WpaCipher` for each.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
