### PR TITLE
Add script to automate updating version number

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+#
+# Update the version number references in the project. This currently updates the version number in the CMake version
+# script file and vcpkg.json files.
+
+set -eu -o pipefail
+
+SCRIPT_DIR="$(dirname "${0}")"
+PROJECT_ROOT="$(dirname "$(dirname "$(readlink -fm "${0}")")")"
+
+# Set constants.
+readonly SCRIPT_DIR
+readonly PROJECT_ROOT
+readonly CMAKE_SCRIPT_VERSION_FILE="${PROJECT_ROOT}/cmake/version.cmake"
+readonly VCPKG_JSON_FILES=( "${PROJECT_ROOT}/vcpkg.json" "${PROJECT_ROOT}/.docker/netremote-dev/vcpkg.json" )
+readonly VERSION_TYPES=(MAJOR MINOR PATCH)
+readonly VERSION="${1:-}"
+
+# Verify the version is provided.
+if [[ -z "${VERSION}" ]]; then
+  echo "Usage: $0 <version major>.<version minor>.<version patch>"
+  exit 1
+fi
+
+# Parse and verify the version is a valid semantic version with major, minor, and patch components.
+if ! [[ "${VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  echo "Invalid version: ${VERSION}"
+  echo "Usage: ${0} <version major>.<version minor>.<version patch>"
+  exit 1
+fi
+
+# Parse the specified version into major, minor, and patch components.
+readonly VERSION_MAJOR="${BASH_REMATCH[1]}"
+readonly VERSION_MINOR="${BASH_REMATCH[2]}"
+readonly VERSION_PATCH="${BASH_REMATCH[3]}"
+
+# Update the lines with 'set(VERSION_<MAJOR|MINOR|PATCH> <value>)' in the version.cmake file.
+printf 'Updating CMake version script file %s ... ' "${CMAKE_SCRIPT_VERSION_FILE}"
+for version_type in "${VERSION_TYPES[@]}"; do
+    VERSION_VALUE="VERSION_${version_type}"
+    sed -i "s/set(VERSION_${version_type} [0-9]\+)/set(VERSION_${version_type} ${!VERSION_VALUE})/" "${CMAKE_SCRIPT_VERSION_FILE}"
+done
+printf '\xE2\x9C\x94\n'
+
+# Update the version in the vcpkg.json files, with format "version-string": "<version>".
+echo -n "Updating version is vcpkg manifest files ... "
+for vcpkg_json_file in "${VCPKG_JSON_FILES[@]}"; do
+  sed -i "s/\"version-string\": \"[0-9]\+\.[0-9]\+\.[0-9]\+\"/\"version-string\": \"${VERSION}\"/" "${vcpkg_json_file}"
+done
+printf '\xE2\x9C\x94\n'
+
+echo "NetRemote version updated to v${VERSION}"


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Automate updating the version as used in the project repository code.

### Technical Details

* Add new script `update-version.sh` in newly added `scripts` directory which takes as an argument a semantic version string with major, minor, and patch versions, and updates the `vcpkg.json` files in the project (`./vcpkg.json`, `./docker/netremote-dev/vcpkg.json`) and the hard-coded version number in `./cmake/version.cmake`.

### Test Results

* Ran with valid version string and validated the script succeeded and all files were updated:
```bash
shadowfax@foxmulder:~/src/netremote/scripts$ ./update-version.sh 1.2.3
Updating CMake version script file /home/shadowfax/src/netremote/cmake/version.cmake ... ✔
Updating version is vcpkg manifest files ... ✔
NetRemote version updated to v1.2.3

shadowfax@foxmulder:~/src/netremote$ find . -path ./vcpkg -prune -o -name vcpkg.json -exec grep -H "version-string" {} \;
./.docker/netremote-dev/vcpkg.json:  "version-string": "1.2.3",
./vcpkg.json:  "version-string": "1.2.3",

shadowfax@foxmulder:~/src/netremote$ find . -name version.cmake -exec grep -E -H "set\(VERSION_(MAJOR|MINOR|PATCH) [0-9]+" {} \;
./cmake/version.cmake:set(VERSION_MAJOR 1)
./cmake/version.cmake:set(VERSION_MINOR 2)
./cmake/version.cmake:set(VERSION_PATCH 3)
```

* Ran with invalid version string and validated the script failed:
```bash
shadowfax@foxmulder:~/src/netremote/scripts$ ./update-version.sh 1.2.3.4
Invalid version: 1.2.3.4
Usage: ./update-version.sh <version major>.<version minor>.<version patch>

shadowfax@foxmulder:~/src/netremote$ find . -path ./vcpkg -prune -o -name vcpkg.json -exec grep -H "version-string" {} \;
./.docker/netremote-dev/vcpkg.json:  "version-string": "0.3.0",
./vcpkg.json:  "version-string": "0.3.0"

shadowfax@foxmulder:~/src/netremote$ find . -name version.cmake -exec grep -Eh -H "set\(VERSION_(MAJOR|MINOR|PATCH) [0-9]+" {} \;
./cmake/version.cmake:set(VERSION_MAJOR 0)
./cmake/version.cmake:set(VERSION_MINOR 3)
./cmake/version.cmake:set(VERSION_PATCH 0)
```

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
