### PR TITLE
0.5.2 release

### DIFF
--- a/.docker/netremote-dev/vcpkg.json
+++ b/.docker/netremote-dev/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "netremote",
-  "version-string": "0.4.1",
+  "version-string": "0.5.2",
   "dependencies": [
     {
       "name": "sdbus-cpp",

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,8 +1,8 @@
 
 # Default version values in case we can't get them from git.
 set(VERSION_MAJOR 0)
-set(VERSION_MINOR 4)
-set(VERSION_PATCH 1)
+set(VERSION_MINOR 5)
+set(VERSION_PATCH 2)
 
 if (NOT GIT_EXECUTABLE)
   message(WARNING "Git not found; falling back to hard-coded version")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "netremote",
-  "version-string": "0.4.1",
+  "version-string": "0.5.2",
   "dependencies": [
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
### Type

- [ ] Bug fix
- [ ] Feature addition
- [x] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [x] Non-functional change

### Goals
Publish 0.5.2

### Technical Details
None

### Test Results
Build succeeds

### Reviewer Focus
None

### Future Work
None

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
