### PR TITLE
Add WifiAccessPointGetAttributes API

### DIFF
--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -20,5 +20,5 @@ service NetRemote
     rpc WifiAccessPointSetSsid (Microsoft.Net.Remote.Wifi.WifiAccessPointSetSsidRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetSsidResult);
     rpc WifiAccessPointSetNetworkBridge (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeResult);
     rpc WifiAccessPointSetAuthenticationDot1x (Microsoft.Net.Remote.Wifi.WifiAccessPointSetAuthenticationDot1xRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetAuthenticationDot1xResult);
-    rpc WifiAccessPointGetProperties (Microsoft.Net.Remote.Wifi.WifiAccessPointGetPropertiesRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointGetPropertiesResult);
+    rpc WifiAccessPointGetAttributes (Microsoft.Net.Remote.Wifi.WifiAccessPointGetAttributesRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointGetAttributesResult);
 }

--- a/protocol/protos/NetRemoteService.proto
+++ b/protocol/protos/NetRemoteService.proto
@@ -20,4 +20,5 @@ service NetRemote
     rpc WifiAccessPointSetSsid (Microsoft.Net.Remote.Wifi.WifiAccessPointSetSsidRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetSsidResult);
     rpc WifiAccessPointSetNetworkBridge (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetNetworkBridgeResult);
     rpc WifiAccessPointSetAuthenticationDot1x (Microsoft.Net.Remote.Wifi.WifiAccessPointSetAuthenticationDot1xRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointSetAuthenticationDot1xResult);
+    rpc WifiAccessPointGetProperties (Microsoft.Net.Remote.Wifi.WifiAccessPointGetPropertiesRequest) returns (Microsoft.Net.Remote.Wifi.WifiAccessPointGetPropertiesResult);
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -125,14 +125,14 @@ message WifiAccessPointSetAuthenticationDot1xResult
     WifiAccessPointOperationStatus Status = 2;
 }
 
-message WifiAccessPointGetPropertiesRequest
+message WifiAccessPointGetAttributesRequest
 {
     string AccessPointId = 1;
 }
 
-message WifiAccessPointGetPropertiesResult
+message WifiAccessPointGetAttributesResult
 {
     string AccessPointId = 1;
     WifiAccessPointOperationStatus Status = 2;
-    repeated string Properties = 3;
+    Microsoft.Net.Wifi.Dot11AccessPointAttributes Attributes = 3;
 }

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -124,3 +124,14 @@ message WifiAccessPointSetAuthenticationDot1xResult
     string AccessPointId = 1;
     WifiAccessPointOperationStatus Status = 2;
 }
+
+message WifiAccessPointGetPropertiesRequest
+{
+    string AccessPointId = 1;
+}
+
+message WifiAccessPointGetPropertiesResult
+{
+    string AccessPointId = 1;
+    repeated string Properties = 2;
+}

--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -133,5 +133,6 @@ message WifiAccessPointGetPropertiesRequest
 message WifiAccessPointGetPropertiesResult
 {
     string AccessPointId = 1;
-    repeated string Properties = 2;
+    WifiAccessPointOperationStatus Status = 2;
+    repeated string Properties = 3;
 }

--- a/protocol/protos/WifiCore.proto
+++ b/protocol/protos/WifiCore.proto
@@ -224,6 +224,11 @@ message Dot11AccessPointCapabilities
     repeated Microsoft.Net.Wifi.Dot11AkmSuite AkmSuites = 5;
 }
 
+message Dot11AccessPointAttributes
+{
+    map<string, string> Properties = 1;
+}
+
 enum Dot11AccessPointState
 {
     AccessPointStateUnknown = 0;

--- a/src/common/net/wifi/core/AccessPoint.cxx
+++ b/src/common/net/wifi/core/AccessPoint.cxx
@@ -30,7 +30,7 @@ AccessPoint::GetMacAddress() const noexcept
     return m_macAddress.value_or(Ieee80211MacAddress{});
 }
 
-AccessPointProperties
+const AccessPointProperties&
 AccessPoint::GetProperties() const noexcept
 {
     return m_properties;

--- a/src/common/net/wifi/core/AccessPoint.cxx
+++ b/src/common/net/wifi/core/AccessPoint.cxx
@@ -29,6 +29,12 @@ AccessPoint::GetMacAddress() const noexcept
     return m_macAddress.value_or(Ieee80211MacAddress{});
 }
 
