### PR TITLE
Conditionally include vcpkg port file generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include(version)
 
 # Configure vcpkg usage within the project.
 include(vcpkg)
+option(NETREMOTE_VCPKG_BUILD_FOR_PORT "Enable building the project via a vcpkg port" OFF)
 
 # Add options for vcpkg port file features.
 option(NETREMOTE_EXCLUDE_PROTOCOL "Disable building the protocol" OFF)

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -1,5 +1,7 @@
 
-add_subdirectory(vcpkg)
+if (NOT NETREMOTE_VCPKG_BUILD_FOR_PORT)
+  add_subdirectory(vcpkg)
+endif()
 
 if (BUILD_FOR_LINUX)
   add_subdirectory(deb)

--- a/packaging/vcpkg/ports/netremote/portfile.cmake.in
+++ b/packaging/vcpkg/ports/netremote/portfile.cmake.in
@@ -28,6 +28,7 @@ vcpkg_check_features(
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
+        -DNETREMOTE_VCPKG_BUILD_FOR_PORT=ON
         ${FEATURE_OPTIONS}
 )
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Avoid calling external processes when building the project as a vcpkg port.

### Technical Details

* Conditionally include `vcpkg` packaging directory in CMake execution by restoring the previously removed `NETREMOTE_BUILD_FOR_VCPKG_PORT` variable.

### Test Results

* Built with and without `NETREMOTE_VCPKG_BUILD_FOR_PORT` defined and verified the port file was and was not generated, respectively.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
