### PR TITLE
Add AccessPointAttributes JSON serialization/deserialization support

### DIFF
--- a/src/common/net/wifi/core/AccessPointAttributes.cxx
+++ b/src/common/net/wifi/core/AccessPointAttributes.cxx
@@ -1,0 +1,25 @@
+
+#include <istream>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include <microsoft/net/wifi/AccessPointAttributes.hxx>
+
+#include "AccessPointAttributesJsonSerialization.hxx"
+
+using namespace Microsoft::Net::Wifi;
+
+/* static */
+std::optional<std::unordered_map<std::string, AccessPointAttributes>>
+AccessPointAttributes::TryParseJson(const std::string& json)
+{
+    return ParseAccessPointAttributesFromJson(json);
+}
+
+/* static */
+std::optional<std::unordered_map<std::string, AccessPointAttributes>>
+AccessPointAttributes::TryParseJson(std::istream& json)
+{
+    return ParseAccessPointAttributesFromJson(json);
+}

--- a/src/common/net/wifi/core/AccessPointAttributesJsonSerialization.cxx
+++ b/src/common/net/wifi/core/AccessPointAttributesJsonSerialization.cxx
@@ -1,0 +1,23 @@
+
+#include <microsoft/net/wifi/AccessPointAttributes.hxx>
+#include <nlohmann/json.hpp>
+
+#include "AccessPointAttributesJsonSerialization.hxx"
+
+namespace Microsoft::Net::Wifi
+{
+void
+to_json(nlohmann::json& accessPointAttributesJson, const AccessPointAttributes& accessPointAttributes)
+{
+    accessPointAttributesJson = nlohmann::json{
+        { "Properties", accessPointAttributes.Properties }
+    };
+}
+
+void
+from_json(const nlohmann::json& accessPointAttributesJson, AccessPointAttributes& accessPointAttributes)
+{
+    accessPointAttributesJson.at("Properties").get_to(accessPointAttributes.Properties);
+}
+
+} // namespace Microsoft::Net::Wifi

--- a/src/common/net/wifi/core/AccessPointAttributesJsonSerialization.hxx
+++ b/src/common/net/wifi/core/AccessPointAttributesJsonSerialization.hxx
@@ -1,0 +1,62 @@
+
+#ifndef ACCESS_POINT_ATTRIBUTES_JSON_SERIALIZATION_HXX
+#define ACCESS_POINT_ATTRIBUTES_JSON_SERIALIZATION_HXX
+
+#include <format>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include <microsoft/net/wifi/AccessPointAttributes.hxx>
+#include <nlohmann/json.hpp>
+#include <plog/Log.h>
+
+namespace Microsoft::Net::Wifi
+{
+/**
+ * @brief Serialize access point attributes to JSON.
+ *
+ * @param accessPointAttributesJson The JSON object to hold the serialized data.
+ * @param accessPointAttributes The access point attributes to serialize.
+ */
+void
+to_json(nlohmann::json& accessPointAttributesJson, const AccessPointAttributes& accessPointAttributes);
+
+/**
+ * @brief Deserialize access point attributes from JSON.
+ *
+ * @param accessPointAttributesJson The JSON object to deserialize.
+ * @param accessPointAttributes The access point attributes to populate.
+ */
+void
+from_json(const nlohmann::json& accessPointAttributesJson, AccessPointAttributes& accessPointAttributes);
+
+/**
+ * @brief Parse access point attributes from a JSON input type.
+ *
+ * @tparam InputType The input type holding the JSON to parse. This must be one of the types supported by
+ * nlohmann::json::parse (input stream, string, iterator pair, contiguous container, character array).
+ * @param json The JSON input to parse.
+ * @return std::optional<std::unordered_map<std::string, AccessPointAttributes>>
+ */
+template <typename InputType>
+std::optional<std::unordered_map<std::string, AccessPointAttributes>>
+ParseAccessPointAttributesFromJson(InputType& json)
+{
+    std::unordered_map<std::string, AccessPointAttributes> accessPointAttributesMap;
+    nlohmann::json accessPointAttributesJson;
+
+    try {
+        accessPointAttributesJson = nlohmann::json::parse(json);
+        accessPointAttributesJson.get_to(accessPointAttributesMap);
+    } catch (const nlohmann::json::parse_error& e) {
+        LOGE << std::format("Failed to parse access point access point attributes JSON: {}", e.what());
+        return std::nullopt;
+    }
+
+    return accessPointAttributesMap;
+}
+
+} // namespace Microsoft::Net::Wifi
+
+#endif // ACCESS_POINT_ATTRIBUTES_JSON_SERIALIZATION_HXX