+AccessPointProperties
+AccessPoint::GetProperties() const noexcept
+{
+    return m_properties;
+}
+
 std::unique_ptr<IAccessPointController>
 AccessPoint::CreateController()
 {

--- a/src/common/net/wifi/core/AccessPoint.cxx
+++ b/src/common/net/wifi/core/AccessPoint.cxx
@@ -11,10 +11,10 @@
 
 using namespace Microsoft::Net::Wifi;
 
-AccessPoint::AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, AccessPointProperties properties, std::optional<Ieee80211MacAddress> macAddress) :
+AccessPoint::AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, AccessPointAttributes attributes, std::optional<Ieee80211MacAddress> macAddress) :
     m_interfaceName(interfaceName),
     m_accessPointControllerFactory(std::move(accessPointControllerFactory)),
-    m_properties(std::move(properties)),
+    m_attributes(std::move(attributes)),
     m_macAddress(macAddress)
 {}
 
@@ -30,10 +30,10 @@ AccessPoint::GetMacAddress() const noexcept
     return m_macAddress.value_or(Ieee80211MacAddress{});
 }
 
-const AccessPointProperties&
-AccessPoint::GetProperties() const noexcept
+const AccessPointAttributes&
+AccessPoint::GetAttributes() const noexcept
 {
-    return m_properties;
+    return m_attributes;
 }
 
 std::unique_ptr<IAccessPointController>

--- a/src/common/net/wifi/core/AccessPoint.cxx
+++ b/src/common/net/wifi/core/AccessPoint.cxx
@@ -11,9 +11,10 @@
 
 using namespace Microsoft::Net::Wifi;
 
-AccessPoint::AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, std::optional<Ieee80211MacAddress> macAddress) :
+AccessPoint::AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, AccessPointProperties properties, std::optional<Ieee80211MacAddress> macAddress) :
     m_interfaceName(interfaceName),
     m_accessPointControllerFactory(std::move(accessPointControllerFactory)),
+    m_properties(std::move(properties)),
     m_macAddress(macAddress)
 {}
 

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
@@ -48,9 +48,9 @@ struct AccessPoint :
     /**
      * @brief Get the static properties of an access point.
      *
-     * @return AccessPointProperties
+     * @return AccessPointProperties&
      */
-    AccessPointProperties
+    const AccessPointProperties&
     GetProperties() const noexcept override;
 
     /**

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
@@ -24,10 +24,10 @@ struct AccessPoint :
      *
      * @param interfaceName The network interface name representing the access point.
      * @param accessPointControllerFactory The factory used to create controller objects.
-     * @param properties The static properties of the access point.
+     * @param attributes The static attributes of the access point.
      * @param macAddress The mac address of the access point.
      */
-    AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, AccessPointProperties properties = {}, std::optional<Ieee80211MacAddress> macAddress = std::nullopt);
+    AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, AccessPointAttributes attributes = {}, std::optional<Ieee80211MacAddress> macAddress = std::nullopt);
 
     /**
      * @brief Get the network interface name representing the access point.
@@ -46,12 +46,12 @@ struct AccessPoint :
     GetMacAddress() const noexcept override;
 
     /**
-     * @brief Get the static properties of an access point.
+     * @brief Get the static attributes of an access point.
      *
-     * @return AccessPointProperties&
+     * @return AccessPointAttributes&
      */
