### PR TITLE
Add new protocol buffer API files to dotnet projects

### DIFF
--- a/src/common/dotnet/NetRemoteClient/NetRemoteClient.csproj
+++ b/src/common/dotnet/NetRemoteClient/NetRemoteClient.csproj
@@ -21,13 +21,28 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\..\..\protocol\protos\NetRemoteService.proto" GrpcServices="Client">
+    <Protobuf Include="..\..\..\..\api\protos\NetRemoteDataStream.proto" GrpcServices="None">
+      <Link>Protos\NetRemoteDataStream.proto</Link>
+    </Protobuf>
+    <Protobuf Include="..\..\..\..\api\protos\NetRemoteDataStreamingService.proto" GrpcServices="Server">
+      <Link>Protos\NetRemoteDataStreamingService.proto</Link>
+    </Protobuf>
+    <Protobuf Include="..\..\..\..\api\protos\NetRemoteNetwork.proto" GrpcServices="None">
+      <Link>Protos\NetRemoteNetwork.proto</Link>
+    </Protobuf>
+    <Protobuf Include="..\..\..\..\api\protos\NetRemoteService.proto" GprcServices="Server">
       <Link>Protos\NetRemoteService.proto</Link>
     </Protobuf>
-    <Protobuf Include="..\..\..\protocol\protos\NetRemoteWifi.proto" GrpcServices="None">
+    <Protobuf Include="..\..\..\..\api\protos\NetRemoteWifi.proto" GrpcServices="None">
       <Link>Protos\NetRemoteWifi.proto</Link>
     </Protobuf>
-    <Protobuf Include="..\..\..\protocol\protos\WifiCore.proto" GrpcServices="None">
+    <Protobuf Include="..\..\..\..\api\protos\Network8021x.proto" GrpcServices="None">
+      <Link>Protos\Network8021x.proto</Link>
+    </Protobuf>
+    <Protobuf Include="..\..\..\..\api\protos\NetworkCore.proto" GrpcServices="None">
+      <Link>Protos\NetworkCore.proto</Link>
+    </Protobuf>
+    <Protobuf Include="..\..\..\..\api\protos\WifiCore.proto" GrpcServices="None">
       <Link>Protos\WifiCore.proto</Link>
     </Protobuf>
   </ItemGroup>

--- a/src/common/dotnet/NetRemoteService/NetRemoteService.csproj
+++ b/src/common/dotnet/NetRemoteService/NetRemoteService.csproj
@@ -16,13 +16,28 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Protobuf Include="..\..\..\protocol\protos\NetRemoteService.proto" GprcServices="Server">
+    <Protobuf Include="..\..\..\..\api\protos\NetRemoteDataStream.proto" GrpcServices="None">
+      <Link>Protos\NetRemoteDataStream.proto</Link>
+    </Protobuf>
+    <Protobuf Include="..\..\..\..\api\protos\NetRemoteDataStreamingService.proto" GrpcServices="Server">
+      <Link>Protos\NetRemoteDataStreamingService.proto</Link>
+    </Protobuf>
+    <Protobuf Include="..\..\..\..\api\protos\NetRemoteNetwork.proto" GrpcServices="None">
+      <Link>Protos\NetRemoteNetwork.proto</Link>
+    </Protobuf>
+    <Protobuf Include="..\..\..\..\api\protos\NetRemoteService.proto" GprcServices="Server">
       <Link>Protos\NetRemoteService.proto</Link>
     </Protobuf>
-    <Protobuf Include="..\..\..\protocol\protos\NetRemoteWifi.proto" GrpcServices="None">
+    <Protobuf Include="..\..\..\..\api\protos\NetRemoteWifi.proto" GrpcServices="None">
       <Link>Protos\NetRemoteWifi.proto</Link>
     </Protobuf>
-    <Protobuf Include="..\..\..\protocol\protos\WifiCore.proto" GrpcServices="None">
+    <Protobuf Include="..\..\..\..\api\protos\Network8021x.proto" GrpcServices="None">
+      <Link>Protos\Network8021x.proto</Link>
+    </Protobuf>
+    <Protobuf Include="..\..\..\..\api\protos\NetworkCore.proto" GrpcServices="None">
+      <Link>Protos\NetworkCore.proto</Link>
+    </Protobuf>
+    <Protobuf Include="..\..\..\..\api\protos\WifiCore.proto" GrpcServices="None">
       <Link>Protos\WifiCore.proto</Link>
     </Protobuf>
   </ItemGroup>


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals

* Ensure the dotnet project include all of the latest protocol buffer API files.

### Technical Details

* Add new, missing `.proto` files to the client and server dotnet projects.

### Test Results

* Built each project and entire solution, confirmed build works, server runs, and unit test passes.

### Reviewer Focus

* None

### Future Work

* None

### Checklist

- [ ] Build target `all` compiles cleanly.
- [ ] clang-format and clang-tidy deltas produced no new output.
- [ ] Newly added functions include doxygen-style comment block.
