### PR TITLE
enable api folder if NETREMOTE_EXCLUDE_API_BINDINGS is off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ add_subdirectory(config)
 add_subdirectory(packaging)
 add_subdirectory(src)
 
-if (NOT NETREMOTE_EXCLUDE_API)
+if (NOT NETREMOTE_EXCLUDE_API OR NOT NETREMOTE_EXCLUDE_API_BINDINGS)
   add_subdirectory(api)
 endif()
 


### PR DESCRIPTION
### Type

- [X] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals
- Include api folder in build when NETREMOTE_EXCLUDE_API_BINDINGS flag is OFF

### Technical Details
- NETREMOTE_EXCLUDE_API_BINDINGS flag is created to control the switch of building api/protocol, its parent folder api is controlled by NETREMOTE_EXCLUDE_API. When NETREMOTE_EXCLUDE_API_BINDINGS is OFF, its parent folder should be included in build also or api/protocol folder won't be built.

### Test Results
- Build successfully

### Reviewer Focus
- None

### Future Work
- Ingest it on windows by turning off NETREMOTE_EXCLUDE_API_BINDINGS only

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