-    const AccessPointProperties&
-    GetProperties() const noexcept override;
+    const AccessPointAttributes&
+    GetAttributes() const noexcept override;
 
     /**
      * @brief Create a controller object.
@@ -64,7 +64,7 @@ struct AccessPoint :
 private:
     const std::string m_interfaceName;
     std::shared_ptr<IAccessPointControllerFactory> m_accessPointControllerFactory;
-    AccessPointProperties m_properties{};
+    AccessPointAttributes m_attributes{};
     std::optional<Ieee80211MacAddress> m_macAddress;
 };
 

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
@@ -44,6 +44,14 @@ struct AccessPoint :
     GetMacAddress() const noexcept override;
 
     /**
+     * @brief Get the static properties of an access point.
+     *
+     * @return AccessPointProperties
+     */
+    AccessPointProperties
+    GetProperties() const noexcept override;
+
+    /**
      * @brief Create a controller object.
      *
      * @return std::unique_ptr<Microsoft::Net::Wifi::IAccessPointController>
@@ -55,6 +63,7 @@ private:
     const std::string m_interfaceName;
     std::shared_ptr<IAccessPointControllerFactory> m_accessPointControllerFactory;
     std::optional<Ieee80211MacAddress> m_macAddress;
+    AccessPointProperties m_properties{};
 };
 
 /**

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPoint.hxx
@@ -24,8 +24,10 @@ struct AccessPoint :
      *
      * @param interfaceName The network interface name representing the access point.
      * @param accessPointControllerFactory The factory used to create controller objects.
+     * @param properties The static properties of the access point.
+     * @param macAddress The mac address of the access point.
      */
-    AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, std::optional<Ieee80211MacAddress> macAddress = std::nullopt);
+    AccessPoint(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, AccessPointProperties properties = {}, std::optional<Ieee80211MacAddress> macAddress = std::nullopt);
 
     /**
      * @brief Get the network interface name representing the access point.
@@ -62,8 +64,8 @@ struct AccessPoint :
 private:
     const std::string m_interfaceName;
     std::shared_ptr<IAccessPointControllerFactory> m_accessPointControllerFactory;
-    std::optional<Ieee80211MacAddress> m_macAddress;
     AccessPointProperties m_properties{};
+    std::optional<Ieee80211MacAddress> m_macAddress;
 };
 
 /**

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
@@ -63,9 +63,9 @@ struct IAccessPoint
     /**
      * @brief Get the static properties of an access point.
      *
-     * @return AccessPointProperties
+     * @return AccessPointProperties&
      */
-    virtual AccessPointProperties
+    virtual const AccessPointProperties&
     GetProperties() const noexcept = 0;
 
     /**

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
@@ -10,6 +10,15 @@
 
 namespace Microsoft::Net::Wifi
 {
+
+/**
+ * @brief Container to hold static properties about an access point.
+ */
+struct AccessPointProperties
+{
+    // TODO: add properties here
+};
+
 /**
  * @brief Represents a wireless access point.
  */
@@ -50,6 +59,14 @@ struct IAccessPoint
      */
     virtual Ieee80211MacAddress
     GetMacAddress() const noexcept = 0;
+
+    /**
+     * @brief Get the static properties of an access point.
+     *
+     * @return AccessPointProperties
+     */
+    virtual AccessPointProperties
+    GetProperties() const noexcept = 0;
 
     /**
      * @brief Create a new instance that can control the access point.

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
@@ -16,7 +16,7 @@ namespace Microsoft::Net::Wifi
  */
 struct AccessPointProperties
 {
-    // TODO: add properties here
+    std::vector<std::string> Properties{};
 };
 
 /**

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string_view>
+#include <unordered_map>
 
 #include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
@@ -12,11 +13,11 @@ namespace Microsoft::Net::Wifi
 {
 
 /**
- * @brief Container to hold static properties about an access point.
+ * @brief Container to hold static attributes about an access point.
  */
-struct AccessPointProperties
+struct AccessPointAttributes
 {
-    std::vector<std::string> Properties{};
+    std::unordered_map<std::string, std::string> Properties{};
 };
 
 /**
@@ -61,12 +62,12 @@ struct IAccessPoint
     GetMacAddress() const noexcept = 0;
 
     /**
-     * @brief Get the static properties of an access point.
+     * @brief Get the static attributes of an access point.
      *
-     * @return AccessPointProperties&
+     * @return AccessPointAttributes&
      */
