### PR TITLE
Log AP manager events and WPA events to audit log

### DIFF
--- a/src/common/net/wifi/apmanager/AccessPointManager.cxx
+++ b/src/common/net/wifi/apmanager/AccessPointManager.cxx
@@ -41,7 +41,7 @@ AccessPointManager::AddAccessPoint(std::shared_ptr<IAccessPoint> accessPoint)
 {
     const auto interfaceName{ accessPoint->GetInterfaceName() };
     LOGI << std::format("Attempting to add access point {} to manager", interfaceName);
-    AUDIT_LOGD << std::format("Attempting to add access point {} to manager", interfaceName);
+    AUDITD << std::format("Attempting to add access point {} to manager", interfaceName);
 
     {
         auto accessPointController = accessPoint->CreateController();
@@ -62,7 +62,7 @@ AccessPointManager::AddAccessPoint(std::shared_ptr<IAccessPoint> accessPoint)
     }
 
     LOGI << std::format("Adding access point {} to manager", interfaceName);
-    AUDIT_LOGI << std::format("Adding access point {} to manager", interfaceName);
+    AUDITI << std::format("Adding access point {} to manager", interfaceName);
 
     m_accessPoints.push_back(std::move(accessPoint));
 }
@@ -72,7 +72,7 @@ AccessPointManager::RemoveAccessPoint(std::shared_ptr<IAccessPoint> accessPoint)
 {
     const auto interfaceName{ accessPoint->GetInterfaceName() };
     LOGI << std::format("Attempting to remove access point {} from manager", interfaceName);
-    AUDIT_LOGD << std::format("Attempting to remove access point {} from manager", interfaceName);
+    AUDITD << std::format("Attempting to remove access point {} from manager", interfaceName);
 
     const auto accessPointsLock = std::scoped_lock{ m_accessPointGate };
     const auto accessPointToRemove = std::ranges::find_if(m_accessPoints, [&](const auto& accessPointExisting) {
@@ -85,7 +85,7 @@ AccessPointManager::RemoveAccessPoint(std::shared_ptr<IAccessPoint> accessPoint)
     }
 
     LOGI << std::format("Removing access point {} from manager", interfaceName);
-    AUDIT_LOGI << std::format("Removing access point {} from manager", interfaceName);
+    AUDITI << std::format("Removing access point {} from manager", interfaceName);
 
     m_accessPoints.erase(accessPointToRemove);
 }

--- a/src/common/net/wifi/apmanager/AccessPointManager.cxx
+++ b/src/common/net/wifi/apmanager/AccessPointManager.cxx
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include <logging/LogUtils.hxx>
 #include <magic_enum.hpp>
 #include <microsoft/net/wifi/AccessPointDiscoveryAgent.hxx>
 #include <microsoft/net/wifi/AccessPointManager.hxx>
@@ -40,6 +41,7 @@ AccessPointManager::AddAccessPoint(std::shared_ptr<IAccessPoint> accessPoint)
 {
     const auto interfaceName{ accessPoint->GetInterfaceName() };
     LOGI << std::format("Attempting to add access point {} to manager", interfaceName);
+    AUDIT_LOGD << std::format("Attempting to add access point {} to manager", interfaceName);
 
     {
         auto accessPointController = accessPoint->CreateController();
@@ -60,6 +62,7 @@ AccessPointManager::AddAccessPoint(std::shared_ptr<IAccessPoint> accessPoint)
     }
 
     LOGI << std::format("Adding access point {} to manager", interfaceName);
+    AUDIT_LOGI << std::format("Adding access point {} to manager", interfaceName);
 
     m_accessPoints.push_back(std::move(accessPoint));
 }
@@ -69,6 +72,7 @@ AccessPointManager::RemoveAccessPoint(std::shared_ptr<IAccessPoint> accessPoint)
 {
     const auto interfaceName{ accessPoint->GetInterfaceName() };
     LOGI << std::format("Attempting to remove access point {} from manager", interfaceName);
+    AUDIT_LOGD << std::format("Attempting to remove access point {} from manager", interfaceName);
 
     const auto accessPointsLock = std::scoped_lock{ m_accessPointGate };
     const auto accessPointToRemove = std::ranges::find_if(m_accessPoints, [&](const auto& accessPointExisting) {
@@ -81,6 +85,7 @@ AccessPointManager::RemoveAccessPoint(std::shared_ptr<IAccessPoint> accessPoint)
     }
 
     LOGI << std::format("Removing access point {} from manager", interfaceName);
+    AUDIT_LOGI << std::format("Removing access point {} from manager", interfaceName);
 
     m_accessPoints.erase(accessPointToRemove);
 }

--- a/src/common/net/wifi/apmanager/CMakeLists.txt
+++ b/src/common/net/wifi/apmanager/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(wifi-apmanager
         plog::plog
     PUBLIC
         ${PROJECT_NAME}-protocol
+        logging-utils
         wifi-core
 )
 

--- a/src/linux/net/wifi/wpa-controller/CMakeLists.txt
+++ b/src/linux/net/wifi/wpa-controller/CMakeLists.txt
@@ -57,6 +57,7 @@ target_sources(wpa-controller
 target_link_libraries(wpa-controller
     PUBLIC
         libwpa-client
+        logging-utils
         notstd
         wifi-core
     PRIVATE

--- a/src/linux/net/wifi/wpa-controller/Hostapd.cxx
+++ b/src/linux/net/wifi/wpa-controller/Hostapd.cxx
@@ -21,6 +21,7 @@
 #include <Wpa/WpaCore.hxx>
 #include <Wpa/WpaResponseGetConfig.hxx>
 #include <Wpa/WpaResponseStatus.hxx>
+#include <logging/LogUtils.hxx>
 #include <magic_enum.hpp>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <plog/Log.h>
@@ -553,4 +554,5 @@ Hostapd::OnWpaEvent(WpaEventSender* sender, const WpaEventArgs* eventArgs)
 {
     const auto& event{ eventArgs->Event };
     LOGD << std::format("> [{}-Event|{}|{}|Sender={:#08x}] {}", magic_enum::enum_name(event.Source), magic_enum::enum_name(event.LogLevel), eventArgs->Timestamp, reinterpret_cast<uintptr_t>(sender), event.Payload);
+    AUDIT_LOGI << std::format("> [{}-Event|{}|{}|Sender={:#08x}] {}", magic_enum::enum_name(event.Source), magic_enum::enum_name(event.LogLevel), eventArgs->Timestamp, reinterpret_cast<uintptr_t>(sender), event.Payload);
 }

--- a/src/linux/net/wifi/wpa-controller/Hostapd.cxx
+++ b/src/linux/net/wifi/wpa-controller/Hostapd.cxx
@@ -554,5 +554,5 @@ Hostapd::OnWpaEvent(WpaEventSender* sender, const WpaEventArgs* eventArgs)
 {
     const auto& event{ eventArgs->Event };
     LOGD << std::format("> [{}-Event|{}|{}|Sender={:#08x}] {}", magic_enum::enum_name(event.Source), magic_enum::enum_name(event.LogLevel), eventArgs->Timestamp, reinterpret_cast<uintptr_t>(sender), event.Payload);
-    AUDIT_LOGI << std::format("> [{}-Event|{}|{}|Sender={:#08x}] {}", magic_enum::enum_name(event.Source), magic_enum::enum_name(event.LogLevel), eventArgs->Timestamp, reinterpret_cast<uintptr_t>(sender), event.Payload);
+    AUDITI << std::format("> [{}-Event|{}|{}|Sender={:#08x}] {}", magic_enum::enum_name(event.Source), magic_enum::enum_name(event.LogLevel), eventArgs->Timestamp, reinterpret_cast<uintptr_t>(sender), event.Payload);
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

This PR adds additional logging to the audit log, specifically for events. This includes WPA events from `Hostapd::OnWpaEvent` and AP manager events from `AccessPointManager::AddAccessPoint` and `AccessPointManager::RemoveAccessPoint`.

### Technical Details

* Added additional `AUDIT_LOG*` lines for events.

### Test Results

TBD

### Reviewer Focus

Are there any other places where it would be useful to log stuff to the audit log?

### Future Work

None.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
