### PR TITLE
Rename primary branch from master to main

### DIFF
--- a/packaging/vcpkg/CMakeLists.txt
+++ b/packaging/vcpkg/CMakeLists.txt
@@ -4,7 +4,7 @@ set(VCPKG_PORT_FILE_OUT ${CMAKE_CURRENT_LIST_DIR}/ports/netremote/portfile.cmake
 set(VCPKG_PORT_FILE_IN ${VCPKG_PORT_FILE_OUT}.in)
 
 # Configure variables to be substituted in the vcpkg portfile.
-set(GIT_REF_HEAD master)
+set(GIT_REF_HEAD main)
 set(GIT_REF v${CMAKE_PROJECT_VERSION})
 set(GIT_REF_URL ${CMAKE_PROJECT_HOMEPAGE_URL}/archive/refs/tags/${GIT_REF}.tar.gz)
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [X] Breaking change
- [ ] Non-functional change

### Goals

* Use modern branch naming.

### Technical Details

* Rename primary branch from `master` to `main`.

### Test Results

* None

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
