### PR TITLE
Add explicit CMake presets for Ubuntu 23.10 and update default presets to target Ubuntu 24.04

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -63,6 +63,24 @@
             }
         },
         {
+            "name": "linux-ubuntu-23.10",
+            "hidden": true,
+            "description": "Base options for Ubuntu 23.10 (mantic) builds",
+            "inherits": [
+                "linux",
+                "linux-toolchain-llvm-17"
+            ]
+        },
+        {
+            "name": "linux-ubuntu-24.04",
+            "hidden": true,
+            "description": "Base options for Ubuntu 24.04 (noble) builds",
+            "inherits": [
+                "linux",
+                "linux-toolchain-llvm-18"
+            ]
+        },
+        {
             "name": "linux-toolchain-default",
             "hidden": true,
             "description": "Default toolchain to use for Linux builds",
@@ -201,17 +219,33 @@
             ]
         },
         {
-            "name": "dev-linux",
-            "displayName": "Development",
-            "description": "Development inner-loop on Linux",
+            "name": "dev-linux-common",
+            "hidden": true,
+            "description": "Common options for development inner-loop on Linux",
             "inherits": [
                 "dev",
                 "linux",
-                "linux-toolchain-default",
                 "packaging-linux-dev"
             ]
         },
-
+        {
+            "name": "dev-linux",
+            "displayName": "Development (Ubuntu 24.04 noble)",
+            "description": "Development inner-loop on Ubuntu 24.04 (noble)",
+            "inherits": [
+                "dev-linux-common",
+                "linux-ubuntu-24.04"
+            ]
+        },
+        {
+            "name": "dev-linux-ubuntu-23.10",
+            "displayName": "Development (Ubuntu 23.10 mantic)",
+            "description": "Development inner-loop on Ubuntu 23.10 (mantic)",
+            "inherits": [
+                "dev-linux-common",
+                "linux-ubuntu-23.10"
+            ]
+        },
         {
             "name": "dev-windows",
             "displayName": "Development",
@@ -242,18 +276,35 @@
             ]
         },
         {
-            "name": "release-linux",
-            "displayName": "Release",
-            "description": "Release for Linux",
+            "name": "release-linux-common",
+            "hidden": true,
+            "description": "Common options for release on Linux",
             "inherits": [
                 "release",
                 "linux",
-                "linux-toolchain-default",
                 "packaging-linux-release"
+            ]
+        },
+        {
+            "name": "release-linux",
+            "displayName": "Release (Ubuntu 24.04 noble)",
+            "description": "Release for Ubuntu 24.04 (noble)",
+            "inherits": [
+                "release-linux-common",
+                "linux-ubuntu-24.04"
             ],
             "cacheVariables": {
                 "CMAKE_INSTALL_PREFIX": "/usr/local"
             }
+        },
+        {
+            "name": "release-linux-ubuntu-23.10",
+            "displayName": "Release (Ubuntu 23.10 mantic)",
+            "description": "Release for Ubuntu 23.10 (mantic)",
+            "inherits": [
+                "release-linux-common",
+                "linux-ubuntu-23.10"
+            ]
         },
         {
             "name": "release-windows",
@@ -374,8 +425,17 @@
         {
             "name": "build-dev-linux",
             "displayName": "Development",
-            "description": "Build the project for development on Linux",
+            "description": "Build the project for development on Ubuntu 24.04 (noble)",
             "configurePreset": "dev-linux",
+            "inherits": [
+                "build-dev"
+            ]
+        },
+        {
+            "name": "build-dev-linux-ubuntu-23.10",
+            "displayName": "Development (Ubuntu 23.10 mantic)",
+            "description": "Build the project for development on Ubuntu 23.10 (mantic)",
+            "configurePreset": "dev-linux-ubuntu-23.10",
             "inherits": [
                 "build-dev"
             ]
@@ -403,6 +463,15 @@
             "displayName": "Release",
             "description": "Build the project for release on Linux",
             "configurePreset": "release-linux",
+            "inherits": [
+                "build-release"
+            ]
+        },
+        {
+            "name": "build-release-linux-ubuntu-23.10",
+            "displayName": "Release (Ubuntu 23.10 mantic)",
+            "description": "Build the project for release on Ubuntu 23.10 (mantic)",
+            "configurePreset": "release-linux-ubuntu-23.10",
             "inherits": [
                 "build-release"
             ]
@@ -531,14 +600,26 @@
         {
             "name": "packaging-dev-linux",
             "displayName": "Development",
-            "description": "Development packaging for inner-loop on Linux",
+            "description": "Development packaging for inner-loop on Ubuntu 24.04 (noble)",
             "configurePreset": "dev-linux"
+        },
+        {
+            "name": "packaging-dev-linux-ubuntu-23.10",
+            "displayName": "Development (Ubuntu 23.10 mantic)",
+            "description": "Development packaging for inner-loop on Ubuntu 23.10 (mantic)",
+            "configurePreset": "dev-linux-ubuntu-23.10"
         },
         {
             "name": "packaging-release-linux",
             "displayName": "Release",
-            "description": "Release packaging for inner-loop on Linux",
+            "description": "Release packaging for inner-loop on Ubuntu 24.04 (noble)",
             "configurePreset": "release-linux"
+        },
+        {
+            "name": "packaging-release-linux-ubuntu-23.10",
+            "displayName": "Release (Ubuntu 23.10 mantic)",
+            "description": "Release packaging for inner-loop on Ubuntu 23.10 (mantic)",
+            "configurePreset": "release-linux-ubuntu-23.10"
         },
         {
             "name": "packaging-dev-windows",


### PR DESCRIPTION
## **NOTE:** 
This moves the default CMake presets to Ubuntu 24.04. You __must__ either upgrade your development environment to Ubuntu 24.04 (WSL, devcontainer, etc.), or explicitly select the newly introduced presets for Ubuntu 23.10, as shown below:

<img width="459" alt="image" src="https://github.com/user-attachments/assets/b89c596d-3ada-4874-aa25-585221d5e9da">

### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [X] Breaking change
- [ ] Non-functional change

### Goals

* Allow easy use of Ubuntu 23.10 as a development environment.
* Make Ubuntu 24.04 the target for the default configure, build, and packaging Linux CMake presets (`[dev|relase|package]-linux`).

### Technical Details

* Add new hidden CMake presets `linux-ubuntu-23.10` and `linux-ubuntu-24.04` which define common options for their respective distributions, particularly the use of LLVM 17 on 23.10 and LLVM 18 on 24.04.
* Add new hidden CMake presets `[dev|release]-linux-common` which define common options for their respective build posture (development, release).
* Transition the default OS target to Ubuntu 24.04 for the default development, release, and packaging targets.

### Test Results

* Built locally on 23.10 and validated everything worked.
* Built locally on 24.04 and validated everything worked.
* CI/CD run pending completion.

### Reviewer Focus

* None 

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
