### PR TITLE
Enable/disable 80211be based on mld_ap value

### DIFF
--- a/src/linux/net/wifi/core/AccessPointControllerLinux.cxx
+++ b/src/linux/net/wifi/core/AccessPointControllerLinux.cxx
@@ -683,6 +683,16 @@ AccessPointControllerLinux::SetMldAp(bool mldAp) noexcept
         return status;
     }
 
+    // Set the hostapd "ieee80211be" property.
+    try {
+        propertyValueToSet = mldAp ? Wpa::ProtocolHostapd::PropertyEnabled : Wpa::ProtocolHostapd::PropertyDisabled;
+        m_hostapd.SetProperty(Wpa::ProtocolHostapd::PropertyNameIeee80211BE, propertyValueToSet, EnforceConfigurationChange::Now);
+    } catch (const Wpa::HostapdException& ex) {
+        status.Code = AccessPointOperationStatusCode::InternalError;
+        status.Details = std::format("failed to set hostapd property '{}' to '{}' - {}", Wpa::ProtocolHostapd::PropertyNameIeee80211BE, propertyValueToSet, ex.what());
+        return status;
+    }
+
     status.Code = AccessPointOperationStatusCode::Succeeded;
     return status;
 }

--- a/src/linux/net/wifi/wpa-controller/WpaCommandStatus.cxx
+++ b/src/linux/net/wifi/wpa-controller/WpaCommandStatus.cxx
@@ -69,6 +69,8 @@ WpaStatusResponseParser::ParsePayload()
             ParseInt(value, status.Ieee80211ax);
         } else if (key == ProtocolHostapd::ResponseStatusPropertyKeyDisableAX) {
             ParseInt(value, status.Disable11ax);
+        } else if (key == ProtocolHostapd::ResponseStatusPropertyKeyIeee80211BE) {
+            ParseInt(value, status.Ieee80211be);
         } else if (key == ProtocolHostapd::PropertyNameBss) {
             enforceRequiredBssInfoSize(index.value() + 1);
             status.Bss[index.value()].Interface = value;

--- a/src/linux/net/wifi/wpa-controller/include/Wpa/ProtocolHostapd.hxx
+++ b/src/linux/net/wifi/wpa-controller/include/Wpa/ProtocolHostapd.hxx
@@ -476,6 +476,7 @@ struct HostapdStatus
     int Disable11n{ 0 };
     int Disable11ac{ 0 };
     int Disable11ax{ 0 };
+    int Ieee80211be{ 0 };
     // int Ieee80211be{ 0 };
     // uint16_t BeaconInterval{ 0 };
     // int DtimPeriod{ 0 };
@@ -635,6 +636,7 @@ struct ProtocolHostapd :
     static constexpr auto PropertyNameDisable11AC = "disable_11ac";
     static constexpr auto PropertyNameIeee80211AX = "ieee80211ax";
     static constexpr auto PropertyNameDisable11AX = "disable_11ax";
+    static constexpr auto PropertyNameIeee80211BE = "ieee80211be";
     static constexpr auto PropertyNameWmmEnabled = "wmm_enabled";
     static constexpr auto PropertyNameState = "state";
 
@@ -702,6 +704,7 @@ struct ProtocolHostapd :
     static constexpr auto ResponseStatusPropertyKeyDisableAC = PropertyNameDisable11AC;
     static constexpr auto ResponseStatusPropertyKeyIeee80211AX = PropertyNameIeee80211AX;
     static constexpr auto ResponseStatusPropertyKeyDisableAX = PropertyNameDisable11AX;
+    static constexpr auto ResponseStatusPropertyKeyIeee80211BE = PropertyNameIeee80211BE;
 
     // Response properties for the "GET_CONFIG" command.
     // Note: all properties must be terminated with the key-value delimeter (=).


### PR DESCRIPTION

### Type

- [ ] Bug fix
- [ ] Feature addition
- [X] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals
This change enables/disables 80211be radio per mld_ap hostap setting.

### Technical Details
None

### Test Results
- Test the station radio type is 80211 ax when mld_ap is disabled
- Test the station radio type is 80211 be when mld_ap is enabled

### Reviewer Focus
None

### Future Work
None

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
