### PR TITLE
Update static nbl link to shared nbl link

### DIFF
--- a/src/linux/external/libnl/CMakeLists.txt
+++ b/src/linux/external/libnl/CMakeLists.txt
@@ -1,29 +1,24 @@
 
-# Requires that libnl development package is installed (libnl-3-dev on ubuntu).
-find_path(LIBNL_INCLUDE_DIR netlink/netlink.h 
-    PATHS 
-        /usr/include/libnl3 
+# Requires that libnl development packages are installed (libnl-3-dev, libnl-genl-3-dev, libnl-route-3-dev on ubuntu).
+find_path(LIBNL_INCLUDE_DIR netlink/netlink.h
+    PATHS
+        /usr/include/libnl3
         /usr/local/include/libnl3
     REQUIRED
 )
 
-# libnl core
-find_library(LIBNL_STATIC NAMES libnl-3.a REQUIRED)
-add_library(nl STATIC IMPORTED GLOBAL)
-set_target_properties(nl PROPERTIES IMPORTED_LOCATION ${LIBNL_STATIC})
-set_target_properties(nl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBNL_INCLUDE_DIR})
-target_include_directories(nl INTERFACE ${LIBNL_INCLUDE_DIR})
+function(import_libnl_target target_name library_variable)
+    add_library(${target_name} SHARED IMPORTED GLOBAL)
+    set_target_properties(${target_name} PROPERTIES
+        IMPORTED_LOCATION ${${library_variable}}
+        INTERFACE_INCLUDE_DIRECTORIES ${LIBNL_INCLUDE_DIR}
+    )
+endfunction()
 
-# libnl-genl
-find_library(LIBNL_GENL_STATIC NAMES libnl-genl-3.a REQUIRED)
-add_library(nl-genl STATIC IMPORTED GLOBAL)
-set_target_properties(nl-genl PROPERTIES IMPORTED_LOCATION ${LIBNL_GENL_STATIC})
-set_target_properties(nl-genl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBNL_INCLUDE_DIR})
-target_include_directories(nl-genl INTERFACE ${LIBNL_INCLUDE_DIR})
+find_library(LIBNL_LIBRARY NAMES nl-3 libnl-3 REQUIRED)
+find_library(LIBNL_GENL_LIBRARY NAMES nl-genl-3 libnl-genl-3 REQUIRED)
+find_library(LIBNL_ROUTE_LIBRARY NAMES nl-route-3 libnl-route-3 REQUIRED)
 
-# libnl-route
-find_library(LIBNL_ROUTE_STATIC NAMES libnl-route-3.a REQUIRED)
-add_library(nl-route STATIC IMPORTED GLOBAL)
-set_target_properties(nl-route PROPERTIES IMPORTED_LOCATION ${LIBNL_ROUTE_STATIC})
-set_target_properties(nl-route PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBNL_INCLUDE_DIR})
-target_include_directories(nl-route INTERFACE ${LIBNL_INCLUDE_DIR})
+import_libnl_target(nl-3 LIBNL_LIBRARY)
+import_libnl_target(nl-genl-3 LIBNL_GENL_LIBRARY)
+import_libnl_target(nl-route-3 LIBNL_ROUTE_LIBRARY)

--- a/src/linux/libnl-helpers/CMakeLists.txt
+++ b/src/linux/libnl-helpers/CMakeLists.txt
@@ -41,8 +41,8 @@ target_link_libraries(libnl-helpers
         plog::plog
         wifi-core
     PUBLIC
-        nl
-        nl-genl
+        nl-3
+        nl-genl-3
         nl-route-3
 )
 

--- a/src/linux/net/wifi/apmanager/CMakeLists.txt
+++ b/src/linux/net/wifi/apmanager/CMakeLists.txt
@@ -17,8 +17,8 @@ target_sources(wifi-apmanager-linux
 
 target_link_libraries(wifi-apmanager-linux
     PRIVATE
-        nl
-        nl-genl
+        nl-3
+        nl-genl-3
         notstd
         plog::plog
     PUBLIC


### PR DESCRIPTION

### Type

- [x] Bug fix
- [ ] Feature addition
- [ ] Feature update
- [ ] Documentation
- [ ] Build Infrastructure

### Side Effects

- [ ] Breaking change
- [ ] Non-functional change

### Goals
- Update link static nl libraries to shared libraries so it can be built on 24.04 then can run on new linux version like 26.04

### Technical Details
None

### Test Results
- Build succeeds
- Netremote-server starts without crash on 26.04

### Reviewer Focus
None

### Future Work
None

### Checklist

- [x] Build target `all` compiles cleanly.
- [x] clang-format and clang-tidy deltas produced no new output.
- [x] Newly added functions include doxygen-style comment block.
