### PR TITLE
Update hostapd to 2.11

### DIFF
--- a/src/linux/external/hostap/CMakeLists.txt
+++ b/src/linux/external/hostap/CMakeLists.txt
@@ -41,7 +41,7 @@ set(HOSTAPD_PREFIX ${HOSTAP_SOURCE_DIR}/${HOSTAPD_DIR_NAME})
 # Pull in hostap project with a tagged release.
 ExternalProject_Add(hostap
     GIT_REPOSITORY "http://w1.fi/hostap.git"
-    GIT_TAG "hostap_2_10"
+    GIT_TAG "hostap_2_11"
     GIT_SHALLOW TRUE
     CONFIGURE_COMMAND
         # Copy local build configuration files for libwpa_client.so and hostapd builds.

--- a/src/linux/external/hostap/libwpa_client/.config
+++ b/src/linux/external/hostap/libwpa_client/.config
@@ -12,3 +12,5 @@ CONFIG_CTRL_IFACE=unix
 
 # Request to build the libwpa_client.so client library.
 CONFIG_BUILD_WPA_CLIENT_SO=y
+
+CONFIG_NO_WPA_PASSPHRASE=n


### PR DESCRIPTION

### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals
Update to hostapd 2.11 that supports wi-fi 7

### Technical Details
None

### Test Results
- Test hostapd 2.11 can enable softAP that doesn't have Wi-Fi 7 configuration
- Test hostpd 2.11 won't fail because of new Wi-Fi 7 configuration
``mld_ap=1``

### Reviewer Focus
None

### Future Work
- Update hostapd2.10 to 2.11 in lab

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