-    virtual const AccessPointProperties&
-    GetProperties() const noexcept = 0;
+    virtual const AccessPointAttributes&
+    GetAttributes() const noexcept = 0;
 
     /**
      * @brief Create a new instance that can control the access point.
@@ -99,7 +100,7 @@ struct IAccessPointCreateArgs
     IAccessPointCreateArgs&
     operator=(IAccessPointCreateArgs&&) = delete;
 
-    AccessPointProperties Properties{};
+    AccessPointAttributes Attributes{};
 };
 
 /**

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
@@ -98,6 +98,8 @@ struct IAccessPointCreateArgs
 
     IAccessPointCreateArgs&
     operator=(IAccessPointCreateArgs&&) = delete;
+
+    AccessPointProperties Properties{};
 };
 
 /**

--- a/src/common/net/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
+++ b/src/common/net/wifi/dot11/adapter/Ieee80211Dot11Adapters.cxx
@@ -835,15 +835,41 @@ FromDot11AuthenticationDot1x(const Dot11AuthenticationDot1x& Dot11Authentication
 Dot11AuthenticationDot1x
 ToDot11AuthenticationDot1x(const Ieee80211Authentication8021x& ieee8021xAuthentication) noexcept
 {
-    Dot11AuthenticationDot1x Dot11AuthenticationDot1x{};
+    Dot11AuthenticationDot1x dot11AuthenticationDot1x{};
 
     // Convert RADIUS configuration, if present.
     if (ieee8021xAuthentication.Radius.has_value()) {
         auto dot1xRadiusConfiguration = ToServiceDot1xRadiusConfiguration(ieee8021xAuthentication.Radius.value());
-        *Dot11AuthenticationDot1x.mutable_radius() = std::move(dot1xRadiusConfiguration);
+        *dot11AuthenticationDot1x.mutable_radius() = std::move(dot1xRadiusConfiguration);
     }
 
-    return Dot11AuthenticationDot1x;
+    return dot11AuthenticationDot1x;
+}
+
+AccessPointAttributes
+FromDot11AccessPointAttributes(const Dot11AccessPointAttributes& dot11AccessPointConfiguration) noexcept
+{
+    AccessPointAttributes accessPointAttributes{};
+
+    accessPointAttributes.Properties = {
+        std::cbegin(dot11AccessPointConfiguration.properties()),
+        std::cend(dot11AccessPointConfiguration.properties()),
+    };
+
+    return accessPointAttributes;
+}
+
+Dot11AccessPointAttributes
+ToDot11AccessPointAttributes(const AccessPointAttributes& accessPointAttributes) noexcept
+{
+    Dot11AccessPointAttributes dot11AccessPointAttributes{};
+
+    *dot11AccessPointAttributes.mutable_properties() = {
+        std::make_move_iterator(std::begin(accessPointAttributes.Properties)),
+        std::make_move_iterator(std::end(accessPointAttributes.Properties)),
+    };
+
+    return dot11AccessPointAttributes;
 }
 
 } // namespace Microsoft::Net::Wifi

--- a/src/common/net/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
+++ b/src/common/net/wifi/dot11/adapter/include/microsoft/net/wifi/Ieee80211Dot11Adapters.hxx
@@ -9,6 +9,7 @@
 #include <microsoft/net/remote/protocol/Network8021x.pb.h>
 #include <microsoft/net/remote/protocol/WifiCore.pb.h>
 #include <microsoft/net/wifi/AccessPointOperationStatus.hxx>
+#include <microsoft/net/wifi/IAccessPoint.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 #include <microsoft/net/wifi/Ieee80211AccessPointCapabilities.hxx>
 #include <microsoft/net/wifi/Ieee80211Authentication.hxx>
@@ -360,21 +361,39 @@ ToDot11AuthenticationData(const Ieee80211AuthenticationData& ieee80211Authentica
 
 /**
  * @brief Convert the specified Dot11AuthenticationDot1x to the equivalent IEEE 802.1x authentication.
- * 
+ *
  * @param dot11AuthenticationDot1x The Dot11AuthenticationDot1x to convert.
- * @return Ieee80211Authentication8021x 
+ * @return Ieee80211Authentication8021x
  */
 Ieee80211Authentication8021x
 FromDot11AuthenticationDot1x(const Dot11AuthenticationDot1x& dot11AuthenticationDot1x) noexcept;
 
 /**
  * @brief Convert the specified IEEE 802.1x authentication to the equivalent Dot11AuthenticationDot1x.
- * 
+ *
  * @param ieee8021xAuthentication The IEEE 802.1x authentication to convert.
- * @return Dot11AuthenticationDot1x 
+ * @return Dot11AuthenticationDot1x
  */
 Dot11AuthenticationDot1x
 ToDot11AuthenticationDot1x(const Ieee80211Authentication8021x& ieee8021xAuthentication) noexcept;
