### PR TITLE
Extend WifiAccessPointsEnumerate to provide access point capabilities.

### DIFF
--- a/protocol/protos/NetRemoteWifi.proto
+++ b/protocol/protos/NetRemoteWifi.proto
@@ -11,6 +11,7 @@ message WifiAccessPointsEnumerateResultItem
     string AccessPointId = 1;
     string MacAddress = 2;
     Microsoft.Net.Wifi.Dot11AccessPointCapabilities Capabilities = 3;
+    Microsoft.Net.Wifi.Dot11AccessPointAttributes Attributes = 5;
     bool IsEnabled = 4;
 }
 

--- a/src/common/service/NetRemoteService.cxx
+++ b/src/common/service/NetRemoteService.cxx
@@ -209,6 +209,7 @@ IAccessPointToNetRemoteAccessPointResultItem(IAccessPoint& accessPoint)
     id.assign(std::cbegin(interfaceName), std::cend(interfaceName));
 
     std::string macAddress = Ieee80211MacAddressToString(accessPoint.GetMacAddress());
+    auto dot11AccessPointAttributes = ToDot11AccessPointAttributes(accessPoint.GetAttributes());
 
     auto accessPointController = accessPoint.CreateController();
     if (accessPointController == nullptr) {
@@ -242,6 +243,7 @@ IAccessPointToNetRemoteAccessPointResultItem(IAccessPoint& accessPoint)
     item.set_macaddress(std::move(macAddress));
     item.set_isenabled(isEnabled);
     *item.mutable_capabilities() = std::move(dot11AccessPointCapabilities);
+    *item.mutable_attributes() = std::move(dot11AccessPointAttributes);
 
     return item;
 }


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow clients to obtain access point attributes during enumeration via the `WifiAccessPointsEnumerate` API.

### Technical Details

* Extend `WifiAccessPointsEnumerateResultItem` to include a `Dot11AccessPointAttributes` field.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Specify attributes using JSON (file).

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
