### PR TITLE
Add netremote-server JSON schema and example file.

### DIFF
--- a/config/netremote-server-config-schema.json
+++ b/config/netremote-server-config-schema.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/microsoft/netremote/tree/develop/config/netremote-server-config-schema.json",
+    "$title": "NetRemote Server",
+    "description": "NetRemote Server Configuration Schema",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "description": "The schema version"
+        },
+        "WifiAccessPointAttributes": {
+            "type": "object",
+            "description": "Wifi Access Point Attributes",
+            "additionalProperties": false,
+            "properties": {
+                "Properties": {
+                    "type": "object",
+                    "description": "Unstructured (string) Wifi Access Point Properties",
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "description": "Additional properties"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/common/net/wifi/apmanager/AccessPointManager.cxx
+++ b/src/common/net/wifi/apmanager/AccessPointManager.cxx
@@ -126,6 +126,7 @@ AccessPointManager::GetAllAccessPoints() const
 std::optional<AccessPointAttributes>
 AccessPointManager::GetAccessPointAttributes(const std::string& interfaceName) const
 {
+    // Note: no locks are used here because m_accessPointAttributes cannot be modified after construction.
     auto accessPointAttributesIterator = m_accessPointAttributes.find(interfaceName);
     if (accessPointAttributesIterator == std::cend(m_accessPointAttributes)) {
         return std::nullopt;

--- a/src/common/server/config/netremote-server-config-example.json
+++ b/src/common/server/config/netremote-server-config-example.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "../../../../config/netremote-server-config-schema.json",
+    "WifiAccessPointAttributes": {
+        "Properties": {
+            "wlan0": {
+                "MacAddress": "00:11:22:33:44:55",
+                "RfAttenuatorChannelsAttached": "1,3"
+            },
+            "wlp0s3": {
+                "MacAddress": "AA:BB:CC:DD:EE:FF",
+                "RfAttenuatorChannelsAttached": "2,4,6",
+                "Another": "String value"
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [X] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Provide understanding of netremote-server JSON configuration file format.

### Technical Details

* Add JSON schema file `netremote-server` JSON configuration file.
* Add example `netremote-server` JSON configuration file.
* Add commit adding comment to `AccessPointManager.cxx` that was missed in #329.

### Test Results

* Confirmed schema file is valid JSON schema.
* Confirmed example `netremote-server` JSON configuration file is valid per newly added schema file.

### Reviewer Focus

* None

### Future Work

* Determine whether "Properties" attribute can be removed while supporting other adjacent properties that are not string <-> string mappings.

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