+
+/**
+ * @brief Convert the specified Dot11AccessPointAttributes to the equivalent neutral type access point attributes.
+ *
+ * @param dot11AccessPointConfiguration The Dot11AccessPointAttributes to convert.
+ * @return AccessPointAttributes
+ */
+AccessPointAttributes
+FromDot11AccessPointAttributes(const Dot11AccessPointAttributes& dot11AccessPointConfiguration) noexcept;
+
+/**
+ * @brief Convert the specified neutral type access point attributes to the equivalent Dot11AccessPointAttributes.
+ *
+ * @param accessPointAttributes The IEEE 802.11 access point configuration to convert.
+ * @return Dot11AccessPointAttributes
+ */
+Dot11AccessPointAttributes
+ToDot11AccessPointAttributes(const AccessPointAttributes& accessPointAttributes) noexcept;
 
 } // namespace Microsoft::Net::Wifi
 

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -427,6 +427,8 @@ NetRemoteService::WifiAccessPointGetProperties([[maybe_unused]] grpc::ServerCont
     const NetRemoteWifiApiTrace traceMe{ request->accesspointid(), result->mutable_status() };
     const auto accessPointId{ request->accesspointid() };
 
+    *result->mutable_accesspointid() = accessPointId;
+
     // Obtain the access point specified in the request.
     std::shared_ptr<IAccessPoint> accessPoint{};
     auto operationStatus = TryGetAccessPoint(accessPointId, accessPoint);

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -420,6 +420,15 @@ NetRemoteService::WifiAccessPointSetAuthenticationDot1x([[maybe_unused]] grpc::S
     return grpc::Status::OK;
 }
 
+::grpc::Status
+NetRemoteService::WifiAccessPointGetProperties(grpc::ServerContext* context, const WifiAccessPointGetPropertiesRequest* request, WifiAccessPointGetPropertiesResult* result)
+{
+    AccessPointOperationStatus operationStatus{ request->accesspointid() };
+    const NetRemoteWifiApiTrace traceMe{ request->accesspointid(), result->mutable_status() };
+
+    return grpc::Status::OK;
+}
+
 AccessPointOperationStatus
 NetRemoteService::TryGetAccessPoint(std::string_view accessPointId, std::shared_ptr<IAccessPoint>& accessPoint)
 {

--- a/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
@@ -6,7 +6,7 @@
 #include <string>
 #include <string_view>
 
-#include <google/protobuf/repeated_ptr_field.h>
+#include <google/protobuf/map.h>
 #include <grpcpp/server_context.h>
 #include <grpcpp/support/status.h>
 #include <microsoft/net/NetworkManager.hxx>
@@ -157,7 +157,7 @@ private:
      * @return ::grpc::Status
      */
     ::grpc::Status
-    WifiAccessPointGetProperties(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointGetPropertiesRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointGetPropertiesResult* result) override;
+    WifiAccessPointGetAttributes(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointGetAttributesRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointGetAttributesResult* result) override;
 
 protected:
     /**
@@ -317,14 +317,14 @@ protected:
     WifiAccessPointSetAuthenticationDot1xImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11AuthenticationDot1x& dot11AuthenticationDot1x, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
 
     /**
-     * @brief Get the properties of the specified access point.
+     * @brief Get the sttaic attributes of the specified access point.
      *
      * @param accessPointId The access point identifier.
-     * @param accessPointProperties Output variable to receive the access point properties.
+     * @param dot11AccessPointAttributes Output variable to receive the access point attributes.
      * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
-    WifiAccessPointGetPropertiesImpl(std::string_view accessPointId, google::protobuf::RepeatedPtrField<std::string>& accessPointProperties);
+    WifiAccessPointGetAttributesImpl(std::string_view accessPointId, Microsoft::Net::Wifi::Dot11AccessPointAttributes& dot11AccessPointAttributes);
 
 private:
     std::shared_ptr<Microsoft::Net::NetworkManager> m_networkManager;

--- a/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
@@ -3,8 +3,10 @@
 #define NET_REMOTE_SERVICE_HXX
 
 #include <memory>
+#include <string>
 #include <string_view>
 
+#include <google/protobuf/repeated_ptr_field.h>
 #include <grpcpp/server_context.h>
 #include <grpcpp/support/status.h>
 #include <microsoft/net/NetworkManager.hxx>
@@ -148,11 +150,11 @@ private:
 
     /**
      * @brief Get the properties of the specified access point.
-     * 
-     * @param context 
-     * @param request 
+     *
+     * @param context
+     * @param request
      * @param result
-     * @return ::grpc::Status 
+     * @return ::grpc::Status
      */
     ::grpc::Status
     WifiAccessPointGetProperties(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointGetPropertiesRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointGetPropertiesResult* result) override;
@@ -313,6 +315,16 @@ protected:
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
     WifiAccessPointSetAuthenticationDot1xImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11AuthenticationDot1x& dot11AuthenticationDot1x, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);
+
+    /**
+     * @brief Get the properties of the specified access point.
+     *
+     * @param accessPointId The access point identifier.
+     * @param accessPointProperties Output variable to receive the access point properties.
+     * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+     */
+    Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
+    WifiAccessPointGetPropertiesImpl(std::string_view accessPointId, google::protobuf::RepeatedPtrField<std::string>& accessPointProperties);
 
 private:
     std::shared_ptr<Microsoft::Net::NetworkManager> m_networkManager;

--- a/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
+++ b/src/common/service/include/microsoft/net/remote/service/NetRemoteService.hxx
@@ -146,6 +146,17 @@ private:
     grpc::Status
     WifiAccessPointSetAuthenticationDot1x(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointSetAuthenticationDot1xRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointSetAuthenticationDot1xResult* result) override;
 
+    /**
+     * @brief Get the properties of the specified access point.
+     * 
+     * @param context 
+     * @param request 
+     * @param result
+     * @return ::grpc::Status 
+     */
+    ::grpc::Status
+    WifiAccessPointGetProperties(grpc::ServerContext* context, const Microsoft::Net::Remote::Wifi::WifiAccessPointGetPropertiesRequest* request, Microsoft::Net::Remote::Wifi::WifiAccessPointGetPropertiesResult* result) override;
+
 protected:
     /**
      * @brief Attempt to obtain an IAccessPoint instance for the specified access point identifier.
@@ -294,11 +305,11 @@ protected:
 
     /**
      * @brief Set the IEEE 802.1x configuration for the access point.
-     * 
+     *
      * @param accessPointId The access point identifier.
      * @param dot11AuthenticationDot1x The new IEEE 802.1x configuration to set.
      * @param accessPointController  The access point controller for the specified access point (optional).
-     * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus 
+     * @return Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
      */
     Microsoft::Net::Remote::Wifi::WifiAccessPointOperationStatus
     WifiAccessPointSetAuthenticationDot1xImpl(std::string_view accessPointId, const Microsoft::Net::Wifi::Dot11AuthenticationDot1x& dot11AuthenticationDot1x, std::shared_ptr<Microsoft::Net::Wifi::IAccessPointController> accessPointController = nullptr);

--- a/src/linux/net/wifi/core/AccessPointLinux.cxx
+++ b/src/linux/net/wifi/core/AccessPointLinux.cxx
@@ -16,8 +16,8 @@ using Microsoft::Net::Netlink::Nl80211::Nl80211Interface;
 
 using namespace Microsoft::Net::Wifi;
 
-AccessPointLinux::AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Nl80211Interface nl80211Interface) :
-    AccessPoint(interfaceName, std::move(accessPointControllerFactory)),
+AccessPointLinux::AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Nl80211Interface nl80211Interface, AccessPointProperties properties) :
+    AccessPoint(interfaceName, std::move(accessPointControllerFactory), std::move(properties)),
     m_nl80211Interface{ std::move(nl80211Interface) }
 {
 }
