### PR TITLE
Merge v0.4.0 release back to develop

### DIFF
--- a/.docker/netremote-dev/vcpkg.json
+++ b/.docker/netremote-dev/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "netremote",
-  "version-string": "0.3.0",
+  "version-string": "0.4.0",
   "dependencies": [
     {
       "name": "sdbus-cpp",

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,7 +1,7 @@
 
 # Default version values in case we can't get them from git.
 set(VERSION_MAJOR 0)
-set(VERSION_MINOR 3)
+set(VERSION_MINOR 4)
 set(VERSION_PATCH 0)
 
 if (NOT GIT_EXECUTABLE)

--- a/packaging/vcpkg/CMakeLists.txt
+++ b/packaging/vcpkg/CMakeLists.txt
@@ -4,7 +4,7 @@ set(VCPKG_PORT_FILE_OUT ${CMAKE_CURRENT_LIST_DIR}/ports/netremote/portfile.cmake
 set(VCPKG_PORT_FILE_IN ${VCPKG_PORT_FILE_OUT}.in)
 
 # Configure variables to be substituted in the vcpkg portfile.
-set(GIT_REF_HEAD main)
+set(GIT_REF_HEAD master)
 set(GIT_REF v${CMAKE_PROJECT_VERSION})
 set(GIT_REF_URL ${CMAKE_PROJECT_HOMEPAGE_URL}/archive/refs/tags/${GIT_REF}.tar.gz)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "netremote",
-  "version-string": "0.3.0",
+  "version-string": "0.4.0",
   "dependencies": [
     {
       "name": "sdbus-cpp",


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Merge v0.4.0 specific changes to development branch.

### Technical Details

* Straight-merge.

### Test Results

* None

### Reviewer Focus

* None

### Future Work

* Rename `master` branch to `main`.

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
