### PR TITLE
Release v0.4.1

### DIFF
--- a/.docker/netremote-dev/vcpkg.json
+++ b/.docker/netremote-dev/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "netremote",
-  "version-string": "0.4.0",
+  "version-string": "0.4.1",
   "dependencies": [
     {
       "name": "sdbus-cpp",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include(version)
 
 # Configure vcpkg usage within the project.
 include(vcpkg)
+option(NETREMOTE_VCPKG_BUILD_FOR_PORT "Enable building the project via a vcpkg port" OFF)
 
 # Add options for vcpkg port file features.
 option(NETREMOTE_EXCLUDE_PROTOCOL "Disable building the protocol" OFF)

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -2,7 +2,7 @@
 # Default version values in case we can't get them from git.
 set(VERSION_MAJOR 0)
 set(VERSION_MINOR 4)
-set(VERSION_PATCH 0)
+set(VERSION_PATCH 1)
 
 if (NOT GIT_EXECUTABLE)
   message(WARNING "Git not found; falling back to hard-coded version")

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -1,5 +1,7 @@
 
-add_subdirectory(vcpkg)
+if (NOT NETREMOTE_VCPKG_BUILD_FOR_PORT)
+  add_subdirectory(vcpkg)
+endif()
 
 if (BUILD_FOR_LINUX)
   add_subdirectory(deb)

--- a/packaging/vcpkg/CMakeLists.txt
+++ b/packaging/vcpkg/CMakeLists.txt
@@ -4,7 +4,7 @@ set(VCPKG_PORT_FILE_OUT ${CMAKE_CURRENT_LIST_DIR}/ports/netremote/portfile.cmake
 set(VCPKG_PORT_FILE_IN ${VCPKG_PORT_FILE_OUT}.in)
 
 # Configure variables to be substituted in the vcpkg portfile.
-set(GIT_REF_HEAD master)
+set(GIT_REF_HEAD main)
 set(GIT_REF v${CMAKE_PROJECT_VERSION})
 set(GIT_REF_URL ${CMAKE_PROJECT_HOMEPAGE_URL}/archive/refs/tags/${GIT_REF}.tar.gz)
 

--- a/packaging/vcpkg/ports/netremote/portfile.cmake.in
+++ b/packaging/vcpkg/ports/netremote/portfile.cmake.in
@@ -28,6 +28,7 @@ vcpkg_check_features(
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
+        -DNETREMOTE_VCPKG_BUILD_FOR_PORT=ON
         ${FEATURE_OPTIONS}
 )
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "netremote",
-  "version-string": "0.4.0",
+  "version-string": "0.4.1",
   "dependencies": [
     {
       "name": "sdbus-cpp",


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Release v0.4.1.

### Technical Details

* Incorporate conditional inclusion of netremote port generation.

### Test Results

* All unit tests pass on both Linux and Windows.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