@@ -42,7 +42,7 @@ AccessPointFactoryLinux::Create(std::string_view interfaceName, std::unique_ptr<
         throw std::runtime_error("invalid arguments passed to AccessPointFactoryLinux::Create; this is a bug!");
     }
 
-    return std::make_shared<AccessPointLinux>(interfaceName, GetControllerFactory(), std::move(createArgsLinux->Interface));
+    return std::make_shared<AccessPointLinux>(interfaceName, GetControllerFactory(), std::move(createArgsLinux->Interface), std::move(createArgs->Properties));
 }
 
 AccessPointCreateArgsLinux::AccessPointCreateArgsLinux(Nl80211Interface nl80211Interface) :

--- a/src/linux/net/wifi/core/AccessPointLinux.cxx
+++ b/src/linux/net/wifi/core/AccessPointLinux.cxx
@@ -16,8 +16,8 @@ using Microsoft::Net::Netlink::Nl80211::Nl80211Interface;
 
 using namespace Microsoft::Net::Wifi;
 
-AccessPointLinux::AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Nl80211Interface nl80211Interface, AccessPointProperties properties) :
-    AccessPoint(interfaceName, std::move(accessPointControllerFactory), std::move(properties)),
+AccessPointLinux::AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Nl80211Interface nl80211Interface, AccessPointAttributes attributes) :
+    AccessPoint(interfaceName, std::move(accessPointControllerFactory), std::move(attributes)),
     m_nl80211Interface{ std::move(nl80211Interface) }
 {
 }
