### PR TITLE
Implement an attenuator tool to test both software and socket attenuator

### DIFF
--- a/src/common/service/NetRemoteRfAttenuatorService.cxx
+++ b/src/common/service/NetRemoteRfAttenuatorService.cxx
@@ -106,6 +106,9 @@ grpc::Status NetRemoteRfAttenuatorService::SetAttenuationForChannel([[maybe_unus
     std::scoped_lock attenuatorLock{ m_mutex };
     const NetRemoteApiTrace traceMe{};
 
+    auto clientAddress = context->peer();
+    LOGI << std::format("SetAttenuationForChannel: client-id: {}, channel: {}, attenuationdbm: {}", clientAddress, request->channel(), request->attenuationdbm());
+
     try {
         auto result = m_attenuator->SetAttenuationForChannel(request->channel(), request->attenuationdbm());
 

--- a/src/linux/rfattenuator/CMakeLists.txt
+++ b/src/linux/rfattenuator/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(lib)
+add_subdirectory(cli)

--- a/src/linux/rfattenuator/cli/CMakeLists.txt
+++ b/src/linux/rfattenuator/cli/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(${PROJECT_NAME}-rfattenuator-cli-linux)
+
+target_sources(${PROJECT_NAME}-rfattenuator-cli-linux
+    PRIVATE
+        Main.cxx
+)
+
+target_link_libraries(${PROJECT_NAME}-rfattenuator-cli-linux
+    PRIVATE
+        ${PROJECT_NAME}-rfattenuator-linux
+)
+
+set_target_properties(${PROJECT_NAME}-rfattenuator-cli-linux
+    PROPERTIES
+        OUTPUT_NAME rfattenuator-cli
+)

--- a/src/linux/rfattenuator/cli/Main.cxx
+++ b/src/linux/rfattenuator/cli/Main.cxx
@@ -1,0 +1,272 @@
+#include <exception>
+#include <filesystem>
+#include <format>
+#include <functional>
+#include <ios>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <tuple>
+
+#include <microsoft/net/remote/service/RfAttenuator.hxx>
+#include <microsoft/net/remote/service/RfAttenuatorFactory.hxx>
+// #include "RfAttenuatorSoftwareSimulated.hxx"
+
+namespace detail
+{
+void
+DisplayAttenuatorProperties(const RfAttenuatorProperties& properties, std::ostream& out)
+{
+    // clang-format off
+    out << properties.Identification.value_or("Unidentified Mode") << ", "
+        << std::size(properties.Channels) << " channels, "
+        << properties.FrequencyBandwidthMHzMin << "-" << properties.FrequencyBandwidthMHzMax << " MHz frequency bandwidth, "
+        << properties.AttenuationRangeDbmMin << "-" << properties.AttenuationRangeDbmMax << " +/- "
+        << properties.AttenuationStepDbmMin << "-" << properties.AttenuationStepDbmMax << " dBm attenuation, "
+        << properties.AttenuationAccuracyDbmMin << "-" << properties.AttenuationAccuracyDbmMax << " dBm accuracy";
+    if (properties.SupportsSweep)
+    {
+        out << " +Sweep";
+    }
+    out << std::endl;
+    // clang-format on
+}
+
+std::tuple<bool, std::optional<RfAttenuatorProperties>>
+ValidateAttenuatorInitialization(IRfAttenuatorController* attenuator)
+{
+    try {
+        // Reset attenuator and clear state.
+        std::cout << "Resetting attenuator ... ";
+        attenuator->Reset();
+        std::cout << "succeeded" << std::endl;
+
+        // Obtain properties.
+        std::cout << "Obtaining attenuator properties: ";
+        auto properties = attenuator->GetProperties();
+        detail::DisplayAttenuatorProperties(properties, std::cout);
+
+        // Ensure at least 1 channel is supported.
+        if (std::empty(properties.Channels)) {
+            std::cout << "Attenuator does not support any channels, abandoning further sanity checks.";
+            return { false, std::nullopt };
+        }
+
+        return { true, std::move(properties) };
+    } catch (const RfAttenuatorException& e) {
+        std::cout << "failed (" << e.what() << ")" << std::endl;
+        return { false, std::nullopt };
+    }
+}
+
+bool
+ValidateAttenuatorSanityBasic(IRfAttenuatorController* attenuator)
+{
+    const auto [initializationSucceeded, properties] = ValidateAttenuatorInitialization(attenuator);
+    if (!initializationSucceeded) {
+        return false;
+    }
+
+    try {
+        // Use first supported channel.
+        uint32_t channel{ properties->Channels.front() };
+
+        // Get attenuation for channel.
+        std::cout << std::format("Getting attenuation for channel {}: ", channel);
+        double attenuation = attenuator->GetAttenuationForChannel(channel);
+        std::cout << std::format("{} dBm", attenuation) << std::endl;
+
+        // Set attenuation for first channel.
+        attenuation = (attenuation < properties->AttenuationRangeDbmMax) ? attenuation + 1 : attenuation - 1;
+        std::cout << std::format("Setting attenuation for channel {} to {} dBm: ", channel, attenuation);
+        auto setAttenuationSucceeded = attenuator->SetAttenuationForChannel(channel, attenuation);
+        std::cout << ((setAttenuationSucceeded) ? "succeeded" : "failed") << std::endl;
+        if (!setAttenuationSucceeded) {
+            return false;
+        }
+
+        // Get attenuation and ensure the value was persisted.
+        auto attenuationSet = attenuator->GetAttenuationForChannel(channel);
+        std::cout << std::format("Re-reading attenuation for channel {}: {} dBm", channel, attenuationSet) << std::endl;
+
+        return (attenuation == attenuationSet);
+    } catch (const RfAttenuatorException& e) {
+        std::cout << "failed (" << e.what() << ")" << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+bool
+ValidateAttenuatorSanityExtended(IRfAttenuatorController* attenuator)
+{
+    const auto [initializationSucceeded, properties] = ValidateAttenuatorInitialization(attenuator);
+    if (!initializationSucceeded) {
+        return false;
+    }
+
+    try {
+        // Get attenuation for first channel.
+        uint32_t channel{ properties->Channels.front() };
+        std::cout << "Getting attenuation for channel " << channel << ": ";
+        double attenuation = attenuator->GetAttenuationForChannel(channel);
+        std::cout << attenuation << " dBm" << std::endl;
+
+        // Set attenuation from min to max using min step.
+        std::cout << "Increasing attenuation from min to max using minimum step value (" << properties->AttenuationRangeDbmMin << "-"
+                  << properties->AttenuationRangeDbmMax << " dBm, +" << properties->AttenuationStepDbmMin << " dBm steps): ";
+        attenuation = properties->AttenuationRangeDbmMin;
+        while (attenuation < properties->AttenuationRangeDbmMax) {
+            attenuation = std::clamp(
+                attenuation + properties->AttenuationStepDbmMin, properties->AttenuationRangeDbmMin, properties->AttenuationRangeDbmMax);
+            std::cout << attenuation << " ";
+
+            if (!attenuator->SetAttenuationForChannel(channel, attenuation)) {
+                std::cout << "*" << std::endl
+                          << std::format("failed to set attenuation for channel {} to {}", channel, attenuation);
+                return false;
+            }
+        }
+        std::cout << std::endl;
+
+        std::cout << "Decreasing attenuation from max to min using maximum step value (" << properties->AttenuationRangeDbmMax << "-"
+                  << properties->AttenuationRangeDbmMin << " dBm, -" << properties->AttenuationStepDbmMax << " dBm steps): ";
+        while (attenuation > properties->AttenuationRangeDbmMin) {
+            attenuation = std::clamp(
+                attenuation - properties->AttenuationStepDbmMax, properties->AttenuationRangeDbmMin, properties->AttenuationRangeDbmMax);
+            std::cout << attenuation << " ";
+
+            if (!attenuator->SetAttenuationForChannel(channel, attenuation)) {
+                std::cout << "*" << std::endl
+                          << std::format("failed to set attenuation for channel {} to {}", channel, attenuation);
+                return false;
+            }
+        }
+        std::cout << std::endl;
+    } catch (const RfAttenuatorException& e) {
+        std::cout << "failed (" << e.what() << ")" << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+void
+ShowUsage(const char* programPath)
+{
+    const auto programName = std::filesystem::path(programPath).filename().string();
+
+    // clang-format off
+    std::cout << programName << " <attenuator type> [attenuator-type-args] [validation-mode]" << std::endl
+               << std::endl
+               << "    Attenuator Types: " << std::endl
+               << "        'software'" << std::endl
+               << "          'socket'" << std::endl
+               << std::endl
+               << "    Attenuator Type Arguments:" << std::endl
+               << "         'software': none" << std::endl
+               << "           'socket': AFW83 <ip address> <port>" << std::endl
+               << std::endl
+               << "    Validation Modes: " << std::endl
+               << "           'basic' (default)" << std::endl
+               << "        'extended'" << std::endl
+               << std::endl;
+    // clang-format on
+}
+} // namespace detail
+
+int
+main(int argc, char* argv[])
+{
+    static const auto MinExpectedArguments = 1;
+    static const auto MinExpectedArgumentsSoftware = 1;
+    static const auto MinExpectedArgumentsSocket = 4;
+    static const auto ValidationModeArgBasic = "basic";
+    static const auto ValidationModeArgExtended = "extended";
+
+    if (argc < (MinExpectedArguments + 1)) {
+        std::cerr << std::format("error: {} arguments are expected, {} specified", MinExpectedArguments, argc - 1) << std::endl;
+        detail::ShowUsage(argv[0]);
+        return -1;
+    }
+
+    std::unique_ptr<IRfAttenuatorController> attenuator = nullptr;
+
+    int argIndex{ 1 };
+    int numArgsExpected{ 0 };
+    std::string validationMode{ ValidationModeArgBasic };
+    std::string attenuatorType{ argv[argIndex++] };
+
+    if (attenuatorType == "software") {
+        numArgsExpected = MinExpectedArgumentsSoftware;
+
+        if (argc < numArgsExpected + 1) {
+            std::cerr << std::format(
+                             "error: {} arguments are expected for software-base attenuators, {} specified",
+                             numArgsExpected,
+                             argc - 1)
+                      << std::endl;
+            detail::ShowUsage(argv[0]);
+            return -1;
+        }
+
+        if (argc > numArgsExpected + 1) {
+            validationMode = argv[argIndex++];
+        }
+
+        attenuator = RfAttenuatorFactory::CreateSimulatedSoftwareAttenuator();
+    } else if (attenuatorType == "socket") {
+        numArgsExpected = MinExpectedArgumentsSocket;
+
+        if (argc < numArgsExpected + 1) {
+            std::cerr << std::format(
+                             "error: {} arguments are expected for socket-based attenuators, {} specified",
+                             numArgsExpected,
+                             argc - 1)
+                      << std::endl;
+            detail::ShowUsage(argv[0]);
+            return -1;
+        }
+
+        // Capture arguments.
+        const std::string attenuatorName{ argv[argIndex++] };
+        const std::string ipAddress{ argv[argIndex++] };
+        const std::string portString{ argv[argIndex++] };
+        if (argc > numArgsExpected + 1) {
+            validationMode = argv[argIndex++];
+        }
+
+        std::istringstream ss{ portString };
+        uint16_t port{ 0 };
+        ss >> port;
+        if (attenuatorName == "AFW83") {
+            attenuator = RfAttenuatorFactory::CreateSocketAfw83Attenuator(std::move(ipAddress), port);
+        }
+        else {
+            std::cerr << std::format("unknown socket-based attenuator name '{}'", attenuatorName) << std::endl;
+            detail::ShowUsage(argv[0]);
+            return -1;
+        }
+    } else {
+        std::cerr << "attenuator type not specified, exiting" << std::endl;
+        detail::ShowUsage(argv[0]);
+        return -1;
+    }
+
+    if (attenuator == nullptr) {
+        std::cerr << std::format("failed to create specified {} attenuator, exiting", attenuatorType) << std::endl;
+        return -1;
+    }
+
+    const std::function<bool(IRfAttenuatorController*)> validateSanity = (validationMode == ValidationModeArgExtended)
+        ? detail::ValidateAttenuatorSanityExtended
+        : detail::ValidateAttenuatorSanityBasic;
+
+    const bool sanityCheckSucceeded = validateSanity(attenuator.get());
+    std::cout << "Sanity check " << ((sanityCheckSucceeded) ? "succeeded" : "failed") << std::endl;
+
+    return 0;
+}

--- a/src/linux/rfattenuator/lib/CMakeLists.txt
+++ b/src/linux/rfattenuator/lib/CMakeLists.txt
@@ -1,11 +1,11 @@
 
-add_library(${PROJECT_NAME}-rfattenuator STATIC "")
+add_library(${PROJECT_NAME}-rfattenuator-linux STATIC "")
 
 set(NET_REMOTE_RFATTENUATOR_LINUX_PUBLIC_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/include)
 set(NET_REMOTE_RFATTENUATOR_LINUX_PUBLIC_INCLUDE_SUFFIX microsoft/net/remote/service)
 set(NET_REMOTE_RFATTENUATOR_LINUX_PUBLIC_INCLUDE_PREFIX ${NET_REMOTE_RFATTENUATOR_LINUX_PUBLIC_INCLUDE}/${NET_REMOTE_RFATTENUATOR_LINUX_PUBLIC_INCLUDE_SUFFIX})
 
-target_sources(${PROJECT_NAME}-rfattenuator
+target_sources(${PROJECT_NAME}-rfattenuator-linux
     PRIVATE
         RfAttenuatorAeroflexWeinschle83XX.cxx
         RfAttenuatorExceptionImpl.cxx
@@ -22,7 +22,7 @@ target_sources(${PROJECT_NAME}-rfattenuator
         ${NET_REMOTE_RFATTENUATOR_LINUX_PUBLIC_INCLUDE_PREFIX}/RfAttenuatorFactory.hxx
 )
 
-target_link_libraries(${PROJECT_NAME}-rfattenuator
+target_link_libraries(${PROJECT_NAME}-rfattenuator-linux
     PUBLIC
         ${PROJECT_NAME}-rfattenuator-interface
     PRIVATE
@@ -30,7 +30,7 @@ target_link_libraries(${PROJECT_NAME}-rfattenuator
 )
 
 install(
-    TARGETS ${PROJECT_NAME}-rfattenuator
+    TARGETS ${PROJECT_NAME}-rfattenuator-linux
     EXPORT ${PROJECT_NAME}
     COMPONENT dev
     FILE_SET HEADERS

--- a/src/linux/rfattenuator/lib/RfAttenuatorFactoryImpl.cxx
+++ b/src/linux/rfattenuator/lib/RfAttenuatorFactoryImpl.cxx
@@ -1,4 +1,5 @@
 #include <format>
+#include <iostream>
 
 #include "RfAttenuatorAeroflexWeinschle83XX.hxx"
 #include "RfAttenuatorExceptionImpl.hxx"
@@ -61,4 +62,62 @@ RfAttenuatorFactory::TryCreateWithTcpConnection(std::string attenuatorName, RfAt
     }
 
     return instance;
+}
+
+std::unique_ptr<IRfAttenuatorController>
+RfAttenuatorFactory::CreateSimulatedSoftwareAttenuator()
+{
+    RfAttenuatorProperties properties{
+        .Channels{ 1, 2, 3, 4 },
+        .AttenuationRangeDbmMin = 0,
+        .AttenuationRangeDbmMax = 100,
+        .AttenuationStepDbmMin = 1,
+        .AttenuationStepDbmMax = 5,
+        .AttenuationAccuracyDbmMin = 1,
+        .AttenuationAccuracyDbmMax = 1,
+        .FrequencyBandwidthMHzMin = 0,
+        .FrequencyBandwidthMHzMax = 6000,
+        .SupportsSweep = false,
+        .Identification = "Simulated Attenuator",
+    };
+
+    std::cout << "Creating software-based attenuator ... ";
+
+    try {
+        auto attenuator = TryCreateBasic("software", std::move(properties));
+        std::cout << "succeeded" << std::endl;
+        return attenuator;
+    } catch (const RfAttenuatorException& e) {
+        std::cout << "failed (" << e.what() << ")" << std::endl;
+        return nullptr;
+    }
+}
+
+std::unique_ptr<IRfAttenuatorController>
+RfAttenuatorFactory::CreateSocketAfw83Attenuator(std::string ipAddress, uint16_t port)
+{
+    RfAttenuatorConnectionArgumentsTcp args{
+        .IpAddress = std::move(ipAddress),
+        .Port = port,
+    };
+
+    const auto attenuatorName = "AFW83";
+    std::cout << std::format(
+                     "Creating socket-based attenuator {} @ {}:{}",
+                     attenuatorName,
+                     args.IpAddress,
+                     args.Port)
+              << " ... ";
+
+    try {
+        auto attenuator = TryCreateWithTcpConnection(attenuatorName, std::move(args));
+        std::cout << "succeeded" << std::endl;
+        return attenuator;
+    } catch (RfAttenuatorException& e) {
+        std::cout << "failed (" << e.what() << ")" << std::endl;
+        return nullptr;
+    } catch (std::exception& e) {
+        std::cout << "failed (" << e.what() << ")" << std::endl;
+        return nullptr;
+    }
 }

--- a/src/linux/rfattenuator/lib/include/microsoft/net/remote/service/RfAttenuatorFactory.hxx
+++ b/src/linux/rfattenuator/lib/include/microsoft/net/remote/service/RfAttenuatorFactory.hxx
@@ -29,4 +29,22 @@ struct RfAttenuatorFactory
      */
     static std::unique_ptr<IRfAttenuatorController>
     TryCreateWithTcpConnection(std::string attenuatorName, RfAttenuatorConnectionArgumentsTcp args);
+
+    /**
+     * @brief Create a simulated software attenuator.
+     *
+     * @return std::unique_ptr<IRfAttenuatorController>
+     */
+    static std::unique_ptr<IRfAttenuatorController>
+    CreateSimulatedSoftwareAttenuator();
+
+    /**
+     * @brief Create a socket-based AFW83 attenuator.
+     *
+     * @param ipAddress The IP address of the attenuator.
+     * @param port The port of the attenuator.
+     * @return std::unique_ptr<IRfAttenuatorController>
+     */
+    static std::unique_ptr<IRfAttenuatorController>
+    CreateSocketAfw83Attenuator(std::string ipAddress, uint16_t port);
 };

--- a/src/linux/server/CMakeLists.txt
+++ b/src/linux/server/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(${PROJECT_NAME}-server-linux
     PRIVATE
         ${PROJECT_NAME}-net-linux
         ${PROJECT_NAME}-server
-        ${PROJECT_NAME}-rfattenuator
+        ${PROJECT_NAME}-rfattenuator-linux
         logging-utils
         notstd
         plog::plog

--- a/src/linux/server/Main.cxx
+++ b/src/linux/server/Main.cxx
@@ -98,64 +98,6 @@ OnSignal(int signal)
     TerminateRequstedChanged.notify_one();
 }
 
-std::unique_ptr<IRfAttenuatorController>
-CreateSimulatedAttenuator()
-{
-    // Implementation of CreateSimulatedAttenuator
-    RfAttenuatorProperties properties{
-        .Channels{ 1, 2, 3, 4 },
-        .AttenuationRangeDbmMin = 0,
-        .AttenuationRangeDbmMax = 100,
-        .AttenuationStepDbmMin = 1,
-        .AttenuationStepDbmMax = 5,
-        .AttenuationAccuracyDbmMin = 1,
-        .AttenuationAccuracyDbmMax = 1,
-        .FrequencyBandwidthMHzMin = 0,
-        .FrequencyBandwidthMHzMax = 6000,
-        .SupportsSweep = false,
-        .Identification = "Simulated Attenuator",
-    };
-
-    LOGI << "Creating software-based attenuator ... ";
-
-    try {
-        auto attenuator = RfAttenuatorFactory::TryCreateBasic("software", std::move(properties));
-        LOGI << "succeeded" << std::endl;
-        return attenuator;
-    } catch (const RfAttenuatorException &e) {
-        LOGE << "failed (" << e.what() << ")" << std::endl;
-        return nullptr;
-    }
-}
-
-std::unique_ptr<IRfAttenuatorController>
-CreateSocketAttenuator(std::string attenuatorName, std::string ipAddress, uint16_t port)
-{
-    RfAttenuatorConnectionArgumentsTcp args{
-        .IpAddress = std::move(ipAddress),
-        .Port = port,
-    };
-
-    LOGI << std::format(
-                "Creating socket-based attenuator {} @ {}:{}",
-                attenuatorName,
-                args.IpAddress,
-                args.Port)
-         << " ... ";
-
-    try {
-        auto attenuator = RfAttenuatorFactory::TryCreateWithTcpConnection(attenuatorName, std::move(args));
-        LOGI << "succeeded" << std::endl;
-        return attenuator;
-    } catch (RfAttenuatorException &e) {
-        LOGE << "failed (" << e.what() << ")" << std::endl;
-        return nullptr;
-    } catch (std::exception &e) {
-        LOGE << "failed (" << e.what() << ")" << std::endl;
-        return nullptr;
-    }
-}
-
 int
 main(int argc, char *argv[])
 {
@@ -221,9 +163,17 @@ main(int argc, char *argv[])
     // Create attenuator controller.
     std::shared_ptr<IRfAttenuatorController> rfAttenuatorController = nullptr;
     if (configuration.RfAttenuatorConfiguration.Type == RfAttenuatorType::Software) {
-        rfAttenuatorController = CreateSimulatedAttenuator();
+        rfAttenuatorController = RfAttenuatorFactory::CreateSimulatedSoftwareAttenuator();
+        if (rfAttenuatorController == nullptr) {
+            LOGE << "Failed to create software-based attenuator";
+            return -1;
+        }
     } else if (configuration.RfAttenuatorConfiguration.Type == RfAttenuatorType::Socket) {
-        rfAttenuatorController = CreateSocketAttenuator("AeroflexWeinschle83", configuration.RfAttenuatorConfiguration.Address, configuration.RfAttenuatorConfiguration.Port);
+        rfAttenuatorController = RfAttenuatorFactory::CreateSocketAfw83Attenuator(configuration.RfAttenuatorConfiguration.Address, configuration.RfAttenuatorConfiguration.Port);
+        if (rfAttenuatorController == nullptr) {
+            LOGE << "Failed to create socket-based attenuator";
+            return -1;
+        }
     } else {
         LOGN << "No RF attenuator controller created";
     }

--- a/tests/unit/linux/rfattenuator/CMakeLists.txt
+++ b/tests/unit/linux/rfattenuator/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_libraries(${PROJECT_NAME}-rfattenuator-linux-test-unit
         ${PROJECT_NAME}-net
         ${PROJECT_NAME}-net-test-helpers
         ${PROJECT_NAME}-server
-        ${PROJECT_NAME}-rfattenuator
+        ${PROJECT_NAME}-rfattenuator-linux
         Catch2::Catch2
         gRPC::grpc++
         magic_enum::magic_enum

--- a/tests/unit/linux/rfattenuator/NetRemoteRfAttenuatorServiceClient.cxx
+++ b/tests/unit/linux/rfattenuator/NetRemoteRfAttenuatorServiceClient.cxx
@@ -18,43 +18,13 @@ using namespace Microsoft::Net::Remote::Service;
 using namespace Microsoft::Net::Remote;
 using namespace Microsoft::Net::Remote::RfAttenuator;
 
-std::unique_ptr<IRfAttenuatorController>
-CreateSimulatedAttenuator()
-{
-    // Implementation of CreateSimulatedAttenuator
-    RfAttenuatorProperties properties{
-        .Channels{ 1, 2, 3, 4 },
-        .AttenuationRangeDbmMin = 0,
-        .AttenuationRangeDbmMax = 100,
-        .AttenuationStepDbmMin = 1,
-        .AttenuationStepDbmMax = 5,
-        .AttenuationAccuracyDbmMin = 1,
-        .AttenuationAccuracyDbmMax = 1,
-        .FrequencyBandwidthMHzMin = 0,
-        .FrequencyBandwidthMHzMax = 6000,
-        .SupportsSweep = false,
-        .Identification = "Simulated Attenuator",
-    };
-
-    LOGI << "Creating software-based attenuator ... ";
-
-    try {
-        auto attenuator = RfAttenuatorFactory::TryCreateBasic("software", std::move(properties));
-        LOGI << "succeeded" << std::endl;
-        return attenuator;
-    } catch (const RfAttenuatorException &e) {
-        LOGE << "failed (" << e.what() << ")" << std::endl;
-        return nullptr;
-    }
-}
-
 TEST_CASE("RfAttenuator IsEnabled API", "[basic][rpc][client][remote][rfAttenuator]")
 {
     SECTION("IsEnabled is true")
     {
         auto serverConfiguration = CreateServerConfiguration();
         serverConfiguration.RfAttenuatorConfiguration.Type = RfAttenuatorType::Software;
-        auto attenuator = CreateSimulatedAttenuator();
+        auto attenuator = RfAttenuatorFactory::CreateSimulatedSoftwareAttenuator();
         NetRemoteServer server{ serverConfiguration, std::move(attenuator) };
         server.Run();
 
@@ -101,7 +71,7 @@ TEST_CASE("RfAttenuator Reset API", "[basic][rpc][client][remote][rfAttenuator]"
     {
         auto serverConfiguration = CreateServerConfiguration();
         serverConfiguration.RfAttenuatorConfiguration.Type = RfAttenuatorType::Software;
-        auto attenuator = CreateSimulatedAttenuator();
+        auto attenuator = RfAttenuatorFactory::CreateSimulatedSoftwareAttenuator();
         NetRemoteServer server{ serverConfiguration, std::move(attenuator) };
         server.Run();
 
@@ -148,7 +118,7 @@ TEST_CASE("RfAttenuator GetProperties API", "[basic][rpc][client][remote][rfAtte
     {
         auto serverConfiguration = CreateServerConfiguration();
         serverConfiguration.RfAttenuatorConfiguration.Type = RfAttenuatorType::Software;
-        auto attenuator = CreateSimulatedAttenuator();
+        auto attenuator = RfAttenuatorFactory::CreateSimulatedSoftwareAttenuator();
         NetRemoteServer server{ serverConfiguration, std::move(attenuator) };
         server.Run();
 
@@ -196,7 +166,7 @@ TEST_CASE("RfAttenuator GetAttenuationForChannel and SetAttenuationForChannel AP
     {
         auto serverConfiguration = CreateServerConfiguration();
         serverConfiguration.RfAttenuatorConfiguration.Type = RfAttenuatorType::Software;
-        auto attenuator = CreateSimulatedAttenuator();
+        auto attenuator = RfAttenuatorFactory::CreateSimulatedSoftwareAttenuator();
         NetRemoteServer server{ serverConfiguration, std::move(attenuator) };
         server.Run();
 
@@ -268,7 +238,7 @@ TEST_CASE("RfAttenuator GetAttenuationForChannel and SetAttenuationForChannel AP
     {
         auto serverConfiguration = CreateServerConfiguration();
         serverConfiguration.RfAttenuatorConfiguration.Type = RfAttenuatorType::Software;
-        auto attenuator = CreateSimulatedAttenuator();
+        auto attenuator = RfAttenuatorFactory::CreateSimulatedSoftwareAttenuator();
         NetRemoteServer server{ serverConfiguration, std::move(attenuator) };
         server.Run();
 
@@ -303,7 +273,7 @@ TEST_CASE("RfAttenuator GetAttenuationForChannel and SetAttenuationForChannel AP
     {
         auto serverConfiguration = CreateServerConfiguration();
         serverConfiguration.RfAttenuatorConfiguration.Type = RfAttenuatorType::Software;
-        auto attenuator = CreateSimulatedAttenuator();
+        auto attenuator = RfAttenuatorFactory::CreateSimulatedSoftwareAttenuator();
         NetRemoteServer server{ serverConfiguration, std::move(attenuator) };
         server.Run();
 


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals
- Create a tool to call the attenuator library interfaces so we can do sanity test easily

### Technical Details
- Add ``main`` function to call the attenuator library interfaces
- Add ``CreateSimulatedSoftwareAttenuator`` in the library to replace ``CreateSimulatedAttenuator`` so the funtion won't be duplicated in dfferent clients
- Add ``CreateSocketAfw83Attenuator`` in the library to replace CreateSocketAttenuator so the funtion won't be duplicated in dfferent clients
- Update target name ``${PROJECT_NAME}-rfattenuator`` to ``${PROJECT_NAME}-rfattenuator-linux`` since it is platform specific
- Some other minor update because of the changes listed above

### Test Results
- Test passed
./netremote-rfattenuator-linux-test-unit
===============================================================================
All tests passed (36 assertions in 4 test cases)

### Reviewer Focus
- None

### Future Work
- Create a new release tag for all recent changes
- Ingest the release on windows
- Test on Linux it can works with the real attenuator AFW83
- Test on Windows the attenuator interface works
- Bug fix

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