--- a/src/common/net/wifi/core/CMakeLists.txt
+++ b/src/common/net/wifi/core/CMakeLists.txt
@@ -8,6 +8,9 @@ set(WIFI_CORE_PUBLIC_INCLUDE_PREFIX ${WIFI_CORE_PUBLIC_INCLUDE}/${WIFI_CORE_PUBL
 target_sources(wifi-core
     PRIVATE
         AccessPoint.cxx
+        AccessPointAttributes.cxx
+        AccessPointAttributesJsonSerialization.cxx
+        AccessPointAttributesJsonSerialization.hxx
         AccessPointController.cxx
         AccessPointOperationStatus.cxx
         AccessPointOperationStatusLogOnExit.cxx
@@ -34,6 +37,7 @@ target_sources(wifi-core
 target_link_libraries(wifi-core
     PRIVATE
         magic_enum::magic_enum
+        nlohmann_json::nlohmann_json
         notstd
         strings
     PUBLIC

--- a/src/common/net/wifi/core/CMakeLists.txt
+++ b/src/common/net/wifi/core/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(wifi-core
     BASE_DIRS ${WIFI_CORE_PUBLIC_INCLUDE}
     FILES
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPoint.hxx
+        ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPointAttributes.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPointController.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPointOperationStatus.hxx
         ${WIFI_CORE_PUBLIC_INCLUDE_PREFIX}/AccessPointOperationStatusLogOnExit.hxx

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPointAttributes.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPointAttributes.hxx
@@ -1,0 +1,19 @@
+
+#ifndef ACCESS_POINT_ATTRIBUTES_HXX
+#define ACCESS_POINT_ATTRIBUTES_HXX
+
+#include <string>
+#include <unordered_map>
+
+namespace Microsoft::Net::Wifi
+{
+/**
+ * @brief Container to hold static attributes about an access point.
+ */
+struct AccessPointAttributes
+{
+    std::unordered_map<std::string, std::string> Properties{};
+};
+} // namespace Microsoft::Net::Wifi
+
+#endif // ACCESS_POINT_ATTRIBUTES_HXX

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPointAttributes.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPointAttributes.hxx
@@ -14,8 +14,6 @@ namespace Microsoft::Net::Wifi
  */
 struct AccessPointAttributes
 {
-    AccessPointAttributes() = default;
-
     /**
      * @brief Attempt to deserialize a JSON string into a map of access point attributes.
      *

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPointAttributes.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/AccessPointAttributes.hxx
@@ -2,6 +2,8 @@
 #ifndef ACCESS_POINT_ATTRIBUTES_HXX
 #define ACCESS_POINT_ATTRIBUTES_HXX
 
+#include <istream>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -12,6 +14,26 @@ namespace Microsoft::Net::Wifi
  */
 struct AccessPointAttributes
 {
+    AccessPointAttributes() = default;
+
+    /**
+     * @brief Attempt to deserialize a JSON string into a map of access point attributes.
+     *
+     * @param json The JSON input string to parse.
+     * @return std::optional<std::unordered_map<std::string, AccessPointAttributes>>
+     */
+    static std::optional<std::unordered_map<std::string, AccessPointAttributes>>
+    TryParseJson(const std::string& json);
+
+    /**
+     * @brief Attempt to deserialize a JSON stream into a map of access point attributes.
+     *
+     * @param json The JSON input stream to parse.
+     * @return std::optional<std::unordered_map<std::string, AccessPointAttributes>>
+     */
+    static std::optional<std::unordered_map<std::string, AccessPointAttributes>>
+    TryParseJson(std::istream& json);
+
     std::unordered_map<std::string, std::string> Properties{};
 };
 } // namespace Microsoft::Net::Wifi

--- a/src/common/net/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
+++ b/src/common/net/wifi/core/include/microsoft/net/wifi/IAccessPoint.hxx
@@ -6,20 +6,12 @@
 #include <string_view>
 #include <unordered_map>
 
+#include <microsoft/net/wifi/AccessPointAttributes.hxx>
 #include <microsoft/net/wifi/IAccessPointController.hxx>
 #include <microsoft/net/wifi/Ieee80211.hxx>
 
 namespace Microsoft::Net::Wifi
 {
-
-/**
- * @brief Container to hold static attributes about an access point.
- */
-struct AccessPointAttributes
-{
-    std::unordered_map<std::string, std::string> Properties{};
-};
-
 /**
  * @brief Represents a wireless access point.
  */

--- a/src/linux/net/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
+++ b/src/linux/net/wifi/apmanager/AccessPointDiscoveryAgentOperationsNetlink.cxx
@@ -158,8 +158,8 @@ MakeAccessPoint(const std::shared_ptr<AccessPointFactoryLinux> &accessPointFacto
 std::future<std::vector<std::shared_ptr<IAccessPoint>>>
 AccessPointDiscoveryAgentOperationsNetlink::ProbeAsync()
 {
-    const auto ToAccessPoint = [this](const Nl80211Interface &nl80211Interface) {
-        return detail::MakeAccessPoint(m_accessPointFactory, nl80211Interface);
+    const auto ToAccessPoint = [accessPointFactory = m_accessPointFactory](const Nl80211Interface &nl80211Interface) {
+        return detail::MakeAccessPoint(accessPointFactory, nl80211Interface);
     };
 
     std::promise<std::vector<std::shared_ptr<IAccessPoint>>> probePromise{};

--- a/tests/unit/net/wifi/core/CMakeLists.txt
+++ b/tests/unit/net/wifi/core/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(wifi-core-test-unit
     PRIVATE
         Main.cxx
         TestAccessPoint.cxx
+        TestAccessPointAttributes.cxx
         TestAccessPointOperationStatus.cxx
         TestIeee80211.cxx
 )
@@ -18,6 +19,7 @@ target_link_libraries(wifi-core-test-unit
     PRIVATE
         Catch2::Catch2
         magic_enum::magic_enum
+        nlohmann_json::nlohmann_json
         plog::plog
         strings
         wifi-core

--- a/tests/unit/net/wifi/core/TestAccessPointAttributes.cxx
+++ b/tests/unit/net/wifi/core/TestAccessPointAttributes.cxx
@@ -1,0 +1,75 @@
+
+#include <string>
+#include <unordered_map>
+
+#include <catch2/catch_test_macros.hpp>
+#include <microsoft/net/wifi/AccessPointAttributes.hxx>
+#include <nlohmann/json.hpp>
+
+TEST_CASE("AccessPointAttributes JSON Serialization and Deserialization", "[wifi][core][ap][serialization]")
+{
+    using namespace Microsoft::Net::Wifi;
+
+    auto accessPointAttributesJson = R"(
+        {
+            "wlan0": {
+                "Properties": {
+                    "key1": "value1",
+                    "key2": "value2"
+                }
+            },
+            "wlan1": {
+                "Properties": {
+                    "key1": "value1",
+                    "key2": "value2"
+                }
+            }
+        }
+    )";
+
+    // clang-format off
+    std::unordered_map<std::string, AccessPointAttributes> AccessPointAttributesMap{
+        { 
+            "wlan0", 
+            AccessPointAttributes{
+                {
+                    { "key1", "value1" },
+                    { "key2", "value2" }
+                }
+            },
+        },
+        {
+            "wlan1", 
+            AccessPointAttributes{
+                {
+                    { "key1", "value1" },
+                    { "key2", "value2" }
+                }
+            }
+        }
+    };
+    // clang-format on
+
+    SECTION("Deserialization (direct) doesn't cause a crash")
+    {
+        REQUIRE_NOTHROW(nlohmann::json::parse(accessPointAttributesJson));
+    }
+
+    SECTION("Deserialization (wrapped) doesn't cause a crash")
+    {
+        REQUIRE_NOTHROW(AccessPointAttributes::TryParseJson(accessPointAttributesJson));
+    }
+
+    SECTION("Deserialization (wrapped) populates the access point attributes")
+    {
+        auto deserializedAccessPointAttributesOpt = AccessPointAttributes::TryParseJson(accessPointAttributesJson);
+        REQUIRE(deserializedAccessPointAttributesOpt.has_value());
+        auto& deserializedAccessPointAttributes = deserializedAccessPointAttributesOpt.value();
+        REQUIRE(std::size(deserializedAccessPointAttributes) == std::size(AccessPointAttributesMap));
+
+        for (const auto& [interfaceName, accessPointAttributes] : AccessPointAttributesMap) {
+            REQUIRE(deserializedAccessPointAttributes.contains(interfaceName));
+            REQUIRE(deserializedAccessPointAttributes[interfaceName].Properties == accessPointAttributes.Properties);
+        }
+    }
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Allow `AccessPointAttributes` to be encoded as JSON.
* Allow `AccessPointAttributes` to be instantiated with JSON input (`std::string`, `std::ifstream` (intended for file)).

### Technical Details

* Add nlohmann::json to/from parsers for `AccessPointAttributes`.
* Add basic unit test.

### Test Results

* All unit tests pass.

### Reviewer Focus

* None

### Future Work

* Allow specifying JSON file on command-line for `netremote-server`.

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
