### PR TITLE
Add nlohmann json dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ find_package(Threads REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 find_package(CLI11 CONFIG REQUIRED)
 find_package(plog CONFIG REQUIRED)
+find_package(nlohmann_json CONFIG REQUIRED)
 
 # Include toolchain-specific configuration. 
 include(toolchain-config)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -28,7 +28,8 @@
     "grpc",
     "magic-enum",
     "plog",
-    "protobuf"
+    "protobuf",
+    "nlohmann-json"
   ],
   "overrides": [
     {


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Enable ability to process json.

### Technical Details

* Add nlohmann-json vcpkg as a dependency.

### Test Results

* Build tested on Linux.
 
### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [X] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
