### PR TITLE
Remove preset for default toolchain.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -81,14 +81,6 @@
             ]
         },
         {
-            "name": "linux-toolchain-default",
-            "hidden": true,
-            "description": "Default toolchain to use for Linux builds",
-            "inherits": [
-                "linux-toolchain-llvm-17"
-            ]
-        },
-        {
             "name": "out-of-source-build",
             "hidden": true,
             "displayName": "Out of source build",
@@ -146,7 +138,6 @@
             "displayName": "Packaging Linux (base)",
             "inherits": [
                 "linux",
-                "linux-toolchain-default",
                 "packaging"
             ],
             "cacheVariables": {


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure default development environment using `dev-linux` preset works.

### Technical Details

* #315 added presets but did not remove the old one for the default toolchain, which overrides the compiler from LLVM 18 to LLVM 17 on fresh CMake confitgures. Fix this by removing the default toolchain presets, which are no longer needed.

### Test Results

* Selected `dev-linux` preset from a fresh clone on noble and verified build configuration was generated.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