@@ -42,7 +42,7 @@ AccessPointFactoryLinux::Create(std::string_view interfaceName, std::unique_ptr<
         throw std::runtime_error("invalid arguments passed to AccessPointFactoryLinux::Create; this is a bug!");
     }
 
-    return std::make_shared<AccessPointLinux>(interfaceName, GetControllerFactory(), std::move(createArgsLinux->Interface), std::move(createArgs->Properties));
+    return std::make_shared<AccessPointLinux>(interfaceName, GetControllerFactory(), std::move(createArgsLinux->Interface), std::move(createArgs->Attributes));
 }
 
 AccessPointCreateArgsLinux::AccessPointCreateArgsLinux(Nl80211Interface nl80211Interface) :

--- a/src/linux/net/wifi/core/include/microsoft/net/wifi/AccessPointLinux.hxx
+++ b/src/linux/net/wifi/core/include/microsoft/net/wifi/AccessPointLinux.hxx
@@ -26,8 +26,9 @@ struct AccessPointLinux :
      * @param interfaceName The name of the interface.
      * @param accessPointControllerFactory The access point controller factory to use for creating access point.
      * @param nl80211Interface The nl80211 interface object.
+     * @param properties The static properties of the access point.
      */
-    AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Microsoft::Net::Netlink::Nl80211::Nl80211Interface nl80211Interface);
+    AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Microsoft::Net::Netlink::Nl80211::Nl80211Interface nl80211Interface, AccessPointProperties properties = {});
 
     /**
      * @brief Get the mac address of the access point.

--- a/src/linux/net/wifi/core/include/microsoft/net/wifi/AccessPointLinux.hxx
+++ b/src/linux/net/wifi/core/include/microsoft/net/wifi/AccessPointLinux.hxx
@@ -26,9 +26,9 @@ struct AccessPointLinux :
      * @param interfaceName The name of the interface.
      * @param accessPointControllerFactory The access point controller factory to use for creating access point.
      * @param nl80211Interface The nl80211 interface object.
-     * @param properties The static properties of the access point.
+     * @param attributes The static attributes of the access point.
      */
