### PR TITLE
Only build config and packaging on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,9 +100,8 @@ endif()
 if (BUILD_FOR_LINUX)
   add_subdirectory(config)
   add_subdirectory(packaging)
+  add_subdirectory(src)
 endif()
-
-add_subdirectory(src)
 
 if (NOT NETREMOTE_EXCLUDE_API OR NOT NETREMOTE_EXCLUDE_API_BINDINGS)
   add_subdirectory(api)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,11 @@ if (WERROR)
   add_compile_options(-Werror)
 endif()
 
-add_subdirectory(config)
-add_subdirectory(packaging)
+if (BUILD_FOR_LINUX)
+  add_subdirectory(config)
+  add_subdirectory(packaging)
+endif()
+
 add_subdirectory(src)
 
 if (NOT NETREMOTE_EXCLUDE_API OR NOT NETREMOTE_EXCLUDE_API_BINDINGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,9 @@ endif()
 if (BUILD_FOR_LINUX)
   add_subdirectory(config)
   add_subdirectory(packaging)
-  add_subdirectory(src)
 endif()
+
+add_subdirectory(src)
 
 if (NOT NETREMOTE_EXCLUDE_API OR NOT NETREMOTE_EXCLUDE_API_BINDINGS)
   add_subdirectory(api)


### PR DESCRIPTION

### Type

- [ ] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [X] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [X] Non-functional change

### Goals
Don't build config and packaging on Windows since they are not needed on Windows

### Technical Details
None

### Test Results
- Linux build succeeds

### Reviewer Focus
None

### Future Work
- Ingest this change on Windows and check how the build on Windows works

### Checklist

- [X] Build target `all` compiles cleanly.
- [X] clang-format and clang-tidy deltas produced no new output.
- [X] Newly added functions include doxygen-style comment block.
