### PR TITLE
Fix regression in abseil dependency

### DIFF
--- a/packaging/vcpkg/ports/abseil/0001-Mark-absl_cc_library-target-as-test-only.patch
+++ b/packaging/vcpkg/ports/abseil/0001-Mark-absl_cc_library-target-as-test-only.patch
@@ -1,0 +1,24 @@
+From ccb2f752f6ba4f90eda8931de78c9d8535286602 Mon Sep 17 00:00:00 2001
+From: Andrew Beltrano <abeltrano@gmail.com>
+Date: Tue, 16 Jul 2024 13:36:58 -0600
+Subject: [PATCH 1/1] Mark absl_cc_library target as test-only.
+
+---
+ absl/container/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/absl/container/CMakeLists.txt b/absl/container/CMakeLists.txt
+index 128cc0e9..11d65d55 100644
+--- a/absl/container/CMakeLists.txt
++++ b/absl/container/CMakeLists.txt
+@@ -213,6 +213,7 @@ absl_cc_library(
+   DEPS
+     absl::config
+     GTest::gmock
++  TESTONLY
+ )
+ 
+ absl_cc_test(
+-- 
+2.43.0
+

--- a/packaging/vcpkg/ports/abseil/portfile.cmake
+++ b/packaging/vcpkg/ports/abseil/portfile.cmake
@@ -1,0 +1,60 @@
+if (NOT VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO abseil/abseil-cpp
+    REF "${VERSION}"
+    SHA512 41504899ac4fd4a6eaa0a5fdf27a7765ec81962fb99b6a07982ceed32c5289e9eb12206c83a70fd44c5c3e1b96c2bfa160eb12f1dbbb45f1109d632c7690de90
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        cxx17 ABSL_USE_CXX17
+)
+
+# With ABSL_PROPAGATE_CXX_STD=ON abseil automatically detect if it is being
+# compiled with C++14 or C++17, and modifies the installed `absl/base/options.h`
+# header accordingly. This works even if CMAKE_CXX_STANDARD is not set. Abseil
+# uses the compiler default behavior to update `absl/base/options.h` as needed.
+if (ABSL_USE_CXX17)
+    set(ABSL_USE_CXX17_OPTION "-DCMAKE_CXX_STANDARD=17")
+endif ()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS 
+        -DABSL_PROPAGATE_CXX_STD=ON 
+        -DABSL_BUILD_TESTING=OFF
+        -DBUILD_TESTING=OFF
+        ${ABSL_USE_CXX17_OPTION}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME absl CONFIG_PATH lib/cmake/absl)
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/include/absl/copts"
+                    "${CURRENT_PACKAGES_DIR}/include/absl/strings/testdata"
+                    "${CURRENT_PACKAGES_DIR}/include/absl/time/internal/cctz/testdata"
+)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(GLOB_RECURSE headers "${CURRENT_PACKAGES_DIR}/include/absl/*.h")
+    foreach(header IN LISTS ${headers})
+        vcpkg_replace_string("${header}"
+            "!defined(ABSL_CONSUME_DLL)" "0"
+        )
+        vcpkg_replace_string("${header}"
+            "defined(ABSL_CONSUME_DLL)" "1"
+        )
+    endforeach()
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packaging/vcpkg/ports/abseil/portfile.cmake
+++ b/packaging/vcpkg/ports/abseil/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 41504899ac4fd4a6eaa0a5fdf27a7765ec81962fb99b6a07982ceed32c5289e9eb12206c83a70fd44c5c3e1b96c2bfa160eb12f1dbbb45f1109d632c7690de90
     HEAD_REF master
+    PATCHES
+        0001-Mark-absl_cc_library-target-as-test-only.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -28,8 +30,6 @@ vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
         -DABSL_PROPAGATE_CXX_STD=ON 
-        -DABSL_BUILD_TESTING=OFF
-        -DBUILD_TESTING=OFF
         ${ABSL_USE_CXX17_OPTION}
 )
 

--- a/packaging/vcpkg/ports/abseil/vcpkg.json
+++ b/packaging/vcpkg/ports/abseil/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "abseil",
+  "version": "20240116.1",
+  "port-version": 1,
+  "description": [
+    "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
+    "In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.",
+    "Abseil is not meant to be a competitor to the standard library; we've just found that many of these utilities serve a purpose within our code base, and we now want to provide those resources to the C++ community as a whole."
+  ],
+  "homepage": "https://github.com/abseil/abseil-cpp",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "cxx17": {
+      "description": "Enable compiler C++17."
+    }
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -36,6 +36,11 @@
       "version": "2.3.1"
     }
   ],
+  "vcpkg-configuration": {
+    "overlay-ports": [
+      "packaging/vcpkg/ports/abseil"
+    ]
+  },
   "features": {
     "protocol": {
       "description": "Enable building the client protocol",


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the GitHub CI/CD build succeeds.

### Technical Details

The most recent version(s) of `abseil`, depended on by `grpc` and `protobuf`, introduced a regression where changes to its tests caused `gtest` became a hard dependency without adding corresponding CMake changes to locate the library.

* Fix this by adding a vcpkg overlay port for abseil, and modify the latest version to include a manually written patch that makes the erroneous test target a test-only target.

### Test Results

* GitHub build validation CI/CD workflow now passes.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