-    AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Microsoft::Net::Netlink::Nl80211::Nl80211Interface nl80211Interface, AccessPointProperties properties = {});
+    AccessPointLinux(std::string_view interfaceName, std::shared_ptr<IAccessPointControllerFactory> accessPointControllerFactory, Microsoft::Net::Netlink::Nl80211::Nl80211Interface nl80211Interface, AccessPointAttributes attributes = {});
 
     /**
      * @brief Get the mac address of the access point.

--- a/tests/unit/net/wifi/helpers/AccessPointTest.cxx
+++ b/tests/unit/net/wifi/helpers/AccessPointTest.cxx
@@ -33,7 +33,7 @@ AccessPointTest::GetMacAddress() const noexcept
     return MacAddress;
 }
 
-AccessPointProperties
+const AccessPointProperties&
 AccessPointTest::GetProperties() const noexcept
 {
     return Properties;

--- a/tests/unit/net/wifi/helpers/AccessPointTest.cxx
+++ b/tests/unit/net/wifi/helpers/AccessPointTest.cxx
@@ -33,6 +33,12 @@ AccessPointTest::GetMacAddress() const noexcept
     return MacAddress;
 }
 
+AccessPointProperties
+AccessPointTest::GetProperties() const noexcept
+{
+    return Properties;
+}
+
 std::unique_ptr<IAccessPointController>
 AccessPointTest::CreateController()
 {

--- a/tests/unit/net/wifi/helpers/AccessPointTest.cxx
+++ b/tests/unit/net/wifi/helpers/AccessPointTest.cxx
@@ -33,10 +33,10 @@ AccessPointTest::GetMacAddress() const noexcept
     return MacAddress;
 }
 
-const AccessPointProperties&
-AccessPointTest::GetProperties() const noexcept
+const AccessPointAttributes&
+AccessPointTest::GetAttributes() const noexcept
 {
-    return Properties;
+    return Attributes;
 }
 
 std::unique_ptr<IAccessPointController>

--- a/tests/unit/net/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/net/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -92,9 +92,9 @@ struct AccessPointTest final :
     /**
      * @brief Get the static properties of an access point.
      *
-     * @return AccessPointProperties
+     * @return AccessPointProperties&
      */
-    AccessPointProperties
+    const AccessPointProperties&
     GetProperties() const noexcept override;
 
     /**

--- a/tests/unit/net/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/net/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -40,6 +40,7 @@ struct AccessPointTest final :
     std::vector<Microsoft::Net::Wifi::Ieee80211AkmSuite> AkmSuites;
     std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> CipherSuites;
     AccessPointOperationalState OperationalState{ AccessPointOperationalState::Disabled };
+    AccessPointProperties Properties{};
 
     /**
      * @brief Construct a new AccessPointTest object with the given interface name and default capabilities.
@@ -87,6 +88,14 @@ struct AccessPointTest final :
      */
     Microsoft::Net::Wifi::Ieee80211MacAddress
     GetMacAddress() const noexcept override;
+
+    /**
+     * @brief Get the static properties of an access point.
+     *
+     * @return AccessPointProperties
+     */
+    AccessPointProperties
+    GetProperties() const noexcept override;
 
     /**
      * @brief Create a new instance that can control the access point.

--- a/tests/unit/net/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
+++ b/tests/unit/net/wifi/helpers/include/microsoft/net/wifi/test/AccessPointTest.hxx
@@ -40,7 +40,7 @@ struct AccessPointTest final :
     std::vector<Microsoft::Net::Wifi::Ieee80211AkmSuite> AkmSuites;
     std::unordered_map<Ieee80211SecurityProtocol, std::vector<Ieee80211CipherSuite>> CipherSuites;
     AccessPointOperationalState OperationalState{ AccessPointOperationalState::Disabled };
-    AccessPointProperties Properties{};
+    AccessPointAttributes Attributes{};
 
     /**
      * @brief Construct a new AccessPointTest object with the given interface name and default capabilities.
@@ -90,12 +90,12 @@ struct AccessPointTest final :
     GetMacAddress() const noexcept override;
 
     /**
-     * @brief Get the static properties of an access point.
+     * @brief Get the static attributes of an access point.
      *
-     * @return AccessPointProperties&
+     * @return AccessPointAttributes&
      */
-    const AccessPointProperties&
-    GetProperties() const noexcept override;
+    const AccessPointAttributes&
+    GetAttributes() const noexcept override;
 
     /**
      * @brief Create a new instance that can control the access point.


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [x] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow clients to obtain static attributes associated with an access point. For example, information about an attached attenuator can be encoded expressed as such attributes.

### Technical Details

* Add new API `WifiAccessPointGetAttributes`.
* Add new protocol structure `Dot11AccessPointAttributes` which contains a string key+value map of properties.
* Add `IAccessPoint::GetAttributes` interface function.
* Add basic unit test for `WifiAccessPointGetAttributes`.
* Fix casing in `ToDot11AuthenticationDot1x` adapter helper function.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Consider adding strictly typed RF attenuator information to the `AccessPointAttributes` structure.
* Extend `WifiAccessPointsEnumerate` to provide access point attributes.
* Add ability to specify attributes in a configuration file provided to the `netremote-server` binary.
* Expand unit tests for `WifiAccessPointGetAttributes`.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
